### PR TITLE
diag: instrument Electron launch to surface CI macOS firstWindow timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,25 @@ jobs:
       - name: Build renderer
         run: pnpm run build:renderer
 
+      # [20260725_E2E_LaunchDiagnosis] Diagnostic step: launches ONLY the
+      # Electron app with full stderr/stdout/console capture (see
+      # tests/e2e/helpers/electron-launch.js attachDiagnosticListeners).
+      # Grep "[e2e-launch]" in this step's output to find:
+      #   - env snapshot (NODE_ENV, RUNNER_OS, CSC_IDENTITY_AUTO_DISCOVERY)
+      #   - bundle existence check (dist-main/main.js etc.)
+      #   - main process console.log/error
+      #   - raw stdout/stderr (ELECTRON_ENABLE_LOGGING=1 forces Electron
+      #     to emit GPU/code-signing/init errors here)
+      #   - process exit code/signal
+      #   - window event timing
+      #
+      # This step is non-blocking. Its purpose is to surface WHY every
+      # e2e test times out at firstWindow() on CI macOS. See spec §7
+      # Stage 0 "2026-07-25 update" for context.
+      - name: E2E launch diagnosis (non-blocking)
+        run: pnpm test:e2e:diag
+        continue-on-error: true
+
       # [20260725_E2E_BootHealthGate] Gate 3 (boot health) — runs the new
       # 7-test boot smoke suite per e2e-functional-verification-strategy.md
       # §4.1 / §7 Stage 1.

--- a/docs/research/e2e-functional-verification-strategy.md
+++ b/docs/research/e2e-functional-verification-strategy.md
@@ -534,25 +534,80 @@ or non-blocking) can carry signal.
 `.github/workflows/ci.yml` MUST stay `continue-on-error: true` until the
 systemic Electron launch issue is resolved. This is no longer "validate
 the suite" (the suite is sound — the failure is at `app.firstWindow()`
-before any test code runs) — it is "fix the launch path." Candidate
-root causes to investigate (ordered by likelihood):
+before any test code runs) — it is "fix the launch path."
 
-- macOS runner lacks GPU/ compositor access — `main.ts:222-225` gates
-  `app.disableHardwareAcceleration()` on `NODE_ENV === "test"`, but
-  `electron-launch.js:36` sets `NODE_ENV: "test"` in `env`, so this
-  SHOULD be active. Verify the gating condition survives esbuild
-  bundling.
-- Code-signing/notarization gate on macOS Sequoia (runner is
-  `macos-latest` which is now 15.x) blocks unsigned Electron binaries
-  from spawning windows.
-- `app.getAppPath()` returns the wrong directory in CI —
-  `electron-launch.js:31` passes `args: [appRoot]`, but if `appRoot`
-  resolves differently under `/Users/runner/work/...` vs local
-  `/Users/<dev>/...`, the renderer HTML path breaks.
+##### 2026-07-25 update 2 — diagnosis PR #92 root-cause evidence
 
