### PR TITLE
fix: prevent checksums triple upload in release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,8 @@ jobs:
         run: |
           cat Murmur-macOS/checksums-sha256.txt Murmur-Windows/checksums-sha256.txt > checksums-sha256.txt
           cat checksums-sha256.txt
+          # Remove per-platform checksums to avoid filename collision during upload
+          rm -f Murmur-macOS/checksums-sha256.txt Murmur-Windows/checksums-sha256.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
Removes per-platform checksums before upload so only the merged checksums-sha256.txt is uploaded. Fixes the 'already_exists' error that caused v1.0.2 build to show as failure despite all artifacts uploading successfully.