### PR TITLE
test: migrate 5 simple Tier 3 tests to .ts (batch 2)

### DIFF
--- a/tests/unit/aiPrompts-few-shot.test.ts
+++ b/tests/unit/aiPrompts-few-shot.test.ts
@@ -1,14 +1,25 @@
+// [20260726_Tier3_AiPromptsFewShotMigrate] Migrated from .js to .ts as part
+// of Tier 3 batch 2. Pattern: type the destructured require() binding via
+// `typeof import("<module>").<export>` so buildPrompt reuses the source
+// signature from src/helpers/aiPrompts.ts, and annotate the describe.each
+// callback param as `string` (TS7008 — describe.each infers the table as
+// `ReadonlyArray<unknown>` so the callback parameter is implicitly `any`).
+// No `let`-bare bindings in this file. Template reference: phase4-i18n.test.ts
+// (commit d52f2e0).
+//
 // [20260724_Feat_PromptFewShot] Regression tests for AI prompt few-shot examples.
 // Ensures each platform-style prompt includes concrete examples per ADR-012 Issue #4c.
 import { describe, it, expect } from "vitest";
 
-const { buildPrompt } = require("../../src/helpers/aiPrompts");
+const {
+  buildPrompt,
+}: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
 
 describe("AI Prompt few-shot examples (ADR-012 Issue #4c)", () => {
   // Platform prompts that need few-shot examples
   const PLATFORM_MODES = ["xiaohongshu", "dianping", "douyin", "zhihu"];
 
-  describe.each(PLATFORM_MODES)("mode: %s", (mode) => {
+  describe.each(PLATFORM_MODES)("mode: %s", (mode: string) => {
     it("system prompt contains at least one example section", () => {
       const result = buildPrompt(mode, "这是一段测试文本");
       // Look for example markers: ## 示例, ## 范例, 示例：, 例子：

--- a/tests/unit/export-formatters.test.ts
+++ b/tests/unit/export-formatters.test.ts
@@ -1,3 +1,12 @@
+// [20260726_Tier3_ExportFormattersMigrate] Migrated from .js to .ts as part
+// of Tier 3 batch 2. Pattern: type the destructured require() bindings via
+// `typeof import("<module>").<export>` so each formatter reuses the source
+// signature from src/helpers/exportFormatters.ts (including the
+// `TranscriptionForExport` param type and `FormatInfo | null` return) without
+// introducing `any`. The `sampleTranscription` object literal is inferred to
+// satisfy `TranscriptionForExport` structurally at each call site. No
+// `let`-bare bindings or untyped function params in this file. Template
+// reference: phase4-i18n.test.ts (commit d52f2e0).
 import { describe, it, expect } from "vitest";
 
 const {
@@ -6,7 +15,7 @@ const {
   formatVTT,
   formatMD,
   getFormatInfo,
-} = require("../../src/helpers/exportFormatters");
+}: typeof import("../../src/helpers/exportFormatters") = require("../../src/helpers/exportFormatters");
 
 const sampleTranscription = {
   text: "你好世界",
@@ -81,6 +90,10 @@ describe("exportFormatters", () => {
       for (const fmt of ["txt", "srt", "vtt", "md", "docx"]) {
         const info = getFormatInfo(fmt);
         expect(info).toBeDefined();
+        // [20260726_Tier3_ExportFormattersMigrate] getFormatInfo returns
+        // `FormatInfo | null`; vitest's toBeDefined() doesn't narrow the type,
+        // so guard before reading members (avoids `!` assertions).
+        if (!info) throw new Error(`expected format info for "${fmt}"`);
         expect(info.ext).toBeTruthy();
         expect(info.formatter).toBeInstanceOf(Function);
       }

--- a/tests/unit/ipc-contracts-orphans.test.ts
+++ b/tests/unit/ipc-contracts-orphans.test.ts
@@ -1,10 +1,27 @@
+// [20260726_Tier3_IpcContractsOrphansMigrate] Migrated from .js to .ts as
+// part of Tier 3 batch 2. Pattern: type the destructured require() binding C
+// via `typeof import("<module>")` so the namespace reuses src/helpers/
+// ipc-contracts.ts's own `as const` shapes (no `any`). The recursive walker
+// `walk` needs an explicit `string[]` return type (TS7023 — it self-references)
+// and a typed `dir: string` param (TS7006). The generic `flatten` helper
+// operates over the contract's nested-but-heterogeneous shape, so it uses
+// `Record<string, unknown>` for both input and output and an explicit return
+// annotation; the accumulator is declared `Record<string, unknown>` so the
+// `out[key] = v` assignment satisfies TS7053. No `let`-bare bindings. Template
+// reference: phase4-i18n.test.ts (commit d52f2e0).
 import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
-const C = require("../../src/helpers/ipc-contracts");
 
-function walk(dir) {
-  const out = [];
+// [20260726_Tier3_IpcContractsOrphansMigrate] require() under esbuild CJS
+// interop returns the module namespace, so this aligns with the named
+// `export const FUNASR/MODELS/...` members of ipc-contracts.ts.
+const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
+
+// [20260726_Tier3_IpcContractsOrphansMigrate] Recursive walker needs an
+// explicit `string[]` return type (TS7023) and `dir: string` (TS7006).
+function walk(dir: string): string[] {
+  const out: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) out.push(...walk(full));
@@ -16,11 +33,21 @@ function walk(dir) {
   return out;
 }
 
-function flatten(obj, prefix = "") {
-  const out = {};
+// [20260726_Tier3_IpcContractsOrphansMigrate] The contract namespace is
+// heterogeneous (objects, arrays, strings), so model it as
+// `Record<string, unknown>` and recurse. Explicit return annotation lets the
+// caller's Object.keys iterate over a known shape.
+function flatten(
+  obj: Record<string, unknown>,
+  prefix = "",
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj)) {
     if (typeof v === "object" && v !== null) {
-      Object.assign(out, flatten(v, prefix ? `${prefix}.${k}` : k));
+      Object.assign(
+        out,
+        flatten(v as Record<string, unknown>, prefix ? `${prefix}.${k}` : k),
+      );
     } else {
       out[prefix ? `${prefix}.${k}` : k] = v;
     }

--- a/tests/unit/ipc-contracts.test.ts
+++ b/tests/unit/ipc-contracts.test.ts
@@ -1,5 +1,17 @@
+// [20260726_Tier3_IpcContractsMigrate] Migrated from .js to .ts as part of
+// Tier 3 batch 2. Pattern: type the require() binding C via
+// `typeof import("<module>")` so the namespace reuses src/helpers/
+// ipc-contracts.ts's own `as const` shapes. This resolves the Object.entries/
+// Object.values iteration errors (TS2769/TS18046) — without the annotation,
+// `const C = require(...)` is `any`, and iterating `any` yields `unknown`
+// members that break the inner Object.entries(channels) calls. No `let`-bare
+// bindings and no untyped function params in this file. Template reference:
+// phase4-i18n.test.ts (commit d52f2e0).
 import { describe, it, expect } from "vitest";
-const C = require("../../src/helpers/ipc-contracts");
+
+// [20260726_Tier3_IpcContractsMigrate] require() under esbuild CJS interop
+// returns the module namespace, aligning with the named `export const` members.
+const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
 
 describe("ipc-contracts", () => {
   it("exports all domain objects", () => {

--- a/tests/unit/process.test.ts
+++ b/tests/unit/process.test.ts
@@ -1,6 +1,17 @@
+// [20260726_Tier3_ProcessTestMigrate] Migrated from .js to .ts as part of
+// Tier 3 batch 2. Pattern: type the destructured require() bindings via
+// `typeof import("<module>").<export>` so each name reuses the source's own
+// type without introducing `any`. require() under esbuild CJS interop returns
+// the namespace object, so named destructuring aligns 1:1 with `export const`
+// / `export function` members of src/utils/process.ts. No `let`-bare or
+// untyped function params in this file. Template reference: phase4-i18n.test.ts
+// (commit d52f2e0).
 import { describe, it, expect } from "vitest";
 
-const { runCommand, TIMEOUTS } = require("../../src/utils/process");
+const {
+  runCommand,
+  TIMEOUTS,
+}: typeof import("../../src/utils/process") = require("../../src/utils/process");
 
 describe("process utils", () => {
   it("TIMEOUTS has expected keys", () => {


### PR DESCRIPTION
## Summary

Tier 3 batch 2: 5 more .js → .ts test migrations. Continues the pattern from PR #91 batch 1 (commit ba626c0).

## Files migrated (52 → 32 .js tests remaining)

| File | Tests | Pattern |
|---|---|---|
| process.test.ts | 6 | Typed require destructure |
| aiPrompts-few-shot.test.ts | 7 | Typed require + describe.each param |
| ipc-contracts-orphans.test.ts | 1 | Typed require + walk helper |
| ipc-contracts.test.ts | 6 | Typed require (as const flows) |
| export-formatters.test.ts | 16 | Typed require + null guard |

## Pattern

- `typeof import(\"...\")` for require() targets
- Explicit types on helper params (TS7008)
- No \`any\`/\`as any\`/\`@ts-ignore\`
- Template: \`phase4-i18n.test.ts\` (commit d52f2e0)

## Verification

- ✅ \`pnpm typecheck:tests\` — 0 errors (fixed 2 files that had real errors when included as .ts)
- ✅ \`pnpm ci:check\` — 9/9 green
- ✅ 36/36 migrated tests pass
- ✅ 770 total unit tests (no regressions)

## Related

- ADR-014: e2e CI macOS investigation (separate concern, unresolved)
- ts-migration-audit-and-evolution.md §5.0.1: skip-list rationale
- Tier 3 progress: 22/54 migrated (40%)