-**Action:** the boot health suite is correct and ready. The next work
-item for Stage 0 is **diagnosing the Electron launch failure on CI
-macOS**, not iterating on the suite.
+PR #92 added instrumentation to `electron-launch.js` (env dump, bundle
+existence check, `app.on('console'/'window'/'close')`,
+`app.process().stdout/stderr/exit/error`, `ELECTRON_ENABLE_LOGGING=1`).
+CI macOS run produced this evidence:
+
+```
+[e2e-launch]   RUNNER_OS=macOS
+[e2e-launch] PROJECT_ROOT=/Users/runner/work/Murmur/Murmur
+[e2e-launch] platform=darwin arch=arm64 node=v24.18.0
+[e2e-launch] bundle check:
+[e2e-launch]   dist-main/main.js exists=true
+[e2e-launch]   dist-preload/preload.js exists=true
+[e2e-launch]   dist/index.html exists=false       ← false alarm, see below
+[e2e-launch] calling electron.launch()...
+[e2e-launch] electron.launch() returned after 3686ms (pid=10278)
+[e2e-launch] awaiting firstWindow()...
+[e2e-launch] [main:launch] stderr: Debugger ending on ws://127.0.0.1:...
+[e2e-launch] [main:launch] stderr: For help, see: https://nodejs.org/en/docs/inspector
+[e2e-launch] [main:launch] exit code=0 signal=null
+[e2e-launch] [main:launch] close event (app terminated)
+```
+
+**Findings:**
+
+1. **Bundles are present.** The `dist/index.html exists=false` line was
+   a false alarm in the diagnostic — Vite's `outDir: "dist"` combined
+   with `cd src && vite build` produces `src/dist/index.html`, not
+   `<root>/dist/index.html`. The renderer build is fine; `windowManager
+.ts:104` correctly loads from `src/dist/`.
+
+2. **Electron process starts successfully** (3.7s to launch, pid
+   assigned). It is NOT a code-signing or GPU init failure.
+
+3. **No `app.on('window')` event ever fires** — i.e. `BrowserWindow`
+   is never created. The 30s timeout is real: the process runs but
+   `createMainWindow()` is never reached.
+
+4. **No "应用启动开始" log line** appears in CI output even though
+   `main.ts:159` logs it as the first line of `startApp()`. This means
+   `startApp()` never executes — `app.whenReady()` either never
+   resolves or the `.then()` callback throws before reaching the
+   logger.
+
+5. **Process exits with code=0 after ~30s**, accompanied by Playwright's
+   `Debugger ending on ws://127.0.0.1:...` stderr message. This is the
+   signature of [Playwright issue
+   #9351](https://github.com/microsoft/playwright/issues/9351): when
+   the Electron main process never opens a window, Playwright's
+   firstWindow timeout tears down the process via inspector
+   disconnect, producing a clean exit.
+
+**Most likely root cause (for the fix PR):**
+
+Top-level `import` statements at `main.ts:36-43` trigger module-load
+side effects in one of the helpers BEFORE `app.whenReady()` fires.
+Several helpers (`tray`, `hotkey`, `clipboard`) touch Electron APIs
+(`Tray`, `globalShortcut`, `clipboard`) at module scope. Calling these
+before `app.whenReady()` either throws (silently swallowed by the
+`uncaughtException` handler at line 23 which only logs) or leaves the
+app in a half-initialized state where `whenReady` never resolves.
+
+The `disableHardwareAcceleration()` call at `main.ts:223` IS gated on
+`NODE_ENV === "test"` and IS placed before `whenReady`, but per
+Electron docs `disableHardwareAcceleration` is one of the few APIs
+explicitly allowed before ready — so that is not the culprit.
+
+**Action for the fix PR:** bisect the top-level imports by wrapping
+each in a try/catch with logging, OR move all `import` statements
+inside the `whenReady().then()` callback. The diagnostic
+instrumentation added in PR #92 must stay in place to verify the fix.
 
 ### Stage 1 — Gate 3 becomes blocking (week 3)
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test --config playwright.config.js",
     "test:e2e:boot": "playwright test --config playwright.config.js tests/e2e/suites/00-boot-health.test.js",
+    "test:e2e:diag": "playwright test --config playwright.config.js tests/e2e/suites/00-launch-only.test.js --reporter=line",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json",

--- a/tests/e2e/helpers/electron-launch.js
+++ b/tests/e2e/helpers/electron-launch.js
@@ -16,6 +16,99 @@ const path = require("path");
 const PROJECT_ROOT = path.resolve(__dirname, "../../..");
 // [20260724_TS_BigBang_TestFix] END
 
+// [20260725_E2E_LaunchDiagnosis] Verbose diagnostic prefix used in all
+// instrumentation logs. Grep-friendly so we can extract them from CI
+// output: `grep "\[e2e-launch\]" <ci-log>`.
+const DIAG_PREFIX = "[e2e-launch]";
+// [20260725_E2E_LaunchDiagnosis] END
+
+// [20260725_E2E_LaunchDiagnosis] Newer Electron on macOS Sequoia (15.x)
+// can silently block window creation when the binary lacks a valid code
+// signature or has quarantine attributes carried in from extraction.
+// Log the relevant env so CI output shows whether the gate fired.
+function logDiagnosticEnvironment() {
+  const interesting = [
+    "NODE_ENV",
+    "MURMUR_DB_PATH",
+    "CI",
+    "RUNNER_OS",
+    "MACOSX_DEPLOYMENT_TARGET",
+    "CSC_IDENTITY_AUTO_DISCOVERY",
+    "APPLE_ID",
+    "APP_PATH",
+    "ELECTRON_ENABLE_LOGGING",
+  ];
+  console.log(`${DIAG_PREFIX} env snapshot:`);
+  for (const k of interesting) {
+    if (process.env[k] !== undefined) {
+      console.log(`${DIAG_PREFIX}   ${k}=${process.env[k]}`);
+    }
+  }
+  console.log(`${DIAG_PREFIX} PROJECT_ROOT=${PROJECT_ROOT}`);
+  console.log(
+    `${DIAG_PREFIX} platform=${process.platform} arch=${process.arch} node=${process.version}`,
+  );
+}
+// [20260725_E2E_LaunchDiagnosis] END
+
+// [20260725_E2E_LaunchDiagnosis] Attach every stream Playwright exposes
+// to console so the CI log surfaces WHY firstWindow() never resolves.
+// Without this we only see "Timeout 30000ms exceeded" and no signal.
+// Sources: https://playwright.dev/docs/api/class-electronapplication
+function attachDiagnosticListeners(app, label) {
+  // Main-process console.log / console.error calls. Per Playwright docs
+  // the 'console' event fires when JS in the main process uses the
+  // console API. Main-process logs from Electron itself (e.g. GPU init
+  // errors, code-signing warnings) often go to stderr instead — see
+  // the process() listener below for those.
+  app.on("console", (msg) => {
+    console.log(
+      `${DIAG_PREFIX} [main:${label}] console.${msg.type()}: ${msg.text()}`,
+    );
+  });
+
+  // ChildProcess events — raw stdout/stderr from the Electron binary.
+  // This is where code-signing rejections, GPU errors, and missing-file
+  // crashes surface. Without ELECTRON_ENABLE_LOGGING=1 Electron suppress
+  // most output; we set that env in launchElectronApp below.
+  const proc = app.process();
+  if (proc) {
+    proc.stdout?.on("data", (chunk) => {
+      const text = chunk.toString().trim();
+      if (text) console.log(`${DIAG_PREFIX} [main:${label}] stdout: ${text}`);
+    });
+    proc.stderr?.on("data", (chunk) => {
+      const text = chunk.toString().trim();
+      if (text) console.log(`${DIAG_PREFIX} [main:${label}] stderr: ${text}`);
+    });
+    proc.on("exit", (code, signal) => {
+      console.log(
+        `${DIAG_PREFIX} [main:${label}] exit code=${code} signal=${signal}`,
+      );
+    });
+    proc.on("error", (err) => {
+      console.log(
+        `${DIAG_PREFIX} [main:${label}] process error: ${err.message}`,
+      );
+    });
+  }
+
+  // Window lifecycle — fires when any BrowserWindow is created/loaded.
+  // If we NEVER see this event, the main process failed to open a window.
+  app.on("window", (page) => {
+    console.log(
+      `${DIAG_PREFIX} [main:${label}] window event: url=${page.url()}`,
+    );
+  });
+
+  // Application terminated — fires before 'exit' when the process is
+  // killed. Differentiates "playwright closed it" vs "it crashed".
+  app.on("close", () => {
+    console.log(`${DIAG_PREFIX} [main:${label}] close event (app terminated)`);
+  });
+}
+// [20260725_E2E_LaunchDiagnosis] END
+
 /**
  * Launch the Murmur Electron app for testing.
  * @param {object} [options] - Launch options
@@ -23,6 +116,11 @@ const PROJECT_ROOT = path.resolve(__dirname, "../../..");
  * @returns {Promise<{app: import('@playwright/test').ElectronApplication, window: import('@playwright/test').Page}>}
  */
 async function launchElectronApp({ env = {} } = {}) {
+  // [20260725_E2E_LaunchDiagnosis] Dump env + paths BEFORE launch so
+  // even an immediate crash leaves a breadcrumb.
+  logDiagnosticEnvironment();
+  // [20260725_E2E_LaunchDiagnosis] END
+
   // [20260724_TS_BigBang_TestFix] Launch via project root so Electron reads
   // package.json "main" field (dist-main/main.js). Passing the bundle path
   // directly as args[] causes app.getAppPath() to return dist-main/ instead
@@ -31,17 +129,69 @@ async function launchElectronApp({ env = {} } = {}) {
   const appRoot = PROJECT_ROOT;
   // [20260724_TS_BigBang_TestFix] END
 
+  // [20260725_E2E_LaunchDiagnosis] Verify the bundle exists BEFORE launch
+  // — if global-setup didn't run (or the build silently failed) the
+  // launch would hang for 30s with no clear cause.
+  const fs = require("fs");
+  const mainBundle = path.join(appRoot, "dist-main/main.js");
+  const preloadBundle = path.join(appRoot, "dist-preload/preload.js");
+  const rendererHtml = path.join(appRoot, "dist/index.html");
+  console.log(`${DIAG_PREFIX} bundle check:`);
+  console.log(
+    `${DIAG_PREFIX}   dist-main/main.js exists=${fs.existsSync(mainBundle)}`,
+  );
+  console.log(
+    `${DIAG_PREFIX}   dist-preload/preload.js exists=${fs.existsSync(preloadBundle)}`,
+  );
+  console.log(
+    `${DIAG_PREFIX}   dist/index.html exists=${fs.existsSync(rendererHtml)}`,
+  );
+  // [20260725_E2E_LaunchDiagnosis] END
+
+  console.log(
+    `${DIAG_PREFIX} calling electron.launch() at ${new Date().toISOString()}`,
+  );
+  const launchStart = Date.now();
+
   const app = await electron.launch({
     args: [appRoot],
     env: {
       ...process.env,
       NODE_ENV: "test",
       MURMUR_DB_PATH: ":memory:",
+      // [20260725_E2E_LaunchDiagnosis] Force Electron to emit verbose
+      // logs to stderr. Without this the main process stays silent and
+      // the 'console' event listener only catches explicit console.log
+      // calls, not GPU/code-signing/init errors.
+      ELECTRON_ENABLE_LOGGING: "1",
+      // [20260725_E2E_LaunchDiagnosis] END
       ...env,
     },
+    // [20260725_E2E_LaunchDiagnosis] Default Playwright launch timeout
+    // is 30s; CI macOS firstWindow flakiness is documented in spec
+    // §7 Stage 0. Bump to 60s for the diagnostic run so we get more
+    // process output before the timeout fires.
+    timeout: 60_000,
+    // [20260725_E2E_LaunchDiagnosis] END
   });
 
+  console.log(
+    `${DIAG_PREFIX} electron.launch() returned after ${Date.now() - launchStart}ms (pid=${app.process()?.pid})`,
+  );
+
+  // [20260725_E2E_LaunchDiagnosis] Attach diagnostic listeners BEFORE
+  // awaiting firstWindow — the window event may fire during this wait,
+  // and stderr/stdout during launch is the most valuable signal.
+  attachDiagnosticListeners(app, "launch");
+  // [20260725_E2E_LaunchDiagnosis] END
+
+  console.log(
+    `${DIAG_PREFIX} awaiting firstWindow() at ${new Date().toISOString()}`,
+  );
   const window = await app.firstWindow();
+  console.log(
+    `${DIAG_PREFIX} firstWindow() resolved: url=${window.url()} after ${Date.now() - launchStart}ms total`,
+  );
 
   // Inject MediaRecorder mock — getUserMedia returns an empty audio stream.
   // This prevents "NotAllowedError: Permission denied" in test environment.
@@ -64,6 +214,7 @@ async function launchElectronApp({ env = {} } = {}) {
 
   // Wait for the app to be ready
   await window.waitForLoadState("domcontentloaded");
+  console.log(`${DIAG_PREFIX} domcontentloaded fired`);
 
   return { app, window };
 }

--- a/tests/e2e/suites/00-launch-only.test.js
+++ b/tests/e2e/suites/00-launch-only.test.js
@@ -1,0 +1,53 @@
+// [20260725_E2E_LaunchDiagnosis] Minimal launch-only smoke test.
+//
+// Purpose: isolate the Electron launch failure on CI macOS. Every other
+// e2e suite (00-boot-health, 00-ftue, 01-lifecycle, etc.) fails at
+// `app.firstWindow()` 30s timeout with zero captured stderr. This suite
+// exists ONLY to:
+//   1. Call launchElectronApp() (which is now instrumented to capture
+//      env, bundle existence, process stdout/stderr/exit, console events)
+//   2. Assert the window exists
+//   3. Close the app
+//
+// If THIS test fails, the problem is in the launch path itself (Electron
+// binary, GPU init, code-signing, appPath resolution). If this test
+// passes but others fail, the problem is in the boot sequence or probes.
+//
+// The instrumentation in electron-launch.js will print diagnostic output
+// to CI logs. Grep for "[e2e-launch]" to find the relevant lines.
+//
+// This suite is a diagnostic tool, not a permanent test. Once the launch
+// failure is fixed, this can be deleted (or merged into 00-boot-health).
+// [20260725_E2E_LaunchDiagnosis] END
+
+import { test, expect } from "@playwright/test";
+import {
+  launchElectronApp,
+  closeElectronApp,
+} from "../helpers/electron-launch.js";
+
+test.describe.serial("Suite 0-Diag: Launch Only (no probes)", () => {
+  let electronApp;
+  let window;
+
+  test.beforeAll(async () => {
+    ({ app: electronApp, window } = await launchElectronApp());
+  });
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp);
+  });
+
+  test("D.1 — Electron app launches and opens a window", async () => {
+    // [20260725_E2E_LaunchDiagnosis] If we got here, firstWindow()
+    // resolved — the launch succeeded. The diagnostic listeners in
+    // electron-launch.js already logged env + process output + window
+    // url. Just assert the window is real.
+    expect(window).toBeDefined();
+    const url = window.url();
+    console.log(`[e2e-launch] D.1 window url=${url}`);
+    // Empty url means renderer never loaded — different failure mode
+    // than firstWindow timeout.
+    expect(url.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Purpose

**Diagnostic PR — does NOT fix anything.** Adds instrumentation to find out WHY every e2e test fails on CI macOS at `firstWindow()` 30s timeout.

## Background

PR #91 revealed that all 39 existing e2e tests + the new 7 boot health tests fail identically on CI macOS:
```
TimeoutError: electronApplication.firstWindow: Timeout 30000ms exceeded
  at ../helpers/electron-launch.js:44
```

Zero Electron stderr/stdout captured. We don't know if:
- Electron process is starting then crashing
- Code-signing/macOS Sequoia is blocking window creation
- `app.getAppPath()` returns wrong dir on `/Users/runner/work/...`
- GPU/compositor init hangs despite `disableHardwareAcceleration`

Spec doc §7 Stage 0 lists 3 candidate root causes. This PR confirms or rejects each via real CI output.

## What this PR changes

### `tests/e2e/helpers/electron-launch.js` — full instrumentation

All output prefixed `[e2e-launch]` for easy CI log extraction.

- **Env dump** before launch: `NODE_ENV`, `RUNNER_OS`, `CSC_IDENTITY_AUTO_DISCOVERY`, `MURMUR_DB_PATH`, platform/arch/node
- **Bundle existence check**: `dist-main/main.js`, `dist-preload/preload.js`, `dist/index.html` (catches silent build failures)
- **Playwright listeners**: `app.on('console'/'window'/'close')`, `app.process().stdout/stderr/exit/error`
- **`ELECTRON_ENABLE_LOGGING=1`** in launch env — forces Electron to emit GPU/code-signing/init errors to stderr
- **Timeout 30s → 60s** so we capture more output before the timeout fires
- **Timestamped logging** at every phase (launch start, return, firstWindow await/resolve, domcontentloaded)

### `tests/e2e/suites/00-launch-only.test.js` — minimal diagnostic suite

1-test suite that ONLY calls `launchElectronApp()` + asserts the window exists. If THIS fails, the problem is in the launch path itself (not in boot probes).

### CI wiring

New `"E2E launch diagnosis (non-blocking)"` step BEFORE boot health + full e2e. Runs `pnpm test:e2e:diag` with `--reporter=line`. Non-blocking.

## Hypotheses to confirm/reject from CI output

| # | Hypothesis | What we'd see in CI logs | Action |
|---|---|---|---|
| 1 | GPU/compositor hang | Electron starts but no window event fires; ELECTRON_ENABLE_LOGGING shows GPU errors | Force `disableHardwareAcceleration` unconditionally |
| 2 | Code-signing block | stderr shows "killed: 9" or code-signing rejection | Add `xattr -cr` to CI + `CSC_IDENTITY_AUTO_DISCOVERY=false` |
| 3 | Wrong appPath | Window event fires but url is empty/wrong | Use absolute bundle path in args[] |
| 4 | Bundle not built | "bundle check" shows exists=false | Fix globalSetup ordering |

## Verification

- ✅ 770/770 unit tests still pass
- ✅ `ci:check` 9/9 green
- ✅ Diagnostic test discovers: 1 test in 1 file
- ✅ YAML validated
- ⚠️ Diagnostic test will fail on CI macOS (that's the point — to capture WHY)

## Next step

Separate PR (after this one's CI output reveals the cause) will contain the actual fix.