### PR TITLE
feat: add harness audit script and npm command

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "ci:fix": "node scripts/ci-check.js --fix",
     "preview": "cd src && vite preview",
     "clean": "node cleanup.js && rm -rf python",
-    "prepare": "husky"
+    "prepare": "husky",
+    "audit:harness": "node scripts/harness-audit.js"
   },
   "keywords": [
     "speech-to-text",

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -52,10 +52,6 @@ function readAbs(absPath) {
   return fs.readFileSync(absPath, "utf-8");
 }
 
-function hasLine(content, pattern) {
-  return content.split("\n").some((l) => pattern.test(l));
-}
-
 // ---------------------------------------------------------------------------
 // Category checks — each returns { score: 0-10, checks: [{name, pass, detail}] }
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `scripts/harness-audit.js` — deterministic 7-category scorecard (Tool Coverage, Context Efficiency, Quality Gates, Memory Persistence, Eval Coverage, Security Guardrails, Cost Efficiency)
- Add `pnpm audit:harness` npm script
- Cross-platform (Windows/macOS), checks both project and user-level configs
- Add `tasks/lessons.md` for reusable development policies

Current score: **67/70** (5/7 categories at max)

## Usage

```bash
pnpm audit:harness           # text output
pnpm audit:harness -- --format json  # JSON output
```

## Changed files

| File | Change |
|------|--------|
| `scripts/harness-audit.js` | New — deterministic scoring script |
| `tasks/lessons.md` | New — reusable lessons from past sessions |
| `package.json` | Add `audit:harness` script |

## Test plan

- [x] `pnpm audit:harness` runs and outputs 67/70 scorecard
- [x] Cross-platform path handling (HOME/USERPROFILE)
- [x] Detects project + user-level configs (MCP, hooks, commands, skills)