### PR TITLE
fix: remove dependency-review-action continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Dependency review
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v5
-        continue-on-error: true
 
       - name: Test with coverage
         run: pnpm test -- --coverage


### PR DESCRIPTION
Dependency Graph is now enabled on the repo (via `gh api repos/{owner}/{repo}/vulnerability-alerts`), so the `continue-on-error: true` workaround from PR #18 is no longer needed.