### PR TITLE
fix: package bindings runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "axios": "^1.6.0",
     "better-sqlite3": "11.10.0",
+    "bindings": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "docx": "^9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       better-sqlite3:
         specifier: 11.10.0
         version: 11.10.0
+      bindings:
+        specifier: ^1.5.0
+        version: 1.5.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1

--- a/tests/unit/phase0-security.test.js
+++ b/tests/unit/phase0-security.test.js
@@ -115,7 +115,6 @@ describe("Phase 0: LogManager uses sync I/O for crash safety", () => {
 describe("Phase 0: Ghost dependencies removed from package.json", () => {
   const ghostDeps = [
     "asynckit",
-    "bindings",
     "combined-stream",
     "delayed-stream",
     "es-errors",
@@ -132,3 +131,12 @@ describe("Phase 0: Ghost dependencies removed from package.json", () => {
     expect(pkg.dependencies).not.toHaveProperty(dep);
   });
 });
+
+// [20260612_Fix_BindingsPackaging] Ensure native sqlite runtime helper is packaged.
+describe("Phase 0: Native sqlite runtime dependencies", () => {
+  it("should keep bindings as a direct production dependency", () => {
+    const pkg = require("../../package.json");
+    expect(pkg.dependencies).toHaveProperty("bindings");
+  });
+});
+// [20260612_Fix_BindingsPackaging] END


### PR DESCRIPTION
## Description

Fixes Windows packaged app startup failure caused by a missing `bindings` runtime dependency.

When Murmur starts, `better-sqlite3` loads its native addon through `require('bindings')('better_sqlite3.node')`. The packaged app can miss `bindings`, which causes the Electron main process to throw before creating the BrowserWindow. The visible result is that `Murmur.exe` starts but no desktop window appears.

This PR adds `bindings@^1.5.0` as a production dependency and adds a regression test so it is not removed as a ghost dependency again.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm test` passes
- [x] New code has corresponding tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

```text
pnpm exec vitest run tests/unit/phase0-security.test.js

Test Files  1 passed
Tests  25 passed