### PR TITLE
feat: migrate 4 more backend files to TypeScript (ADR-010 Phase 2)

### DIFF
--- a/src/helpers/detectLocalModels.ts
+++ b/src/helpers/detectLocalModels.ts
@@ -1,0 +1,61 @@
+// [20260724_TS_Migration_DetectLocalModels] Migrated from .js to .ts (ADR-010 Phase 2).
+// Uses fetch (Node 18+) with AbortController timeout.
+
+/** A local model probe configuration. */
+interface LocalProbe {
+  name: string;
+  label: string;
+  url: string;
+  extractModels: (data: Record<string, unknown>) => string[];
+}
+
+/** Result of a successful probe. */
+interface DetectedModel {
+  name: string;
+  label: string;
+  models: string[];
+}
+
+const LOCAL_PROBES: LocalProbe[] = [
+  {
+    name: "ollama",
+    label: "Ollama",
+    url: "http://localhost:11434/api/tags",
+    extractModels: (data) =>
+      ((data.models as Array<{ name: string }>) || []).map((m) => m.name),
+  },
+  {
+    name: "lmstudio",
+    label: "LM Studio",
+    url: "http://localhost:1234/v1/models",
+    extractModels: (data) =>
+      ((data.data as Array<{ id: string }>) || []).map((m) => m.id),
+  },
+];
+
+async function probeEndpoint(probe: LocalProbe): Promise<DetectedModel | null> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    const response = await fetch(probe.url, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!response.ok) return null;
+    const data = (await response.json()) as Record<string, unknown>;
+    return {
+      name: probe.name,
+      label: probe.label,
+      models: probe.extractModels(data),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function detectLocalModels(): Promise<DetectedModel[]> {
+  const results = await Promise.all(LOCAL_PROBES.map(probeEndpoint));
+  return results.filter((r): r is DetectedModel => r !== null);
+}
+
+export { detectLocalModels };
+export type { LocalProbe, DetectedModel };

--- a/src/helpers/fileConfig.ts
+++ b/src/helpers/fileConfig.ts
@@ -1,0 +1,56 @@
+// [20260724_TS_Migration_FileConfig] Migrated from .js to .ts (ADR-010 Phase 2).
+// Depends only on fs and path.
+import fs from "fs";
+import path from "path";
+
+/** Settings keys that can be configured via ~/.murmur.json */
+const FILE_CONFIGURABLE_KEYS: readonly string[] = [
+  "ai_base_url",
+  "ai_model",
+  "ai_temperature",
+  "ai_max_tokens",
+  "hotkey",
+  "language",
+  "theme",
+  "auto_paste",
+  "auto_start",
+  "minimize_to_tray",
+  "show_notifications",
+] as const;
+
+/** A settings record keyed by string. */
+type SettingsRecord = Record<string, unknown>;
+
+/** Load filtered settings from a JSON config file. Returns {} on any error. */
+function loadFileConfig(configPath: string): SettingsRecord {
+  try {
+    if (!fs.existsSync(configPath)) return {};
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+      return {};
+
+    const allowed = new Set(FILE_CONFIGURABLE_KEYS);
+    const filtered: SettingsRecord = {};
+    for (const key of Object.keys(parsed as object)) {
+      if (allowed.has(key)) filtered[key] = (parsed as SettingsRecord)[key];
+    }
+    return filtered;
+  } catch {
+    return {};
+  }
+}
+
+/** Save filtered settings to a JSON config file. */
+function saveFileConfig(configPath: string, settings: SettingsRecord): void {
+  const allowed = new Set(FILE_CONFIGURABLE_KEYS);
+  const filtered: SettingsRecord = {};
+  for (const key of Object.keys(settings)) {
+    if (allowed.has(key)) filtered[key] = settings[key];
+  }
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(filtered, null, 2), "utf-8");
+}
+
+export { loadFileConfig, saveFileConfig, FILE_CONFIGURABLE_KEYS };

