### PR TITLE
refactor: convert 20 require() sites to ESM import (Tier 3.2 batch A)

### DIFF
--- a/tests/unit/aiPrompts-few-shot.test.ts
+++ b/tests/unit/aiPrompts-few-shot.test.ts
@@ -10,10 +10,8 @@
 // [20260724_Feat_PromptFewShot] Regression tests for AI prompt few-shot examples.
 // Ensures each platform-style prompt includes concrete examples per ADR-012 Issue #4c.
 import { describe, it, expect } from "vitest";
-
-const {
-  buildPrompt,
-}: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
+// [20260726_Tier32_AiPromptsFewShot] Convert CJS require() → ESM import.
+import { buildPrompt } from "../../src/helpers/aiPrompts";
 
 describe("AI Prompt few-shot examples (ADR-012 Issue #4c)", () => {
   // Platform prompts that need few-shot examples

--- a/tests/unit/audioFileHelpers.test.ts
+++ b/tests/unit/audioFileHelpers.test.ts
@@ -9,10 +9,9 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
-
-// [20260726_Tier3_AudioFileHelpersMigrate] Source named exports pulled out
-// via the module namespace so each binding has its real (function) type.
-const audioHelpers: typeof import("../../src/helpers/audioFileHelpers") = require("../../src/helpers/audioFileHelpers");
+// [20260726_Tier32_AudioFileHelpers] Convert CJS require() → ESM namespace
+// import. The `audioHelpers.X` accessor calls below unchanged.
+import * as audioHelpers from "../../src/helpers/audioFileHelpers";
 const createTempAudioFile = audioHelpers.createTempAudioFile;
 const cleanupTempFile = audioHelpers.cleanupTempFile;
 const getFFmpegPath = audioHelpers.getFFmpegPath;

--- a/tests/unit/database-coverage.test.ts
+++ b/tests/unit/database-coverage.test.ts
@@ -9,10 +9,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import path from "path";
 import fs from "fs";
 import os from "os";
-
-// [20260726_Tier3_DatabaseCoverageMigrate] Default-export class; the require
-// returns the constructor under CJS interop.
-const DatabaseManager: typeof import("../../src/helpers/database").default = require("../../src/helpers/database");
+// [20260726_Tier32_DatabaseCoverage] Convert CJS require() → ESM default
+// import. The _tsresolve.setup PART 3 unwrap previously handed tests the
+// class directly; ESM `import X from` does the same via Vite's transform.
+import DatabaseManager from "../../src/helpers/database";
 
 // [20260726_Tier3_DatabaseCoverageMigrate] better-sqlite3 Database shape:
 // only the .prepare().run() and .backup()/.close() surface the suite

--- a/tests/unit/database-fts.test.ts
+++ b/tests/unit/database-fts.test.ts
@@ -11,8 +11,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import path from "path";
 import fs from "fs";
 import os from "os";
-
-const DatabaseManager: typeof import("../../src/helpers/database").default = require("../../src/helpers/database");
+// [20260726_Tier32_DatabaseFts] Convert CJS require() → ESM default import.
+import DatabaseManager from "../../src/helpers/database";
 
 describe("FTS5 search", () => {
   let db: InstanceType<typeof DatabaseManager>;

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -10,8 +10,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import path from "path";
 import fs from "fs";
 import os from "os";
-
-const DatabaseManager: typeof import("../../src/helpers/database").default = require("../../src/helpers/database");
+// [20260726_Tier32_Database] Convert CJS require() → ESM default import.
+import DatabaseManager from "../../src/helpers/database";
 
 describe("DatabaseManager", () => {
   let db: InstanceType<typeof DatabaseManager>;

--- a/tests/unit/dynamicTranscriptionTimeout.test.ts
+++ b/tests/unit/dynamicTranscriptionTimeout.test.ts
@@ -16,9 +16,13 @@
 // [20260724_Fix_DynamicTranscriptionTimeout] Tests for dynamic file
 // transcription timeout based on file size (ADR-012 Issue #1).
 import { describe, it, expect } from "vitest";
-
-const calculateTranscriptionTimeout: typeof import("../../src/helpers/funasrServer").default.calculateTranscriptionTimeout =
-  require("../../src/helpers/funasrServer").calculateTranscriptionTimeout;
+// [20260726_Tier32_DynamicTranscriptionTimeout] Convert CJS require() → ESM
+// import. The static `calculateTranscriptionTimeout` on the default-exported
+// FunASRServer class is destructured post-import; the local binding keeps the
+// same name and signature the suite exercises.
+import FunASRServer from "../../src/helpers/funasrServer";
+const calculateTranscriptionTimeout =
+  FunASRServer.calculateTranscriptionTimeout;
 
 describe("Dynamic transcription timeout (ADR-012 Issue #1)", () => {
   describe("calculateTranscriptionTimeout", () => {

--- a/tests/unit/environmentHandlers.test.ts
+++ b/tests/unit/environmentHandlers.test.ts
@@ -8,8 +8,11 @@
 // types via `as unknown as Parameters<...>`. Template reference:
 // phase4-i18n.test.ts (commit d52f2e0).
 import { describe, it, expect, vi } from "vitest";
-const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
-const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
+// [20260726_Tier32_EnvironmentHandlers] Convert two CJS require() → ESM
+// namespace imports. The `C.EVENTS.X` and `envHandlers.register(...)` call
+// sites below unchanged.
+import * as C from "../../src/helpers/ipc-contracts";
+import * as envHandlers from "../../src/helpers/ipc/environmentHandlers";
 
 // [20260726_Tier3_EnvironmentHandlersMigrate] Handler shape: ipcMain.handle
 // registers `(event, ...args) => result` callbacks; tests invoke them with a

--- a/tests/unit/export-formatters-coverage.test.ts
+++ b/tests/unit/export-formatters-coverage.test.ts
@@ -6,10 +6,16 @@
 // `buildPrompt` require inside the suite follows the same `typeof import`
 // pattern. Template reference: phase4-i18n.test.ts (commit d52f2e0).
 import { describe, it, expect } from "vitest";
+// [20260726_Tier32_ExportFormattersCoverage] Convert CJS require() → ESM
+// namespace import. The accessor consts below unchanged.
+import * as exportFormatters from "../../src/helpers/exportFormatters";
+// [20260726_Tier32_ExportFormattersCoverage] Hoist the buildPrompt require
+// (previously inside the describe block) to a top-level import — same value,
+// same name, ESM imports are file-scoped so hoisting is semantically safe.
+import { buildPrompt } from "../../src/helpers/aiPrompts";
 
 // [20260726_Tier3_ExportFormattersCoverageMigrate] Pull named exports out
 // via the module namespace so each binding has its real (function) type.
-const exportFormatters: typeof import("../../src/helpers/exportFormatters") = require("../../src/helpers/exportFormatters");
 const formatTXT = exportFormatters.formatTXT;
 const formatSRT = exportFormatters.formatSRT;
 const formatVTT = exportFormatters.formatVTT;
@@ -224,10 +230,8 @@ describe("exportFormatters - extended coverage", () => {
   });
 
   describe("buildPrompt review modes", () => {
-    // [20260726_Tier3_ExportFormattersCoverageMigrate] Same module-namespace
-    // pattern as the top-level exportFormatters destructure.
-    const buildPrompt: typeof import("../../src/helpers/aiPrompts").buildPrompt =
-      require("../../src/helpers/aiPrompts").buildPrompt;
+    // [20260726_Tier32_ExportFormattersCoverage] buildPrompt is now imported
+    // at the top of the file (hoisted from the original nested require()).
 
     it("returns dianping prompt", () => {
       const p = buildPrompt("dianping", "test");

--- a/tests/unit/export-formatters.test.ts
+++ b/tests/unit/export-formatters.test.ts
@@ -8,14 +8,14 @@
 // `let`-bare bindings or untyped function params in this file. Template
 // reference: phase4-i18n.test.ts (commit d52f2e0).
 import { describe, it, expect } from "vitest";
-
-const {
+// [20260726_Tier32_ExportFormatters] Convert CJS require() → ESM named import.
+import {
   formatTXT,
   formatSRT,
   formatVTT,
   formatMD,
   getFormatInfo,
-}: typeof import("../../src/helpers/exportFormatters") = require("../../src/helpers/exportFormatters");
+} from "../../src/helpers/exportFormatters";
 
 const sampleTranscription = {
   text: "你好世界",

--- a/tests/unit/ipc-contracts-orphans.test.ts
+++ b/tests/unit/ipc-contracts-orphans.test.ts
@@ -12,11 +12,9 @@
 import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
-
-// [20260726_Tier3_IpcContractsOrphansMigrate] require() under esbuild CJS
-// interop returns the module namespace, so this aligns with the named
-// `export const FUNASR/MODELS/...` members of ipc-contracts.ts.
-const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
+// [20260726_Tier32_IpcContractsOrphans] Convert CJS require() → ESM namespace
+// import. `flatten(C)` etc. unchanged.
+import * as C from "../../src/helpers/ipc-contracts";
 
 // [20260726_Tier3_IpcContractsOrphansMigrate] Recursive walker needs an
 // explicit `string[]` return type (TS7023) and `dir: string` (TS7006).

--- a/tests/unit/ipc-contracts.test.ts
+++ b/tests/unit/ipc-contracts.test.ts
@@ -8,10 +8,8 @@
 // bindings and no untyped function params in this file. Template reference:
 // phase4-i18n.test.ts (commit d52f2e0).
 import { describe, it, expect } from "vitest";
-
-// [20260726_Tier3_IpcContractsMigrate] require() under esbuild CJS interop
-// returns the module namespace, aligning with the named `export const` members.
-const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
+// [20260726_Tier32_IpcContracts] Convert CJS require() → ESM namespace import.
+import * as C from "../../src/helpers/ipc-contracts";
 
 describe("ipc-contracts", () => {
   it("exports all domain objects", () => {

--- a/tests/unit/jsx-extension-guard.test.ts
+++ b/tests/unit/jsx-extension-guard.test.ts
@@ -7,8 +7,11 @@
 // at module scope (fs/path are required, not imported, but that resolves
 // fine via @types/node). Template reference: phase4-i18n.test.ts (commit
 // d52f2e0).
-const fs: typeof import("fs") = require("fs");
-const path: typeof import("path") = require("path");
+// [20260726_Tier32_JsxExtensionGuard] Convert CJS require() → ESM default
+// imports. Drop the redundant `typeof import("...")` annotation — ESM import
+// binding carries the type.
+import fs from "fs";
+import path from "path";
 
 const SRC_DIR = path.resolve(__dirname, "../../src");
 

--- a/tests/unit/process.test.ts
+++ b/tests/unit/process.test.ts
@@ -7,11 +7,8 @@
 // untyped function params in this file. Template reference: phase4-i18n.test.ts
 // (commit d52f2e0).
 import { describe, it, expect } from "vitest";
-
-const {
-  runCommand,
-  TIMEOUTS,
-}: typeof import("../../src/utils/process") = require("../../src/utils/process");
+// [20260726_Tier32_Process] Convert CJS require() → ESM named import.
+import { runCommand, TIMEOUTS } from "../../src/utils/process";
 
 describe("process utils", () => {
   it("TIMEOUTS has expected keys", () => {

--- a/tests/unit/server-message-router-coverage.test.ts
+++ b/tests/unit/server-message-router-coverage.test.ts
@@ -12,8 +12,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { EventEmitter } from "events";
 import { PassThrough } from "stream";
 import type { ChildProcess } from "child_process";
-
-const ServerMessageRouter: typeof import("../../src/helpers/serverMessageRouter").default = require("../../src/helpers/serverMessageRouter");
+// [20260726_Tier32_ServerMessageRouterCoverage] Convert CJS require() → ESM
+// default import.
+import ServerMessageRouter from "../../src/helpers/serverMessageRouter";
 const MAX_ENTRY_AGE = 15 * 60 * 1000;
 
 // [20260726_Tier3_ServerMessageRouterCoverageMigrate] Mock process shape:

--- a/tests/unit/server-message-router.test.ts
+++ b/tests/unit/server-message-router.test.ts
@@ -11,8 +11,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { EventEmitter } from "events";
 import { PassThrough } from "stream";
 import type { ChildProcess } from "child_process";
-
-const ServerMessageRouter: typeof import("../../src/helpers/serverMessageRouter").default = require("../../src/helpers/serverMessageRouter");
+// [20260726_Tier32_ServerMessageRouter] Convert CJS require() → ESM default import.
+import ServerMessageRouter from "../../src/helpers/serverMessageRouter";
 
 // [20260726_Tier3_ServerMessageRouterMigrate] Mock process: an EventEmitter
 // (for close/error) plus the three PassThrough streams the router reads/writes.

--- a/tests/unit/systemHandlers-channels.test.ts
+++ b/tests/unit/systemHandlers-channels.test.ts
@@ -6,8 +6,10 @@
 // `as unknown as Parameters<...>`. Template reference: phase4-i18n.test.ts
 // (commit d52f2e0).
 import { describe, it, expect, vi } from "vitest";
-const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
-const sysHandlers: typeof import("../../src/helpers/ipc/systemHandlers") = require("../../src/helpers/ipc/systemHandlers");
+// [20260726_Tier32_SystemHandlersChannels] Convert two CJS require() → ESM
+// namespace imports.
+import * as C from "../../src/helpers/ipc-contracts";
+import * as sysHandlers from "../../src/helpers/ipc/systemHandlers";
 
 // [20260726_Tier3_SystemHandlersChannelsMigrate] Handler shape: ipcMain.handle
 // registers `(event, ...args) => result` callbacks. The suite only asserts


### PR DESCRIPTION
Tier 3.2 batch A: 14/22 EASY files converted (require→import). 8 left untouched (dynamic require or string-literal). 96→76 require count. 770/770 tests pass, 9/9 ci:check green.