### PR TITLE
feat: migrate 4 more backend files to TypeScript (ADR-010 Phase 3)

### DIFF
--- a/src/helpers/aiPrompts.ts
+++ b/src/helpers/aiPrompts.ts
@@ -1,0 +1,63 @@
+// [20260724_TS_Migration_AiPrompts] Migrated from .js to .ts (ADR-010 Phase 3).
+// This file provides TypeScript type declarations for aiPrompts.js.
+// The implementation (474 lines of prompt string literals) lives in the .js
+// file for runtime. This .ts file re-exports it with proper types.
+
+/** A parsed custom prompt template from a Markdown file. */
+export interface PromptTemplate {
+  name: string;
+  label: string;
+  system: string;
+  user: string;
+}
+
+/** Result of buildPrompt: system + user prompt pair. */
+export interface PromptResult {
+  system: string;
+  user: string;
+}
+
+/** Options for buildPrompt. */
+export interface BuildPromptOptions {
+  customTemplates?: PromptTemplate[];
+}
+
+// Re-export the runtime implementation from .js with typed wrappers.
+// vitest resolves .ts first, so these typed versions are used in tests.
+const {
+  buildPrompt: _buildPrompt,
+  parseTemplateFile: _parseTemplateFile,
+  loadCustomTemplates: _loadCustomTemplates,
+} = require("./aiPrompts.js") as {
+  buildPrompt: (
+    mode: string,
+    text: string,
+    options?: BuildPromptOptions,
+  ) => PromptResult;
+  parseTemplateFile: (
+    content: string,
+    fileName: string,
+  ) => PromptTemplate | null;
+  loadCustomTemplates: (templatesDir: string) => PromptTemplate[];
+};
+
+export function buildPrompt(
+  mode: string,
+  text: string,
+  options?: BuildPromptOptions,
+): PromptResult {
+  return _buildPrompt(mode, text, options);
+}
+
+export function parseTemplateFile(
+  content: string,
+  fileName: string,
+): PromptTemplate | null {
+  return _parseTemplateFile(content, fileName);
+}
+
+export function loadCustomTemplates(templatesDir: string): PromptTemplate[] {
+  return _loadCustomTemplates(templatesDir);
+}
+
+export const DEFAULT_PIPELINE = ["optimize"];

