### PR TITLE
fix: transparent window maximize-toggle broken on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ python
 .codex/
 dist-main/
 .claude/
+.gstack/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,36 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ### Commit Format
 
 - Prefer conventional prefixes: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`.
+
+## Change Annotation Rules
+
+Rules for how code changes are structured, documented, and annotated in the codebase.
+
+- **Comments must be written in English.** All comments, annotations, and descriptions use English.
+
+- **Do not modify original code unless the change requires it.** No reformatting, renaming, or comment changes on code unrelated to the current task.
+
+- **Isolate new code blocks with tag comments.** Every insertion of new code must be wrapped with a tag header and footer:
+
+  ```js
+  // [Tag_Name] Description of what this change does and why
+  ... new code ...
+  // [Tag_Name] END
+  ```
+
+- **Each independent change must have its own tag.** Format: `YYYYMMDD_Type_Summary` (e.g., `20260602_Fix_MaximizeToggle`). Each tag corresponds to one logically distinct change.
+
+- **Each tag must include a description.** The tag comment must explain the root cause, purpose, or fix rationale so that future readers can understand the change without checking git history.
+
+- **Add inline comments for substantial new code.** When adding more than a few lines, include comments at key positions explaining intent and context — especially for platform-specific workarounds or non-obvious logic.
+
+- **New files must have a file header comment with tag and purpose.** Example:
+
+  ```js
+  // [20260602_Fix_MaximizeToggle] This file extracts shared validation
+  // logic previously duplicated across multiple handlers.
+  ```
+
+- **No magic numbers.** All hard-coded values (numbers, strings, thresholds) must be extracted into named constants placed at an appropriate scope.
+
+- **Variable naming must follow consistent conventions and convey meaning.** Use the project's established casing (camelCase / PascalCase / UPPER_SNAKE_CASE). Names must express clear intent. No meaningless abbreviations, single-letter variables (loop counters excepted), or arbitrary naming.

--- a/src/helpers/ipc/windowHandlers.js
+++ b/src/helpers/ipc/windowHandlers.js
@@ -25,17 +25,28 @@ function register(ipcMain, managers) {
     return true;
   });
 
+  // [20260602_Fix_MaximizeToggle] Fix maximize-toggle on Windows transparent windows.
+  // Root cause: win.isMaximized() always returns false for transparent windows on
+  // Windows, so the restore path was never taken and maximize() was called again.
+  // Fix: track maximize state via _preMaximizeBounds (null = normal, non-null = maximized).
+  // Save bounds before maximize, restore with setBounds() on toggle, and notify
+  // the renderer directly since the unmaximize event may not fire.
   ipcMain.handle(C.WINDOW.MAXIMIZE, () => {
     if (windowManager.mainWindow) {
       const win = windowManager.mainWindow;
-      if (win.isMaximized()) {
-        win.unmaximize();
+      const saved = windowManager._preMaximizeBounds;
+      if (saved) {
+        windowManager._preMaximizeBounds = null;
+        win.setBounds(saved);
+        win.webContents.send(C.EVENTS.WINDOW_MAXIMIZE_CHANGE, false);
       } else {
+        windowManager._preMaximizeBounds = win.getBounds();
         win.maximize();
       }
     }
     return true;
   });
+  // [20260602_Fix_MaximizeToggle] END
 
   ipcMain.handle(C.WINDOW.IS_MAX, () => {
     if (windowManager.mainWindow) {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -10,6 +10,10 @@ class WindowManager {
     this._creatingMainWindow = false;
     this._alwaysOnTop = true;
     this._cspSetup = false;
+    // [20260602_Fix_MaximizeToggle] Bounds snapshot before maximize
+    // On Windows, transparent windows always report isMaximized() === false,
+    // so we use this property as the maximize-state flag instead.
+    this._preMaximizeBounds = null;
   }
 
   setDefaultAlwaysOnTop(enabled) {

--- a/tests/unit/windowHandlers.test.js
+++ b/tests/unit/windowHandlers.test.js
@@ -29,6 +29,8 @@ describe("windowHandlers", () => {
       isMaximized: vi.fn(() => false),
       setAlwaysOnTop: vi.fn(),
       isDestroyed: vi.fn(() => false),
+      getBounds: vi.fn(() => ({ x: 100, y: 100, width: 520, height: 640 })),
+      setBounds: vi.fn(),
     };
 
     const historyWindow = {
@@ -82,14 +84,45 @@ describe("windowHandlers", () => {
     expect(result).toBe(true);
   });
 
+  // [20260602_Fix_MaximizeToggle] Use _preMaximizeBounds instead of isMaximized()
   it("maximize-window toggles maximize state", () => {
-    managers.windowManager.mainWindow.isMaximized.mockReturnValue(false);
+    const win = managers.windowManager.mainWindow;
+    win.webContents = { send: vi.fn() };
     ipcMain._handlers["maximize-window"]();
-    expect(managers.windowManager.mainWindow.maximize).toHaveBeenCalled();
+    expect(win.maximize).toHaveBeenCalled();
 
-    managers.windowManager.mainWindow.isMaximized.mockReturnValue(true);
     ipcMain._handlers["maximize-window"]();
-    expect(managers.windowManager.mainWindow.unmaximize).toHaveBeenCalled();
+    expect(win.setBounds).toHaveBeenCalled();
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      "window-maximize-change",
+      false,
+    );
+  });
+
+  // [20260602_Fix_MaximizeToggle] Regression: save/restore bounds across multiple toggle cycles
+  it("maximize-window saves bounds before maximize and restores on second click", () => {
+    const win = managers.windowManager.mainWindow;
+    const originalBounds = { x: 100, y: 200, width: 520, height: 640 };
+    win.getBounds.mockReturnValue(originalBounds);
+    win.webContents = { send: vi.fn() };
+
+    // First click: not maximized → save bounds, then maximize
+    ipcMain._handlers["maximize-window"]();
+    expect(win.maximize).toHaveBeenCalled();
+    expect(win.getBounds).toHaveBeenCalled();
+
+    // Second click: has saved bounds → restore via setBounds
+    ipcMain._handlers["maximize-window"]();
+    expect(win.setBounds).toHaveBeenCalledWith(originalBounds);
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      "window-maximize-change",
+      false,
+    );
+
+    // Third click: no saved bounds → maximize again
+    win.maximize.mockClear();
+    ipcMain._handlers["maximize-window"]();
+    expect(win.maximize).toHaveBeenCalled();
   });
 
   it("is-window-maximized returns maximize state", () => {


### PR DESCRIPTION
Root cause: win.isMaximized() always returns false for transparent windows on Windows, so clicking the maximize button after maximizing would call maximize() again instead of restoring the window.

Fix: track maximize state via _preMaximizeBounds on WindowManager. Save bounds before maximize, restore with setBounds() on toggle, and notify the renderer directly since the unmaximize event may not fire.

Tag: 20260602_Fix_MaximizeToggle

## Description

Brief description of what this PR does.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm test` passes
- [ ] New code has corresponding tests
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Describe how you tested this change.

## Screenshots

If applicable, add screenshots for UI changes.
