### PR TITLE
fix: add bindings as runtime dependency for Windows packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "axios": "^1.6.0",
     "better-sqlite3": "11.10.0",
+    "bindings": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "docx": "^9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       better-sqlite3:
         specifier: 11.10.0
         version: 11.10.0
+      bindings:
+        specifier: ^1.5.0
+        version: 1.5.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1

--- a/tests/unit/phase0-security.test.js
+++ b/tests/unit/phase0-security.test.js
@@ -115,7 +115,6 @@ describe("Phase 0: LogManager uses sync I/O for crash safety", () => {
 describe("Phase 0: Ghost dependencies removed from package.json", () => {
   const ghostDeps = [
     "asynckit",
-    "bindings",
     "combined-stream",
     "delayed-stream",
     "es-errors",
@@ -132,3 +131,12 @@ describe("Phase 0: Ghost dependencies removed from package.json", () => {
     expect(pkg.dependencies).not.toHaveProperty(dep);
   });
 });
+
+// [20260612_Fix_BindingsPackaging] Ensure native sqlite runtime helper is packaged.
+describe("Phase 0: Native sqlite runtime dependencies", () => {
+  it("should keep bindings as a direct production dependency", () => {
+    const pkg = require("../../package.json");
+    expect(pkg.dependencies).toHaveProperty("bindings");
+  });
+});
+// [20260612_Fix_BindingsPackaging] END


### PR DESCRIPTION
## Summary

Fixes Windows packaged app startup failure caused by missing `bindings` runtime dependency.

Credit: **@Deeeemooo** (original PR #50, recreated from repo branch so CI can validate — fork PRs don't trigger CI).

## Problem

When Murmur starts, `better-sqlite3` loads its native addon through `require('bindings')('better_sqlite3.node')`. The packaged Windows app was missing `bindings`, causing the Electron main process to throw before creating the BrowserWindow. Visible result: `Murmur.exe` starts but no desktop window appears.

## Fix

- Add `bindings@^1.5.0` as a production dependency
- Remove `bindings` from the ghost-dependency test list (it was incorrectly flagged as a ghost dep)
- Add regression test ensuring `bindings` stays as a direct dependency

## Type of Change

- [x] Bug fix

## Checklist

- [x] `pnpm test` passes (652 tests)
- [x] New code has corresponding tests (regression test included)
- [x] Commit messages follow Conventional Commits