--- a/src/helpers/environment.ts
+++ b/src/helpers/environment.ts
@@ -1,0 +1,287 @@
+// [20260724_TS_Migration_Environment] Migrated from .js to .ts (ADR-010 Phase 3).
+// Depends on path, fs, os, and dotenv (lazy require).
+import path from "path";
+import fs from "fs";
+import os from "os";
+
+/** AI configuration (currently placeholder — configured via settings panel). */
+interface AIConfig {
+  apiKey: string;
+  baseURL: string;
+  model: string;
+}
+
+/** Audio recording configuration. */
+interface AudioConfig {
+  sampleRate: number;
+  channels: number;
+  format: string;
+}
+
+/** FunASR model configuration. */
+interface FunASRConfig {
+  modelDir: string;
+  cacheDir: string;
+  batchSize: number;
+  hotwords: string[];
+}
+
+/** Application-level configuration. */
+interface AppConfig {
+  debug: boolean;
+  logLevel: string;
+  language: string;
+  theme: string;
+  windowAlwaysOnTop: boolean;
+  startMinimized: boolean;
+  globalHotkey: string;
+}
+
+/** Database configuration. */
+interface DatabaseConfig {
+  path: string;
+  backupEnabled: boolean;
+  backupInterval: number;
+}
+
+/** Proxy configuration. */
+interface ProxyConfig {
+  http: string;
+  https: string;
+}
+
+/** Performance configuration. */
+interface PerformanceConfig {
+  maxRecordingDuration: number;
+  maxTextLength: number;
+}
+
+/** System information snapshot. */
+interface SystemInfo {
+  platform: string;
+  arch: string;
+  nodeVersion: string;
+  electronVersion: string | undefined;
+  chromeVersion: string | undefined;
+  osType: string;
+  osRelease: string;
+  totalMemory: number;
+  freeMemory: number;
+  cpus: number;
+  homeDir: string;
+  tmpDir: string;
+}
+
+/** Environment validation result. */
+interface ValidationResult {
+  valid: boolean;
+  issues: string[];
+  systemInfo: SystemInfo;
+}
+
+/** Full exported configuration. */
+interface ExportedConfig {
+  ai: AIConfig;
+  audio: AudioConfig;
+  funasr: FunASRConfig;
+  app: AppConfig;
+  database: DatabaseConfig;
+  proxy: ProxyConfig;
+  performance: PerformanceConfig;
+  system: SystemInfo;
+  directories: {
+    data: string;
+    logs: string;
+    cache: string;
+    models: string;
+  };
+}
+
+class EnvironmentManager {
+  constructor() {
+    this.loadEnvironmentVariables();
+  }
+
+  loadEnvironmentVariables(): void {
+    const envPath = path.join(process.cwd(), ".env");
+    if (fs.existsSync(envPath)) {
+      require("dotenv").config({ path: envPath });
+    }
+  }
+
+  getAIConfig(): AIConfig {
+    return {
+      apiKey: "",
+      baseURL: "https://api.openai.com/v1",
+      model: "gpt-3.5-turbo",
+    };
+  }
+
+  getAudioConfig(): AudioConfig {
+    return {
+      sampleRate: parseInt(process.env.AUDIO_SAMPLE_RATE || "16000"),
+      channels: parseInt(process.env.AUDIO_CHANNELS || "1"),
+      format: process.env.AUDIO_FORMAT || "wav",
+    };
+  }
+
+  getFunASRConfig(): FunASRConfig {
+    return {
+      modelDir: process.env.FUNASR_MODEL_DIR || "./models",
+      cacheDir: process.env.FUNASR_CACHE_DIR || "./cache",
+      batchSize: parseInt(process.env.BATCH_SIZE || "300"),
+      hotwords: process.env.HOTWORDS ? process.env.HOTWORDS.split(",") : [],
+    };
+  }
+
+  getAppConfig(): AppConfig {
+    return {
+      debug: process.env.DEBUG === "true",
+      logLevel: process.env.LOG_LEVEL || "info",
+      language: process.env.LANGUAGE || "zh-CN",
+      theme: process.env.THEME || "auto",
+      windowAlwaysOnTop: process.env.WINDOW_ALWAYS_ON_TOP === "true",
+      startMinimized: process.env.START_MINIMIZED === "true",
+      globalHotkey: process.env.GLOBAL_HOTKEY || "CommandOrControl+Shift+Space",
+    };
+  }
+
+  getDatabaseConfig(): DatabaseConfig {
+    return {
+      path: process.env.DATABASE_PATH || "./data/transcriptions.db",
+      backupEnabled: process.env.BACKUP_ENABLED !== "false",
+      backupInterval: parseInt(process.env.BACKUP_INTERVAL || "24"),
+    };
+  }
+
+  getProxyConfig(): ProxyConfig {
+    return {
+      http: process.env.HTTP_PROXY || "",
+      https: process.env.HTTPS_PROXY || "",
+    };
+  }
+
+  getPerformanceConfig(): PerformanceConfig {
+    return {
+      maxRecordingDuration: parseInt(
+        process.env.MAX_RECORDING_DURATION || "300",
+      ),
+      maxTextLength: parseInt(process.env.MAX_TEXT_LENGTH || "10000"),
+    };
+  }
+
+  getSystemInfo(): SystemInfo {
+    return {
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      electronVersion: process.versions.electron,
+      chromeVersion: process.versions.chrome,
+      osType: os.type(),
+      osRelease: os.release(),
+      totalMemory: os.totalmem(),
+      freeMemory: os.freemem(),
+      cpus: os.cpus().length,
+      homeDir: os.homedir(),
+      tmpDir: os.tmpdir(),
+    };
+  }
+
+  isDevelopment(): boolean {
+    return process.env.NODE_ENV === "development";
+  }
+
+  isProduction(): boolean {
+    return process.env.NODE_ENV === "production";
+  }
+
+  getDataDirectory(): string {
+    const appName = "Murmur";
+    switch (process.platform) {
+      case "win32":
+        return path.join(os.homedir(), "AppData", "Roaming", appName);
+      case "darwin":
+        return path.join(
+          os.homedir(),
+          "Library",
+          "Application Support",
+          appName,
+        );
+      case "linux":
+        return path.join(os.homedir(), ".config", appName);
+      default:
+        return path.join(os.homedir(), `.${appName.toLowerCase()}`);
+    }
+  }
+
+  ensureDataDirectory(): string {
+    const dataDir = this.getDataDirectory();
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+    return dataDir;
+  }
+
+  getLogDirectory(): string {
+    const dataDir = this.ensureDataDirectory();
+    const logDir = path.join(dataDir, "logs");
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
+    }
+    return logDir;
+  }
+
+  getCacheDirectory(): string {
+    const dataDir = this.ensureDataDirectory();
+    const cacheDir = path.join(dataDir, "cache");
+    if (!fs.existsSync(cacheDir)) {
+      fs.mkdirSync(cacheDir, { recursive: true });
+    }
+    return cacheDir;
+  }
+
+  getModelsDirectory(): string {
+    const dataDir = this.ensureDataDirectory();
+    const modelsDir = path.join(dataDir, "models");
+    if (!fs.existsSync(modelsDir)) {
+      fs.mkdirSync(modelsDir, { recursive: true });
+    }
+    return modelsDir;
+  }
+
+  validateEnvironment(): ValidationResult {
+    const issues: string[] = [];
+    try {
+      this.ensureDataDirectory();
+    } catch (error) {
+      issues.push(`无法创建数据目录: ${(error as Error).message}`);
+    }
+    const systemInfo = this.getSystemInfo();
+    const nodeVersion = parseInt(systemInfo.nodeVersion.substring(1));
+    if (nodeVersion < 18) {
+      issues.push(`Node.js 版本过低: ${systemInfo.nodeVersion}，需要 18+`);
+    }
+    return { valid: issues.length === 0, issues, systemInfo };
+  }
+
+  exportConfig(): ExportedConfig {
+    return {
+      ai: this.getAIConfig(),
+      audio: this.getAudioConfig(),
+      funasr: this.getFunASRConfig(),
+      app: this.getAppConfig(),
+      database: this.getDatabaseConfig(),
+      proxy: this.getProxyConfig(),
+      performance: this.getPerformanceConfig(),
+      system: this.getSystemInfo(),
+      directories: {
+        data: this.getDataDirectory(),
+        logs: this.getLogDirectory(),
+        cache: this.getCacheDirectory(),
+        models: this.getModelsDirectory(),
+      },
+    };
+  }
+}
+
+export default EnvironmentManager;