--- a/src/helpers/ipcRateLimiter.ts
+++ b/src/helpers/ipcRateLimiter.ts
@@ -1,0 +1,49 @@
+// [20260724_TS_Migration_IpcRateLimiter] Migrated from .js to .ts (ADR-010 Phase 2).
+// Pure logic — no external dependencies.
+
+const DEFAULT_MAX_CALLS = 30;
+const DEFAULT_WINDOW_MS = 60_000;
+
+/** Options for creating a rate-limited handler. */
+interface RateLimitOptions {
+  maxCalls?: number;
+  windowMs?: number;
+}
+
+/** An IPC handler function signature. */
+type IpcHandler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
+
+/**
+ * Wrap an IPC handler with a sliding-window rate limiter.
+ * Returns a new function that rejects calls exceeding the limit.
+ */
+function createRateLimitedHandler(
+  handler: IpcHandler,
+  options: RateLimitOptions = {},
+): IpcHandler {
+  const maxCalls = options.maxCalls ?? DEFAULT_MAX_CALLS;
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+
+  const timestamps: number[] = [];
+
+  return async function rateLimitedHandler(
+    event: unknown,
+    ...args: unknown[]
+  ): Promise<unknown> {
+    const now = Date.now();
+    const windowStart = now - windowMs;
+
+    while (timestamps.length > 0 && timestamps[0]! < windowStart) {
+      timestamps.shift();
+    }
+
+    if (timestamps.length >= maxCalls) {
+      return { success: false, error: "Rate limit exceeded" };
+    }
+
+    timestamps.push(now);
+    return handler(event, ...args);
+  };
+}
+
+export default createRateLimitedHandler;

--- a/src/helpers/logManager.ts
+++ b/src/helpers/logManager.ts
@@ -1,0 +1,229 @@
+// [20260724_TS_Migration_LogManager] Migrated from .js to .ts (ADR-010 Phase 2).
+// Depends only on fs, path, os, and electron (lazy require in methods).
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+/** A single log entry written to the log file. */
+interface LogEntry {
+  timestamp: string;
+  level: string;
+  message: string;
+  data: unknown;
+  pid?: number;
+  source?: string;
+}
+
+/** Log level type. */
+type LogLevel = "info" | "error" | "warn" | "debug";
+
+/** System info for debugging. */
+interface SystemInfo {
+  platform: string;
+  arch: string;
+  nodeVersion: string;
+  electronVersion: string | undefined;
+  appVersion: string;
+  userDataPath: string;
+  logDir: string | null;
+  env: {
+    NODE_ENV: string | undefined;
+    PATH: string | undefined;
+    PYTHON_PATH: string | undefined;
+  };
+}
+
+class LogManager {
+  private _initialized = false;
+  private logDir: string | null = null;
+  private logFile: string | null = null;
+  private funasrLogFile: string | null = null;
+  private _pendingLogs: unknown[] = [];
+
+  private _ensureInitialized(): void {
+    if (this._initialized) return;
+    this._initialized = true;
+    this.logDir = this.getLogDirectory();
+    this.logFile = path.join(this.logDir, "app.log");
+    this.funasrLogFile = path.join(this.logDir, "funasr.log");
+    this.ensureLogDirectory();
+  }
+
+  getLogDirectory(): string {
+    try {
+      // Lazy require electron — not available in test environment
+      const electron = require("electron");
+      return path.join(electron.app.getPath("userData"), "logs");
+    } catch {
+      return path.join(os.tmpdir(), "murmur-logs");
+    }
+  }
+
+  ensureLogDirectory(): void {
+    try {
+      if (this.logDir && !fs.existsSync(this.logDir)) {
+        fs.mkdirSync(this.logDir, { recursive: true });
+      }
+    } catch (error) {
+      console.error("创建日志目录失败:", error);
+    }
+  }
+
+  log(level: LogLevel, message: string, data: unknown = null): void {
+    this._ensureInitialized();
+    const timestamp = new Date().toISOString();
+    const logEntry: LogEntry = {
+      timestamp,
+      level,
+      message,
+      data,
+      pid: process.pid,
+    };
+
+    console[level](`[${timestamp}] ${message}`, data || "");
+
+    try {
+      const logLine = JSON.stringify(logEntry) + "\n";
+      fs.appendFileSync(this.logFile!, logLine);
+    } catch (error) {
+      console.error("写入日志文件失败:", error);
+    }
+  }
+
+  info(message: string, data?: unknown): void {
+    this.log("info", message, data);
+  }
+
+  error(message: string, data?: unknown): void {
+    this.log("error", message, data);
+  }
+
+  warn(message: string, data?: unknown): void {
+    this.log("warn", message, data);
+  }
+
+  debug(message: string, data?: unknown): void {
+    this.log("debug", message, data);
+  }
+
+  logFunASR(level: LogLevel, message: string, data: unknown = null): void {
+    this._ensureInitialized();
+    const timestamp = new Date().toISOString();
+    const logEntry: LogEntry = {
+      timestamp,
+      level,
+      message,
+      data,
+      source: "FunASR",
+    };
+
+    console[level](`[FunASR] ${message}`, data || "");
+
+    try {
+      const logLine = JSON.stringify(logEntry) + "\n";
+      fs.appendFileSync(this.funasrLogFile!, logLine);
+    } catch (error) {
+      console.error("写入FunASR日志文件失败:", error);
+    }
+  }
+
+  getRecentLogs(lines = 100): LogEntry[] {
+    try {
+      if (!this.logFile || !fs.existsSync(this.logFile)) return [];
+
+      const content = fs.readFileSync(this.logFile, "utf8");
+      const logLines = content
+        .trim()
+        .split("\n")
+        .filter((line: string) => line.trim());
+
+      return logLines.slice(-lines).map((line: string) => {
+        try {
+          return JSON.parse(line) as LogEntry;
+        } catch {
+          return {
+            message: line,
+            timestamp: new Date().toISOString(),
+          } as LogEntry;
+        }
+      });
+    } catch (error) {
+      console.error("读取日志文件失败:", error);
+      return [];
+    }
+  }
+
+  getFunASRLogs(lines = 100): LogEntry[] {
+    try {
+      if (!this.funasrLogFile || !fs.existsSync(this.funasrLogFile)) return [];
+
+      const content = fs.readFileSync(this.funasrLogFile, "utf8");
+      const logLines = content
+        .trim()
+        .split("\n")
+        .filter((line: string) => line.trim());
+
+      return logLines.slice(-lines).map((line: string) => {
+        try {
+          return JSON.parse(line) as LogEntry;
+        } catch {
+          return {
+            message: line,
+            timestamp: new Date().toISOString(),
+          } as LogEntry;
+        }
+      });
+    } catch (error) {
+      console.error("读取FunASR日志文件失败:", error);
+      return [];
+    }
+  }
+
+  cleanOldLogs(daysToKeep = 7): void {
+    try {
+      const cutoffTime = Date.now() - daysToKeep * 24 * 60 * 60 * 1000;
+
+      [this.logFile, this.funasrLogFile].forEach((logFile) => {
+        if (logFile && fs.existsSync(logFile)) {
+          const stats = fs.statSync(logFile);
+          if (stats.mtime.getTime() < cutoffTime) {
+            fs.unlinkSync(logFile);
+            console.log(`清理旧日志文件: ${logFile}`);
+          }
+        }
+      });
+    } catch (error) {
+      console.error("清理旧日志失败:", error);
+    }
+  }
+
+  getLogFilePath(): string {
+    this._ensureInitialized();
+    return this.logFile!;
+  }
+
+  getFunASRLogFilePath(): string {
+    this._ensureInitialized();
+    return this.funasrLogFile!;
+  }
+
+  getSystemInfo(): SystemInfo {
+    const electron = require("electron");
+    return {
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      electronVersion: process.versions.electron,
+      appVersion: electron.app.getVersion(),
+      userDataPath: electron.app.getPath("userData"),
+      logDir: this.logDir,
+      env: {
+        NODE_ENV: process.env.NODE_ENV,
+        PATH: process.env.PATH,
+        PYTHON_PATH: process.env.PYTHON_PATH,
+      },
+    };
+  }
+}
+
+export default LogManager;


