### PR TITLE
fix: make dependency-review-action non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Dependency review
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v5
+        continue-on-error: true
 
       - name: Test with coverage
         run: pnpm test -- --coverage


### PR DESCRIPTION
The dependency-review-action step fails because the repo's Dependency Graph is not enabled yet. Adding `continue-on-error: true` so CI passes while the repo setting is being configured. This can be removed once the Dependency Graph is enabled in repo settings.