--- a/src/helpers/exportFormatters.ts
+++ b/src/helpers/exportFormatters.ts
@@ -1,0 +1,71 @@
+// [20260724_TS_Migration_ExportFormatters] Migrated from .js to .ts (ADR-010 Phase 3).
+// Provides TypeScript type declarations for exportFormatters.js.
+// The implementation (docx document generation) lives in the .js file.
+
+/** A transcription segment with timestamps. */
+export interface TranscriptionSegment {
+  start_ms: number;
+  end_ms: number;
+  text: string;
+}
+
+/** A transcription record for formatting. */
+export interface TranscriptionForExport {
+  text?: string;
+  duration?: number;
+  created_at?: string;
+  source_file_path?: string;
+  parsedSegments?: TranscriptionSegment[];
+}
+
+/** Format info for an export type. */
+export interface FormatInfo {
+  formatter: (
+    transcription: TranscriptionForExport,
+  ) => string | Promise<Buffer>;
+  ext: string;
+  mime: string;
+}
+
+// Re-export the runtime implementation from .js with typed wrappers.
+const {
+  formatTXT: _formatTXT,
+  formatSRT: _formatSRT,
+  formatVTT: _formatVTT,
+  formatMD: _formatMD,
+  formatDOCX: _formatDOCX,
+  getFormatInfo: _getFormatInfo,
+  smartMergeSrt: _smartMergeSrt,
+} = require("./exportFormatters.js") as {
+  formatTXT: (t: TranscriptionForExport) => string;
+  formatSRT: (t: TranscriptionForExport) => string;
+  formatVTT: (t: TranscriptionForExport) => string;
+  formatMD: (t: TranscriptionForExport) => string;
+  formatDOCX: (t: TranscriptionForExport) => Promise<Buffer>;
+  getFormatInfo: (formatName: string) => FormatInfo | null;
+  smartMergeSrt: (segments: TranscriptionSegment[]) => TranscriptionSegment[];
+};
+
+export function formatTXT(t: TranscriptionForExport): string {
+  return _formatTXT(t);
+}
+export function formatSRT(t: TranscriptionForExport): string {
+  return _formatSRT(t);
+}
+export function formatVTT(t: TranscriptionForExport): string {
+  return _formatVTT(t);
+}
+export function formatMD(t: TranscriptionForExport): string {
+  return _formatMD(t);
+}
+export function formatDOCX(t: TranscriptionForExport): Promise<Buffer> {
+  return _formatDOCX(t);
+}
+export function getFormatInfo(formatName: string): FormatInfo | null {
+  return _getFormatInfo(formatName);
+}
+export function smartMergeSrt(
+  segments: TranscriptionSegment[],
+): TranscriptionSegment[] {
+  return _smartMergeSrt(segments);
+}

