### PR TITLE
test: migrate FINAL .js test (regression-session-fixes) — Tier 3.1 100% complete

### DIFF
--- a/tests/unit/regression-session-fixes.test.ts
+++ b/tests/unit/regression-session-fixes.test.ts
@@ -1,3 +1,29 @@
+// [20260726_Tier3_RegressionSessionFixesMigrate] Migrated from .js to .ts as
+// the FINAL Tier 3 migration (54/54). Pattern: same as batch 5 (vi.mock +
+// typeof import + Surface interfaces for private access). Template reference:
+// phase4-i18n.test.ts (commit d52f2e0).
+//
+// [20260726_Tier3_RegressionSessionFixesMigrate] Migration strategy: this file
+// reuses every pattern the earlier batches established —
+//   - `vi.mock("electron", () => ({ app: { getPath: vi.fn(...) } }))` inline
+//     factory (ipcRateLimitIntegration / aiHandlers).
+//   - `createIpcMain()` helper returns a `MockIpcMain` whose `_handlers` map is
+//     `Record<string, MockHandler | undefined>` so the index write inside
+//     handle() and the index reads at invocation sites both type-check
+//     (TS7053) — same as modelHandlers / ipcRateLimitIntegration.
+//   - `MockHandler` returns `Record<string, unknown>` so `result.success` /
+//     `result.error` / `result.id` reads work without per-site casts; `await`
+//     on the (runtime-async, type-sync) return unwraps the Promise safely
+//     (modelHandlers convention).
+//   - Each `require()` binding is typed via `typeof import("...")` so the
+//     imported names infer their source signatures (TS7005/TS7034).
+//   - `register(ipcMain as unknown as Parameters<typeof register>[0], managers
+//     as unknown as Parameters<typeof register>[1])` bridges the mock stubs to
+//     the source signature without `any` (modelHandlers convention).
+//   - `FunASRSurface` interface + `fsurf()` cast helper expose the private
+//     `pythonEnv` / `modelManager` fields the downloadModels regression pokes
+//     directly, mirroring the `dbp()` helper in database-coverage.
+//   - `! ` non-null after `toBeDefined()` / `toHaveBeenCalled()` guards.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("electron", () => ({
@@ -9,22 +35,71 @@ vi.mock("electron", () => ({
 // Each test guards against a specific bug that was fixed.
 // ---------------------------------------------------------------------------
 
-const C = require("../../src/helpers/ipc-contracts");
+// [20260726_Tier3_RegressionSessionFixesMigrate] ipc-contracts namespace,
+// typed via the source module so every `C.FUNASR.STATUS` / `C.EVENTS.*`
+// channel constant carries its literal-string type (TS7005).
+const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
 
-function createIpcMain() {
-  const handlers = {};
+// [20260726_Tier3_RegressionSessionFixesMigrate] Handler shape: ipcMain.handle
+// registers `(event, ...args) => result` callbacks. Tests invoke them with
+// varied args and read result properties (success/error/id/models_initialized/
+// status_message/lastInsertRowid), so the return is Record<string, unknown>
+// and args are unknown[] — the narrowest types that accept every call site
+// without `any`. `await` on the (runtime-async) return unwraps safely.
+type MockHandler = (...args: unknown[]) => Record<string, unknown>;
+
+interface MockIpcMain {
+  handle: (channel: string, handler: MockHandler) => void;
+  _handlers: Record<string, MockHandler | undefined>;
+}
+
+// [20260726_Tier3_RegressionSessionFixesMigrate] handlers map typed as
+// Record<string, MockHandler | undefined> so the `handlers[channel] = fn`
+// index write (TS7053) and the `_handlers[channel]` index reads both
+// type-check. Mirrors modelHandlers / ipcRateLimitIntegration.
+function createIpcMain(): MockIpcMain {
+  const handlers: Record<string, MockHandler | undefined> = {};
   return {
-    handle: vi.fn((channel, fn) => {
+    handle: vi.fn((channel: string, fn: MockHandler) => {
       handlers[channel] = fn;
     }),
     _handlers: handlers,
   };
 }
 
+// [20260726_Tier3_RegressionSessionFixesMigrate] FunASRManager declares
+// pythonEnv/modelManager private; the downloadModels regression overrides
+// them directly to avoid real filesystem/electron calls. Surface interface +
+// cast helper mirror the `dbp()` pattern in database-coverage.
+type FunASRManagerInstance = InstanceType<
+  typeof import("../../src/helpers/funasrManager").default
+>;
+
+interface FunASRSurface {
+  pythonEnv: {
+    findPythonExecutable: ReturnType<typeof vi.fn<() => Promise<string>>>;
+    pythonCmd: string | null;
+  };
+  modelManager: {
+    downloadModels: ReturnType<
+      typeof vi.fn<
+        (
+          cb: ((progress: Record<string, unknown>) => void) | null,
+          pythonCmd: string,
+        ) => Promise<{ success: boolean }>
+      >
+    >;
+  };
+}
+
+function fsurf(m: FunASRManagerInstance): FunASRSurface {
+  return m as unknown as FunASRSurface;
+}
+
 // 1. FUNASR.STATUS spread order — success field computed AFTER spread
 describe("FUNASR.STATUS spread order regression", () => {
   it("defaults to success:true when checkStatus returns no success field", async () => {
-    const envHandlers = require("../../src/helpers/ipc/environmentHandlers");
+    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -47,8 +122,11 @@ describe("FUNASR.STATUS spread order regression", () => {
       logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     };
 
-    envHandlers.register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.FUNASR.STATUS]();
+    envHandlers.register(
+      ipcMain as unknown as Parameters<typeof envHandlers.register>[0],
+      managers as unknown as Parameters<typeof envHandlers.register>[1],
+    );
+    const result = await ipcMain._handlers[C.FUNASR.STATUS]!();
 
     // Without the spread fix, this would be undefined (spread overrode it)
     expect(result.success).toBe(true);
@@ -56,7 +134,7 @@ describe("FUNASR.STATUS spread order regression", () => {
   });
 
   it("propagates success:false when checkStatus explicitly fails", async () => {
-    const envHandlers = require("../../src/helpers/ipc/environmentHandlers");
+    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -82,14 +160,17 @@ describe("FUNASR.STATUS spread order regression", () => {
       logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     };
 
-    envHandlers.register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.FUNASR.STATUS]();
+    envHandlers.register(
+      ipcMain as unknown as Parameters<typeof envHandlers.register>[0],
+      managers as unknown as Parameters<typeof envHandlers.register>[1],
+    );
+    const result = await ipcMain._handlers[C.FUNASR.STATUS]!();
 
     expect(result.success).toBe(false);
   });
 
   it("preserves success:true from checkStatus", async () => {
-    const envHandlers = require("../../src/helpers/ipc/environmentHandlers");
+    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -115,8 +196,11 @@ describe("FUNASR.STATUS spread order regression", () => {
       logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     };
 
-    envHandlers.register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.FUNASR.STATUS]();
+    envHandlers.register(
+      ipcMain as unknown as Parameters<typeof envHandlers.register>[0],
+      managers as unknown as Parameters<typeof envHandlers.register>[1],
+    );
+    const result = await ipcMain._handlers[C.FUNASR.STATUS]!();
 
     expect(result.success).toBe(true);
     expect(result.models_initialized).toBe(true);
@@ -126,7 +210,7 @@ describe("FUNASR.STATUS spread order regression", () => {
 
 // 7. FUNASR.STATUS includes user-friendly status_message
 describe("FUNASR.STATUS status_message", () => {
-  function createEnvManagers(overrides = {}) {
+  function createEnvManagers(overrides: Record<string, unknown> = {}) {
     return {
       environmentManager: {
         exportConfig: vi.fn(),
@@ -150,41 +234,50 @@ describe("FUNASR.STATUS status_message", () => {
   }
 
   it("includes status_message when server is ready", async () => {
-    const envHandlers = require("../../src/helpers/ipc/environmentHandlers");
+    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
     const managers = createEnvManagers({
       modelsInitialized: true,
       serverReady: true,
     });
 
-    envHandlers.register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.FUNASR.STATUS]();
+    envHandlers.register(
+      ipcMain as unknown as Parameters<typeof envHandlers.register>[0],
+      managers as unknown as Parameters<typeof envHandlers.register>[1],
+    );
+    const result = await ipcMain._handlers[C.FUNASR.STATUS]!();
 
     expect(result.status_message).toBeDefined();
     expect(typeof result.status_message).toBe("string");
   });
 
   it("includes status_message when initializing", async () => {
-    const envHandlers = require("../../src/helpers/ipc/environmentHandlers");
+    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
     const managers = createEnvManagers({
       initializationPromise: Promise.resolve(),
     });
 
-    envHandlers.register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.FUNASR.STATUS]();
+    envHandlers.register(
+      ipcMain as unknown as Parameters<typeof envHandlers.register>[0],
+      managers as unknown as Parameters<typeof envHandlers.register>[1],
+    );
+    const result = await ipcMain._handlers[C.FUNASR.STATUS]!();
 
     expect(result.status_message).toBeDefined();
     expect(result.is_initializing).toBe(true);
   });
 
   it("includes status_message when not ready", async () => {
-    const envHandlers = require("../../src/helpers/ipc/environmentHandlers");
+    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
     const managers = createEnvManagers();
 
-    envHandlers.register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.FUNASR.STATUS]();
+    envHandlers.register(
+      ipcMain as unknown as Parameters<typeof envHandlers.register>[0],
+      managers as unknown as Parameters<typeof envHandlers.register>[1],
+    );
+    const result = await ipcMain._handlers[C.FUNASR.STATUS]!();
 
     expect(result.status_message).toBeDefined();
   });
@@ -197,7 +290,9 @@ describe("TRANSCRIPTION.SAVE return shape regression", () => {
   });
 
   it("returns {success:true} on successful save", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -208,8 +303,11 @@ describe("TRANSCRIPTION.SAVE return shape regression", () => {
       processTextWithAI: vi.fn(),
     };
 
-    register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.SAVE](
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.SAVE]!(
       {},
       { text: "hello", raw_text: "hello" },
     );
@@ -219,7 +317,9 @@ describe("TRANSCRIPTION.SAVE return shape regression", () => {
   });
 
   it("returns {success:false, error} on failure", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -232,8 +332,11 @@ describe("TRANSCRIPTION.SAVE return shape regression", () => {
       processTextWithAI: vi.fn(),
     };
 
-    register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.SAVE](
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.SAVE]!(
       {},
       { text: "hello", raw_text: "hello" },
     );
@@ -273,12 +376,17 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
   }
 
   it("sends SETTINGS_UPDATE event on save-setting", async () => {
-    const { register } = require("../../src/helpers/ipc/settingsHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/settingsHandlers") = require("../../src/helpers/ipc/settingsHandlers");
     const ipcMain = createIpcMain();
     const { managers, sendSpy } = createManagers();
 
-    register(ipcMain, managers);
-    await ipcMain._handlers[C.SETTINGS.SAVE]({}, "theme", "dark");
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
+    await ipcMain._handlers[C.SETTINGS.SAVE]!({}, "theme", "dark");
 
     expect(sendSpy).toHaveBeenCalledWith(
       C.EVENTS.SETTINGS_UPDATE,
@@ -287,12 +395,17 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
   });
 
   it("sends SETTINGS_UPDATE event on set-setting", async () => {
-    const { register } = require("../../src/helpers/ipc/settingsHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/settingsHandlers") = require("../../src/helpers/ipc/settingsHandlers");
     const ipcMain = createIpcMain();
     const { managers, sendSpy } = createManagers();
 
-    register(ipcMain, managers);
-    await ipcMain._handlers[C.SETTINGS.SET]({}, "theme", "dark");
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
+    await ipcMain._handlers[C.SETTINGS.SET]!({}, "theme", "dark");
 
     expect(sendSpy).toHaveBeenCalledWith(
       C.EVENTS.SETTINGS_UPDATE,
@@ -301,12 +414,17 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
   });
 
   it("sends SETTINGS_UPDATE event on reset-settings", async () => {
-    const { register } = require("../../src/helpers/ipc/settingsHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/settingsHandlers") = require("../../src/helpers/ipc/settingsHandlers");
     const ipcMain = createIpcMain();
     const { managers, sendSpy } = createManagers();
 
-    register(ipcMain, managers);
-    await ipcMain._handlers[C.SETTINGS.RESET]();
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
+    await ipcMain._handlers[C.SETTINGS.RESET]!();
 
     expect(sendSpy).toHaveBeenCalledWith(
       C.EVENTS.SETTINGS_UPDATE,
@@ -318,7 +436,9 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
 // 4. aiPrompts returns {system, user} structure
 describe("aiPrompts system/user structure regression", () => {
   it("buildPrompt returns {system, user} for optimize mode", () => {
-    const { buildPrompt } = require("../../src/helpers/aiPrompts");
+    const {
+      buildPrompt,
+    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
     const result = buildPrompt("optimize", "测试文本");
 
     expect(result).toHaveProperty("system");
@@ -330,7 +450,9 @@ describe("aiPrompts system/user structure regression", () => {
   });
 
   it("buildPrompt returns {system, user} for optimize_long mode", () => {
-    const { buildPrompt } = require("../../src/helpers/aiPrompts");
+    const {
+      buildPrompt,
+    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
     const result = buildPrompt("optimize_long", "长文本测试");
 
     expect(result).toHaveProperty("system");
@@ -339,7 +461,9 @@ describe("aiPrompts system/user structure regression", () => {
   });
 
   it("buildPrompt falls back to optimize for unknown mode", () => {
-    const { buildPrompt } = require("../../src/helpers/aiPrompts");
+    const {
+      buildPrompt,
+    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
     const result = buildPrompt("unknown_mode", "文本");
 
     expect(result).toHaveProperty("system");
@@ -347,7 +471,9 @@ describe("aiPrompts system/user structure regression", () => {
   });
 
   it("system prompt contains core rules", () => {
-    const { buildPrompt } = require("../../src/helpers/aiPrompts");
+    const {
+      buildPrompt,
+    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
     const { system } = buildPrompt("optimize", "文本");
 
     expect(system).toContain("绝对禁止");
@@ -362,10 +488,12 @@ describe("processTextWithAI SSRF regression", () => {
   });
 
   it("rejects internal base URL in process flow", async () => {
-    const { processTextWithAI } = require("../../src/helpers/ipc/aiHandlers");
+    const {
+      processTextWithAI,
+    }: typeof import("../../src/helpers/ipc/aiHandlers") = require("../../src/helpers/ipc/aiHandlers");
 
     const db = {
-      getSetting: vi.fn(async (key) => {
+      getSetting: vi.fn(async (key: string) => {
         if (key === "ai_api_key") return "sk-test";
         if (key === "ai_base_url") return "https://192.168.1.1/v1";
         if (key === "ai_model") return "gpt-3.5-turbo";
@@ -374,16 +502,23 @@ describe("processTextWithAI SSRF regression", () => {
     };
     const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
 
-    const result = await processTextWithAI("test", "optimize", db, logger);
+    const result = await processTextWithAI(
+      "test",
+      "optimize",
+      db as unknown as Parameters<typeof processTextWithAI>[2],
+      logger as unknown as Parameters<typeof processTextWithAI>[3],
+    );
     expect(result.success).toBe(false);
     expect(result.error).toContain("https");
   });
 
   it("rejects http base URL in process flow", async () => {
-    const { processTextWithAI } = require("../../src/helpers/ipc/aiHandlers");
+    const {
+      processTextWithAI,
+    }: typeof import("../../src/helpers/ipc/aiHandlers") = require("../../src/helpers/ipc/aiHandlers");
 
     const db = {
-      getSetting: vi.fn(async (key) => {
+      getSetting: vi.fn(async (key: string) => {
         if (key === "ai_api_key") return "sk-test";
         if (key === "ai_base_url") return "http://api.openai.com/v1";
         if (key === "ai_model") return "gpt-3.5-turbo";
@@ -392,7 +527,12 @@ describe("processTextWithAI SSRF regression", () => {
     };
     const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
 
-    const result = await processTextWithAI("test", "optimize", db, logger);
+    const result = await processTextWithAI(
+      "test",
+      "optimize",
+      db as unknown as Parameters<typeof processTextWithAI>[2],
+      logger as unknown as Parameters<typeof processTextWithAI>[3],
+    );
     expect(result.success).toBe(false);
   });
 });
@@ -403,32 +543,48 @@ describe("downloadModels python path regression", () => {
     vi.resetModules();
   });
 
-  function createManager() {
-    const FunASRManager = require("../../src/helpers/funasrManager");
+  function createManager(): FunASRManagerInstance {
+    const FunASRManager: typeof import("../../src/helpers/funasrManager").default = require("../../src/helpers/funasrManager");
     const mgr = new FunASRManager();
-    // Override internal methods to avoid real filesystem/electron calls
-    mgr.pythonEnv.findPythonExecutable = vi.fn(async () => "/resolved/python3");
-    mgr.modelManager.downloadModels = vi.fn(async () => ({ success: true }));
+    // [20260726_Tier3_RegressionSessionFixesMigrate] Override internal methods
+    // to avoid real filesystem/electron calls. pythonEnv/modelManager are
+    // private in source; reach them via the FunASRSurface cast helper (mirrors
+    // the dbp() pattern in database-coverage).
+    const surf = fsurf(mgr);
+    surf.pythonEnv.findPythonExecutable = vi.fn(
+      async () => "/resolved/python3",
+    );
+    surf.modelManager.downloadModels = vi.fn(async () => ({ success: true }));
     return mgr;
   }
 
   it("calls findPythonExecutable before passing path to modelManager", async () => {
     const mgr = createManager();
-    await mgr.downloadModels();
+    const surf = fsurf(mgr);
+    // [20260726_Tier3_RegressionSessionFixesMigrate] Source downloadModels
+    // requires a cb arg typed as `((progress) => void) | null`; passing null
+    // is the canonical "no progress callback" value (the original .js called
+    // with no args, which forwards undefined — functionally identical here
+    // since modelManager.downloadModels defaults the cb to null internally).
+    await mgr.downloadModels(null);
 
-    expect(mgr.pythonEnv.findPythonExecutable).toHaveBeenCalled();
-    expect(mgr.modelManager.downloadModels).toHaveBeenCalledWith(
-      undefined,
+    expect(surf.pythonEnv.findPythonExecutable).toHaveBeenCalled();
+    expect(surf.modelManager.downloadModels).toHaveBeenCalledWith(
+      null,
       "/resolved/python3",
     );
   });
 
   it("does not fall back to hardcoded python3 when pythonCmd is null", async () => {
     const mgr = createManager();
-    mgr.pythonEnv.pythonCmd = null;
-    await mgr.downloadModels();
+    const surf = fsurf(mgr);
+    surf.pythonEnv.pythonCmd = null;
+    await mgr.downloadModels(null);
 
-    const passedCmd = mgr.modelManager.downloadModels.mock.calls[0][1];
+    // [20260726_Tier3_RegressionSessionFixesMigrate] mock.calls[0] is
+    // [cb, pythonCmd]; non-null index after the call above. [1] is the
+    // pythonCmd string passed through from findPythonExecutable.
+    const passedCmd = surf.modelManager.downloadModels.mock.calls[0]![1];
     expect(passedCmd).not.toBe("python3");
     expect(passedCmd).toBe("/resolved/python3");
   });
@@ -467,13 +623,18 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("accepts .ogg files (was rejected before BUG 1 fix)", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
     const managers = mockManagers();
-    register(ipcMain, managers);
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
 
-    const os = require("os");
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    const os: typeof import("os") = require("os");
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       `${os.homedir()}/test.ogg`,
     );
@@ -483,13 +644,18 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("accepts .wma files (was rejected before BUG 1 fix)", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
     const managers = mockManagers();
-    register(ipcMain, managers);
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
 
-    const os = require("os");
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    const os: typeof import("os") = require("os");
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       `${os.homedir()}/test.wma`,
     );
@@ -499,13 +665,18 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("accepts .aac files (was rejected before BUG 1 fix)", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
     const managers = mockManagers();
-    register(ipcMain, managers);
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
 
-    const os = require("os");
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    const os: typeof import("os") = require("os");
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       `${os.homedir()}/test.aac`,
     );
@@ -515,12 +686,17 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("still rejects unsupported formats like .txt", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
     const managers = mockManagers();
-    register(ipcMain, managers);
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
 
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       "/Users/test/file.txt",
     );
@@ -536,7 +712,9 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
   });
 
   it("accepts files from /Volumes/ (was rejected before BUG 3 fix)", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
     const managers = {
       funasrManager: {
@@ -553,10 +731,13 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
       logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
       processTextWithAI: vi.fn(),
     };
-    register(ipcMain, managers);
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
 
     const createEvent = () => ({ sender: { send: vi.fn() } });
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       "/Volumes/ExternalDisk/recordings/meeting.wav",
     );
@@ -566,7 +747,9 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
   });
 
   it("allows Windows drive paths like E:\\", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
     const managers = {
       funasrManager: {
@@ -576,10 +759,13 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
       logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
       processTextWithAI: vi.fn(),
     };
-    register(ipcMain, managers);
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
 
     const createEvent = () => ({ sender: { send: vi.fn() } });
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       "E:\\Video\\Murmur\\audio\\test.wav",
     );
@@ -589,7 +775,9 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
   });
 
   it("still rejects paths outside homedir, tmpdir, and /Volumes/", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
     const managers = {
       funasrManager: {
@@ -599,7 +787,10 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
       logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
       processTextWithAI: vi.fn(),
     };
-    register(ipcMain, managers);
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
 
     const createEvent = () => ({ sender: { send: vi.fn() } });
     const badPath =
@@ -607,7 +798,7 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
         ? "\\\\unc-server\\share\\file.wav"
         : "/opt/secret/file.wav";
 
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       badPath,
     );
@@ -629,7 +820,24 @@ describe("TRANSCRIBE_FILE result.id regression", () => {
     };
   }
 
-  function createManagers() {
+  // [20260726_Tier3_RegressionSessionFixesMigrate] Return type widened with
+  // an optional `funasrManager` so the test can attach a transcribeFile mock
+  // after construction (the original .js mutated the object post-creation).
+  // The whole object is later cast through `unknown` to register()'s
+  // Managers signature, so the extra optional field is harmless.
+  function createManagers(): {
+    databaseManager: {
+      saveTranscription: (...args: unknown[]) => {
+        lastInsertRowid: number;
+        changes: number;
+      };
+    };
+    logger: { info: unknown; error: unknown; warn: unknown };
+    processTextWithAI: (...args: unknown[]) => unknown;
+    funasrManager?: {
+      transcribeFile: (...args: unknown[]) => Promise<unknown>;
+    };
+  } {
     return {
       databaseManager: {
         saveTranscription: vi.fn(() => ({ lastInsertRowid: 99, changes: 1 })),
@@ -640,7 +848,9 @@ describe("TRANSCRIBE_FILE result.id regression", () => {
   }
 
   it("sets result.id from lastInsertRowid after successful transcription", async () => {
-    const { register } = require("../../src/helpers/ipc/transcriptionHandlers");
+    const {
+      register,
+    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
     const ipcMain = createIpcMain();
 
     const managers = createManagers();
@@ -653,8 +863,11 @@ describe("TRANSCRIBE_FILE result.id regression", () => {
       })),
     };
 
-    register(ipcMain, managers);
-    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE](
+    register(
+      ipcMain as unknown as Parameters<typeof register>[0],
+      managers as unknown as Parameters<typeof register>[1],
+    );
+    const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       "/Volumes/test.wav",
       {},


### PR DESCRIPTION
## 🎯 Tier 3.1 COMPLETE — 54/54 .js tests migrated

This PR migrates the FINAL .js test file. After merge, \`ls tests/unit/*.js\` returns empty.

## File migrated

\`tests/unit/regression-session-fixes.test.ts\` (666 → 839 lines, +173 net)
- 10 describe blocks, 27 tests
- 30 require() sites, all typed via \`typeof import(\"...\")\`
- Was previously deferred per ADR-014 §5.0.1 as \"needs typed electron-mock strategy first\"
- Batch 5 (PR #98) proved this was a false alarm — patterns already existed

## Patterns applied (proven across 53 prior files)

- \`MockIpcMain\` + \`MockHandler\` + \`Parameters<typeof register>[0/1]\` — modelHandlers convention
- \`FunASRSurface\` interface + \`fsurf()\` cast helper — new local pattern, mirrors \`dbp()\` from database-coverage
- \`vi.mock(\"electron\", () => ({ app: { getPath: vi.fn() } }))\` — inline factory
- \`typeof import(\"...\").<export>\` for all 30 require bindings
- \`! \` non-null after expect().not.toBeNull()/toHaveLength(N)

## One necessary test-logic adjustment

The 2 \`downloadModels python path\` regression tests now call \`mgr.downloadModels(null)\` instead of \`mgr.downloadModels()\`. The source signature requires \`cb: ((progress) => void) | null\` (no default), so 0 args was a type error. \`null\` is the canonical \"no progress callback\" value and is functionally identical. Matching \`toHaveBeenCalledWith\` updated from \`undefined\` to \`null\`.

## Tier 3 status after this PR

| Item | Status |
|---|---|
| 3.1 — Migrate 75 .js test files | ✅ **DONE** (54/54) |
| 3.2 — Delete \`_tsresolve.setup.js\` | ⛔ Still blocked — 96 require() sites remain across .ts tests. Converting to ESM import is a separate effort. |
| 3.3 — \`no-require-imports: error\` lint | ⛔ Still blocked on 3.2 |

The audit doc §5.0 row 3.1 is now ✅ Done. Rows 3.2 and 3.3 remain deferred with clear rationale (require → ESM import conversion is mechanical but separate work).

## Verification

- ✅ \`pnpm typecheck:tests\` — 0 errors
- ✅ \`pnpm ci:check\` — 9/9 green
- ✅ 27 tests pass in migrated file
- ✅ 770 total unit tests (no regressions)
- ✅ No \`any\`/\`as any\`/\`@ts-ignore\` introduced

## Related

- ADR-014: e2e CI macOS (separate concern, unresolved)
- Audit doc §5.0.1: all 8 skip-list entries now marked ✅ Migrated