### PR DESCRIPTION
## Summary

Second batch of backend TypeScript migration (ADR-010). All 4 files have minimal dependencies (fs, path, os, fetch), making them low-risk.

## Migrated Files

| File | Dependencies | New Types |
|------|-------------|-----------|
| `logManager.ts` | fs, path, os, electron (lazy) | `LogEntry`, `SystemInfo`, `LogLevel` |
| `fileConfig.ts` | fs, path | `SettingsRecord`, readonly keys |
| `ipcRateLimiter.ts` | none (pure logic) | `RateLimitOptions`, `IpcHandler` |
| `detectLocalModels.ts` | fetch (Node 18+) | `LocalProbe`, `DetectedModel` |

## Pattern

Same as Phase 1 (PR #76):
- `.ts` = typed source of truth (tsc + vitest resolve `.ts` first)
- `.js` = runtime implementation (production + plain Node)
- esbuild `--resolve-extensions=.js,.ts` ensures bundles use `.js`

## Verification

- `tsc --noEmit`: clean
- `vitest run`: **669 tests pass** (64 files)
- `eslint --max-warnings 0`: clean

## TS Migration Progress

| Layer | Before | After |
|-------|--------|-------|
| Frontend | 43 files TS | 43 files TS |
| Backend | 4/41 files TS | **8/41** files TS |
| Entry | 0/2 | 0/2 |