--- a/src/helpers/serverMessageRouter.ts
+++ b/src/helpers/serverMessageRouter.ts
@@ -1,0 +1,213 @@
+// [20260724_TS_Migration_ServerMessageRouter] Migrated from .js to .ts (ADR-010 Phase 3).
+// Manages stdin/stdout JSON communication with the FunASR Python server process.
+import { randomUUID } from "crypto";
+import type { ChildProcess } from "child_process";
+
+const DEFAULT_TIMEOUT = 60_000;
+const MAX_ENTRY_AGE = 15 * 60 * 1000;
+
+/** Logger interface (accepts console or LogManager). */
+interface Logger {
+  warn(message: string, ...args: unknown[]): void;
+  info?(message: string, ...args: unknown[]): void;
+  error?(message: string, ...args: unknown[]): void;
+  debug?(message: string, ...args: unknown[]): void;
+}
+
+/** Options for sendCommand. */
+interface SendCommandOptions {
+  timeout?: number;
+  timeoutError?: string;
+  onProgress?: ((msg: Record<string, unknown>) => void) | null;
+}
+
+/** A pending request entry tracking resolve/reject/timer. */
+interface PendingEntry {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: NodeJS.Timeout;
+  createdAt: number;
+  lastProgressAt?: number;
+  originalTimeout?: number;
+  onProgress?: ((msg: Record<string, unknown>) => void) | null;
+}
+
+class ServerMessageRouter {
+  private logger: Logger;
+  private pending: Map<string, PendingEntry>;
+  private serverProcess: ChildProcess | null;
+  private _cleanupInterval: NodeJS.Timeout | null;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+    this.pending = new Map();
+    this.serverProcess = null;
+    this._cleanupInterval = null;
+  }
+
+  attach(serverProcess: ChildProcess): void {
+    this.serverProcess = serverProcess;
+    let buffer = "";
+
+    serverProcess.stdout!.on("data", (data: Buffer) => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          this._dispatch(msg);
+        } catch {
+          this.logger.warn("Failed to parse stdout JSON", line.length);
+        }
+      }
+    });
+
+    serverProcess.on("close", () => {
+      this._rejectAll("服务器进程已退出");
+    });
+
+    serverProcess.on("error", (err: Error) => {
+      this._rejectAll(`服务器进程错误: ${err.message}`);
+    });
+
+    this._cleanupInterval = setInterval(() => this._purgeExpired(), 60000);
+  }
+
+  detach(): void {
+    this._rejectAll("Router 已分离");
+    if (this._cleanupInterval) {
+      clearInterval(this._cleanupInterval);
+      this._cleanupInterval = null;
+    }
+    this.serverProcess = null;
+  }
+
+  sendCommand(
+    action: string,
+    params: Record<string, unknown> = {},
+    options: SendCommandOptions = {},
+  ): Promise<unknown> {
+    if (!this.serverProcess || !this.serverProcess.stdin?.writable) {
+      return Promise.reject(new Error("FunASR服务器未就绪"));
+    }
+
+    const requestId = (params.request_id as string) || randomUUID();
+    const timeout = options.timeout || DEFAULT_TIMEOUT;
+    const onProgress = options.onProgress || null;
+
+    const command = { ...params, action, request_id: requestId };
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new Error(options.timeoutError || "服务器响应超时"));
+      }, timeout);
+
+      this.pending.set(requestId, {
+        resolve,
+        reject,
+        timer,
+        createdAt: Date.now(),
+        lastProgressAt: Date.now(),
+        originalTimeout: timeout,
+        onProgress,
+      });
+
+      try {
+        this.serverProcess!.stdin!.write(JSON.stringify(command) + "\n");
+      } catch (e) {
+        clearTimeout(timer);
+        this.pending.delete(requestId);
+        reject(new Error("FunASR服务器写入失败: " + (e as Error).message));
+      }
+    });
+  }
+
+  sendRaw(command: Record<string, unknown>): Promise<unknown> {
+    if (!this.serverProcess || !this.serverProcess.stdin?.writable) {
+      return Promise.reject(new Error("FunASR服务器未就绪"));
+    }
+
+    const requestId = (command.request_id as string) || randomUUID();
+    command.request_id = requestId;
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new Error("服务器响应超时"));
+      }, DEFAULT_TIMEOUT);
+
+      this.pending.set(requestId, {
+        resolve,
+        reject,
+        timer,
+        createdAt: Date.now(),
+      });
+
+      try {
+        this.serverProcess!.stdin!.write(JSON.stringify(command) + "\n");
+      } catch (e) {
+        clearTimeout(timer);
+        this.pending.delete(requestId);
+        reject(new Error("FunASR服务器写入失败: " + (e as Error).message));
+      }
+    });
+  }
+
+  private _dispatch(msg: Record<string, unknown>): void {
+    const requestId = msg.request_id as string;
+    if (!requestId) return;
+
+    const entry = this.pending.get(requestId);
+    if (!entry) return;
+
+    if (msg.type === "progress") {
+      if (entry.onProgress) {
+        entry.onProgress(msg);
+      }
+      clearTimeout(entry.timer);
+      const nextTimeout = Math.max(
+        entry.originalTimeout || MAX_ENTRY_AGE,
+        5 * 60 * 1000,
+      );
+      this.pending.set(requestId, {
+        ...entry,
+        lastProgressAt: Date.now(),
+        timer: setTimeout(() => {
+          this.pending.delete(requestId);
+          entry.reject(new Error("服务器响应超时"));
+        }, nextTimeout),
+      });
+      return;
+    }
+
+    clearTimeout(entry.timer);
+    this.pending.delete(requestId);
+    entry.resolve(msg);
+  }
+
+  private _rejectAll(reason: string): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error(reason));
+    }
+    this.pending.clear();
+  }
+
+  private _purgeExpired(): void {
+    const now = Date.now();
+    for (const [id, entry] of this.pending) {
+      const absoluteAge = now - entry.createdAt;
+      const progressAge = now - (entry.lastProgressAt || entry.createdAt);
+      if (absoluteAge > 60 * 60 * 1000 || progressAge > 5 * 60 * 1000) {
+        clearTimeout(entry.timer);
+        entry.reject(new Error("请求超时（条目过期）"));
+        this.pending.delete(id);
+      }
+    }
+  }
+}
+
+export default ServerMessageRouter;


### PR DESCRIPTION
## Summary

Third batch of backend TypeScript migration (ADR-010 Phase 3). Covers medium-complexity files with OS/process dependencies and large prompt/formatter modules.

## Migrated Files

| File | Strategy | New Types |
|------|----------|-----------|
| `environment.ts` | Full TS rewrite | `AIConfig`, `AudioConfig`, `FunASRConfig`, `AppConfig`, `DatabaseConfig`, `ProxyConfig`, `PerformanceConfig`, `SystemInfo`, `ValidationResult`, `ExportedConfig` |
| `serverMessageRouter.ts` | Full TS rewrite | `Logger`, `PendingEntry`, `SendCommandOptions` |
| `aiPrompts.ts` | Type wrapper | `PromptTemplate`, `PromptResult`, `BuildPromptOptions` |
| `exportFormatters.ts` | Type wrapper | `TranscriptionSegment`, `TranscriptionForExport`, `FormatInfo` |

## Two Migration Strategies

1. **Full TS rewrite** (environment, serverMessageRouter) — implementation moved entirely to `.ts`
2. **Type wrapper** (aiPrompts, exportFormatters) — `.ts` provides typed re-exports from `.js`, avoiding duplication of 900+ lines of prompt strings and docx code

## Verification

- `tsc --noEmit`: clean
- `vitest run`: **669 tests pass** (64 files)
- `eslint --max-warnings 0`: clean

## TS Migration Progress

| Layer | Before | After |
|-------|--------|-------|
| Frontend | 43 files TS | 43 files TS |
| Backend | 8/41 files TS | **12/41** files TS |
| Entry | 0/2 | 0/2 |
