### PR TITLE
refactor: convert 11 cargo-cult HARD files require→import (Tier 3.2 batch B1)

### DIFF
--- a/tests/unit/aiPrompts.test.ts
+++ b/tests/unit/aiPrompts.test.ts
@@ -6,26 +6,23 @@
 // `typeof import("<module>").<export>` to reuse the source module's own types
 // without introducing `any`. Template reference: phase4-i18n.test.ts
 // (commit d52f2e0).
-import { describe, it, expect, vi, beforeEach } from "vitest";
+//
+// [20260726_Tier32_AiPrompts] Tier 3.2: converted cargo-cult require() +
+// vi.resetModules() to top-level ESM import. No vi.mock() was used, so the
+// shim existed only to load the .ts source. Pattern A (single top-level
+// require + resetModules in beforeEach). vitest imports trimmed to what's
+// actually used (describe/it/expect).
+// [20260726_Tier32_AiPrompts] END
+import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
+import {
+  buildPrompt,
+  parseTemplateFile,
+  loadCustomTemplates,
+} from "../../src/helpers/aiPrompts";
 
 describe("aiPrompts", () => {
-  // [20260726_Tier3_AiPromptsMigrate] Named exports; the module namespace
-  // type provides the (content, fileName) / (dir) / (mode, text, opts)
-  // signatures directly.
-  let buildPrompt: typeof import("../../src/helpers/aiPrompts").buildPrompt;
-  let parseTemplateFile: typeof import("../../src/helpers/aiPrompts").parseTemplateFile;
-  let loadCustomTemplates: typeof import("../../src/helpers/aiPrompts").loadCustomTemplates;
-
-  beforeEach(() => {
-    vi.resetModules();
-    const aiPrompts = require("../../src/helpers/aiPrompts");
-    buildPrompt = aiPrompts.buildPrompt;
-    parseTemplateFile = aiPrompts.parseTemplateFile;
-    loadCustomTemplates = aiPrompts.loadCustomTemplates;
-  });
-
   describe("parseTemplateFile", () => {
     it("parses valid template with frontmatter and body", () => {
       const content = `---

--- a/tests/unit/detectLocalModels.test.ts
+++ b/tests/unit/detectLocalModels.test.ts
@@ -6,23 +6,18 @@
 // any under TS7008. The mock Response objects are partial; cast to
 // `unknown as Response` so the structural Response shape stays intact.
 // Template reference: phase4-i18n.test.ts (commit d52f2e0).
-import { describe, it, expect, vi, beforeEach } from "vitest";
+//
+// [20260726_Tier32_DetectLocalModels] Tier 3.2: converted cargo-cult
+// require() + vi.resetModules() to top-level ESM import. The shim only
+// existed to load the .ts source (no vi.mock was ever used). The nested
+// describe's beforeEach that did the require is removed; the outer
+// beforeEach (vi.resetModules only) is also removed as it no-ops.
+// [20260726_Tier32_DetectLocalModels] END
+import { describe, it, expect, vi } from "vitest";
+import { detectLocalModels } from "../../src/helpers/detectLocalModels";
 
 describe("detectLocalModels", () => {
-  // [20260726_Tier3_DetectLocalModelsMigrate] Named async export; the
-  // `let` here is assigned in the nested beforeEach below.
-  let detectLocalModels: typeof import("../../src/helpers/detectLocalModels").detectLocalModels;
-
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
   describe("with fetch mock", () => {
-    beforeEach(() => {
-      const detect = require("../../src/helpers/detectLocalModels");
-      detectLocalModels = detect.detectLocalModels;
-    });
-
     it("returns empty array when no local models running", async () => {
       const originalFetch = globalThis.fetch;
       // [20260726_Tier3_DetectLocalModelsMigrate] globalThis.fetch is

--- a/tests/unit/edge-cases.test.ts
+++ b/tests/unit/edge-cases.test.ts
@@ -6,24 +6,23 @@
 // `typeof import("<module>").<export>` to reuse the source module's own types
 // without introducing `any`. Template reference: phase4-i18n.test.ts
 // (commit d52f2e0).
-import { describe, it, expect, vi, beforeEach } from "vitest";
+//
+// [20260726_Tier32_EdgeCases] Tier 3.2: converted 3 cargo-cult require() +
+// vi.resetModules() sites to top-level ESM imports. Pattern B (multiple
+// resetModules calls in nested describes) — each describe had its own
+// beforeEach that only did require + resetModules, so all three beforeWhatevers
+// are deleted. No vi.mock() anywhere; shim existed only to load .ts source.
+// [20260726_Tier32_EdgeCases] END
+import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { parseTemplateFile } from "../../src/helpers/aiPrompts";
+import { loadFileConfig, saveFileConfig } from "../../src/helpers/fileConfig";
+import { validateAIBaseUrl } from "../../src/helpers/ipc/aiHandlers";
 
 describe("edge cases: template + file config", () => {
   describe("parseTemplateFile edge cases", () => {
-    // [20260725_Tier3_EdgeCasesMigrate] Named export; index the module
-    // namespace type to reuse the source's (content, fileName) => PromptTemplate | null
-    // signature.
-    let parseTemplateFile: typeof import("../../src/helpers/aiPrompts").parseTemplateFile;
-
-    beforeEach(() => {
-      vi.resetModules();
-      const aiPrompts = require("../../src/helpers/aiPrompts");
-      parseTemplateFile = aiPrompts.parseTemplateFile;
-    });
-
     it("handles Windows line endings (\\r\\n)", () => {
       const content =
         "---\r\nname: win\r\nlabel: Win\r\n---\r\nWindows content.";
@@ -61,19 +60,6 @@ describe("edge cases: template + file config", () => {
   });
 
   describe("fileConfig edge cases", () => {
-    // [20260725_Tier3_EdgeCasesMigrate] Named exports; the module namespace
-    // type provides the (configPath, settings) => void / => SettingsRecord
-    // signatures directly.
-    let loadFileConfig: typeof import("../../src/helpers/fileConfig").loadFileConfig;
-    let saveFileConfig: typeof import("../../src/helpers/fileConfig").saveFileConfig;
-
-    beforeEach(() => {
-      vi.resetModules();
-      const fileConfig = require("../../src/helpers/fileConfig");
-      loadFileConfig = fileConfig.loadFileConfig;
-      saveFileConfig = fileConfig.saveFileConfig;
-    });
-
     it("handles file with array root", () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-edge-"));
       const configPath = path.join(dir, "murmur.json");
@@ -125,16 +111,6 @@ describe("edge cases: template + file config", () => {
   });
 
   describe("validateAIBaseUrl edge cases", () => {
-    // [20260725_Tier3_EdgeCasesMigrate] Named export; same shape as in
-    // phase7-tier0-fixes.test.ts.
-    let validateAIBaseUrl: typeof import("../../src/helpers/ipc/aiHandlers").validateAIBaseUrl;
-
-    beforeEach(() => {
-      vi.resetModules();
-      const aiHandlers = require("../../src/helpers/ipc/aiHandlers");
-      validateAIBaseUrl = aiHandlers.validateAIBaseUrl;
-    });
-
     it("rejects javascript: protocol", () => {
       expect(validateAIBaseUrl("javascript:alert(1)")).toBe(false);
     });

--- a/tests/unit/fileConfig.test.ts
+++ b/tests/unit/fileConfig.test.ts
@@ -5,26 +5,26 @@
 // class pattern as database-coverage.test.ts. The saveFileConfig arg is
 // `Record<string, unknown>` per the source; record literals pass through.
 // Template reference: phase4-i18n.test.ts (commit d52f2e0).
+//
+// [20260726_Tier32_FileConfig] Tier 3.2: converted 2 cargo-cult require()
+// sites to top-level ESM imports. Top-level beforeEach had vi.resetModules()
+// + require (no vi.mock) → replaced with top-level named imports; beforeEach
+// is deleted entirely (it only did require+reset). Inner describe's
+// `DatabaseManager = require(...)` is replaced by a top-level default import.
+// The `db` instance still needs `let` (per-test fresh instance + tmpDir).
+// [20260726_Tier32_FileConfig] END
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import {
+  loadFileConfig,
+  saveFileConfig,
+  FILE_CONFIGURABLE_KEYS,
+} from "../../src/helpers/fileConfig";
+import DatabaseManager from "../../src/helpers/database";
 
 describe("fileConfig", () => {
-  // [20260726_Tier3_FileConfigMigrate] Named exports; type via the module
-  // namespace so each binding carries the source's real (function/array) type.
-  let loadFileConfig: typeof import("../../src/helpers/fileConfig").loadFileConfig;
-  let saveFileConfig: typeof import("../../src/helpers/fileConfig").saveFileConfig;
-  let FILE_CONFIGURABLE_KEYS: typeof import("../../src/helpers/fileConfig").FILE_CONFIGURABLE_KEYS;
-
-  beforeEach(() => {
-    vi.resetModules();
-    const fileConfig = require("../../src/helpers/fileConfig");
-    loadFileConfig = fileConfig.loadFileConfig;
-    saveFileConfig = fileConfig.saveFileConfig;
-    FILE_CONFIGURABLE_KEYS = fileConfig.FILE_CONFIGURABLE_KEYS;
-  });
-
   describe("loadFileConfig", () => {
     it("returns empty object when config file does not exist", () => {
       const result = loadFileConfig("/non/existent/murmur.json");
@@ -150,12 +150,10 @@ describe("fileConfig", () => {
   describe("getSetting with file config fallback", () => {
     // [20260726_Tier3_FileConfigMigrate] Default-export class; the require
     // returns the constructor under CJS interop. `db` is the class instance.
-    let DatabaseManager: typeof import("../../src/helpers/database").default;
     let db: InstanceType<typeof DatabaseManager>;
     let configDir: string;
 
     beforeEach(() => {
-      DatabaseManager = require("../../src/helpers/database");
       db = new DatabaseManager({
         info: vi.fn(),
         error: vi.fn(),

--- a/tests/unit/funasrManager-init-race.test.ts
+++ b/tests/unit/funasrManager-init-race.test.ts
@@ -6,15 +6,17 @@
 // no `any` is needed and the real source methods are still type-checked at
 // the construction site. Template reference: phase4-i18n.test.ts (commit
 // d52f2e0).
-import { describe, it, expect, vi, beforeEach } from "vitest";
+//
+// [20260726_Tier32_FunasrManagerInitRace] Tier 3.2: converted cargo-cult
+// require() + vi.resetModules() to top-level ESM default import. The shim
+// existed only to load the .ts source (no vi.mock anywhere). `asSurface`'s
+// `InstanceType<typeof FunASRManager>` now resolves via the imported class.
+// beforeEach is removed (it only did resetModules + the require assignment).
+// [20260726_Tier32_FunasrManagerInitRace] END
+import { describe, it, expect, vi } from "vitest";
+import FunASRManager from "../../src/helpers/funasrManager";
 
-// [20260724_TS_BigBang_TestFix] Replace createRequire with vite-intercepted
-// require + vi.resetModules() for .ts compatibility.
 describe("funasrManager preInitializeModels race", () => {
-  // [20260726_Tier3_FunasrManagerInitRaceMigrate] Default-export class; the
-  // require returns the constructor under CJS interop.
-  let FunASRManager: typeof import("../../src/helpers/funasrManager").default;
-
   // [20260726_Tier3_FunasrManagerInitRaceMigrate] Test-only surface: the
   // suite reassigns these instance methods and pokes the private `server`
   // field. Return types are widened to `Promise<unknown>` / `unknown` so
@@ -30,12 +32,6 @@ describe("funasrManager preInitializeModels race", () => {
     preInitializeModels: () => Promise<unknown>;
     server: { _startFunASRServer: (...args: never[]) => Promise<unknown> };
   }
-
-  beforeEach(() => {
-    vi.resetModules();
-    FunASRManager = require("../../src/helpers/funasrManager");
-  });
-  // [20260724_TS_BigBang_TestFix] END
 
   // [20260726_Tier3_FunasrManagerInitRaceMigrate] Cast helper: the manager
   // class declares `server` private and the methods are non-readonly; the

--- a/tests/unit/ipcRateLimiter.test.ts
+++ b/tests/unit/ipcRateLimiter.test.ts
@@ -7,7 +7,15 @@
 // the under-limit branch returns whatever the wrapped handler returned
 // (string here), so each call site picks the right union member via the
 // assertion flow. Template reference: phase4-i18n.test.ts (commit d52f2e0).
+//
+// [20260726_Tier32_IpcRateLimiter] Tier 3.2: this file used vi.resetModules()
+// + require() but had no vi.mock() to reset — the shim was only needed to
+// load the .ts source. Converted to top-level ESM import; the vi.resetModules
+// + dynamic require pattern was cargo-cult from .js era. vi.useFakeTimers
+// stays (timers are orthogonal to module isolation).
+// [20260726_Tier32_IpcRateLimiter] END
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import createRateLimitedHandler from "../../src/helpers/ipcRateLimiter";
 
 // [20260726_Tier3_IpcRateLimiterMigrate] The over-limit branch returns this
 // shape from the source. Tests reading `.success`/`.error` cast the unknown
@@ -18,13 +26,8 @@ interface RateLimitResult {
 }
 
 describe("ipcRateLimiter", () => {
-  // [20260726_Tier3_IpcRateLimiterMigrate] Default export of a function.
-  let createRateLimitedHandler: typeof import("../../src/helpers/ipcRateLimiter").default;
-
   beforeEach(() => {
-    vi.resetModules();
     vi.useFakeTimers();
-    createRateLimitedHandler = require("../../src/helpers/ipcRateLimiter");
   });
 
   afterEach(() => {

--- a/tests/unit/model-download-guards.test.ts
+++ b/tests/unit/model-download-guards.test.ts
@@ -16,18 +16,21 @@
 // instance type-checked). The validateAudioPath return is a discriminated
 // union; reads of `.ext`/`.error` go via a tiny `as` cast at each call site.
 // Template reference: phase4-i18n.test.ts (commit d52f2e0).
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+//
+// [20260726_Tier32_ModelDownloadGuards] Tier 3.2: converted 3 cargo-cult
+// require() sites + vi.resetModules() to top-level ESM imports. The module-
+// scope `const C = require(...)` / `const validateAudioPath = require(...)`
+// become `import * as C` / `import { validateAudioPath }`. The describe's
+// `ModelManager = require(...)` + vi.resetModules() become a top-level
+// default import; beforeEach retains the tmpDir setup.
+// [20260726_Tier32_ModelDownloadGuards] END
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
-
-// [20260724_TS_BigBang_TestFix] Replace createRequire with vite-intercepted
-// require so .ts files resolve after migration. vi.resetModules() replaces
-// delete-require.cache for module isolation.
-const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
-const validateAudioPath: typeof import("../../src/helpers/audioPathValidator").validateAudioPath =
-  require("../../src/helpers/audioPathValidator").validateAudioPath;
-// [20260724_TS_BigBang_TestFix] END
+import * as C from "../../src/helpers/ipc-contracts";
+import { validateAudioPath } from "../../src/helpers/audioPathValidator";
+import ModelManager from "../../src/helpers/modelManager";
 
 // [20260726_Tier3_ModelDownloadGuardsMigrate] Structural surface for the
 // ModelManager instance: the suite overrides getModelCachePath per test and
@@ -52,13 +55,9 @@ function asSurface<T>(m: T): ModelManagerTestSurface {
 // ─── modelManager: model files missing ───────────────────────────
 
 describe("modelManager — model files missing", () => {
-  // [20260726_Tier3_ModelDownloadGuardsMigrate] Default-export class.
-  let ModelManager: typeof import("../../src/helpers/modelManager").default;
   let tmpDir: string;
 
   beforeEach(() => {
-    vi.resetModules();
-    ModelManager = require("../../src/helpers/modelManager");
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mm-guard-"));
   });
 

--- a/tests/unit/modelHandlers.test.ts
+++ b/tests/unit/modelHandlers.test.ts
@@ -7,7 +7,15 @@
 // Electron.IpcMain / source Managers — the test stubs them — so local
 // Mock* types describe the surface the tests exercise. No `any`.
 // Template reference: phase4-i18n.test.ts (commit d52f2e0).
+//
+// [20260726_Tier32_ModelHandlers] Tier 3.2: converted cargo-cult require() +
+// vi.resetModules() to top-level ESM import. No vi.mock() was used, so the
+// shim existed only to load the .ts source. The `let register: typeof import`
+// declaration collapses to the import. beforeEach retains the mock ipcMain /
+// managers setup and the register() call.
+// [20260726_Tier32_ModelHandlers] END
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { register } from "../../src/helpers/ipc/modelHandlers";
 
 // [20260726_Tier3_ModelHandlersMigrate] Handler shape: ipcMain.handle
 // registers `(event, ...args) => result` callbacks. Tests invoke them with
@@ -47,11 +55,8 @@ interface MockManagers {
 describe("modelHandlers", () => {
   let ipcMain: MockIpcMain;
   let managers: MockManagers;
-  let register: typeof import("../../src/helpers/ipc/modelHandlers").register;
 
   beforeEach(() => {
-    vi.resetModules();
-    register = require("../../src/helpers/ipc/modelHandlers").register;
     ipcMain = createMockIpcMain();
 
     managers = {

--- a/tests/unit/modelManager-shape.test.ts
+++ b/tests/unit/modelManager-shape.test.ts
@@ -7,25 +7,26 @@
 // is typed, `m.modelConfigs` is Record<string, ModelConfig>, so
 // `Object.values(...)` yields ModelConfig[] and `config.cache_path` resolves.
 // Template reference: phase4-i18n.test.ts (commit d52f2e0).
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+//
+// [20260726_Tier32_ModelManagerShape] Tier 3.2: converted cargo-cult
+// require() + vi.resetModules() to top-level ESM default import. No vi.mock()
+// was used — the resetModules call was cargo-cult from .js era. The original
+// comment claimed resetModules reset module-level caches (globalModelCheckCache),
+// but the tests call `m.clearCache()` per-test on a fresh instance, so any
+// module-level cache is irrelevant. beforeEach retains tmpDir setup.
+// [20260726_Tier32_ModelManagerShape] END
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import ModelManager from "../../src/helpers/modelManager";
 
-// [20260724_TS_BigBang_TestFix] Replace createRequire with vite-intercepted
-// require + vi.resetModules() for .ts compatibility. Module-level cache
-// variables (globalModelCheckCache) are reset by re-importing the module,
-// which vi.resetModules() + fresh require achieves.
 describe("modelManager.checkModelFiles contract", () => {
-  let ModelManager: typeof import("../../src/helpers/modelManager").default;
   let tmpDir: string;
 
   beforeEach(() => {
-    vi.resetModules();
-    ModelManager = require("../../src/helpers/modelManager");
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mm-test-"));
   });
-  // [20260724_TS_BigBang_TestFix] END
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/unit/phase7-tier0-fixes.test.ts
+++ b/tests/unit/phase7-tier0-fixes.test.ts
@@ -3,32 +3,28 @@
 // assigned from require() in beforeEach/beforeAll — strict tsc (TS7034/TS7005)
 // cannot infer the type because the assignment happens in a callback whose
 // type does not flow back to the declaration site. Each binding is typed via
-// `typeof import("<module>").<export>` to reuse the source module's own
-// types without introducing `any`. Template reference: phase4-i18n.test.ts
+// `typeof import("<module>").<export>` to reuse the source module's own types
+// without introducing `any`. Template reference: phase4-i18n.test.ts
 // (commit d52f2e0).
 //
-// [20260724_TS_BigBang_TestFix] Replace all createRequire usages with
-// vite-intercepted require + vi.resetModules(). createRequire uses Node's
-// native resolver which cannot load .ts files. The tests only needed module
-// isolation (delete-cache), which vi.resetModules() provides equivalently.
-import { describe, it, expect, vi, beforeEach } from "vitest";
+// [20260726_Tier32_Phase7Tier0Fixes] Tier 3.2: converted 5 of 8 cargo-cult
+// require() sites + all vi.resetModules() to top-level ESM imports. The 5
+// source requires (PythonEnvironment default x2, aiHandlers named x3) all
+// lived in beforeEach blocks with no vi.mock → safe to hoist. The remaining
+// 3 require() calls are `require("fs")` INSIDE one it() body that mutates
+// Node's built-in fs.existsSync — those don't depend on resetModules and
+// converting them is out of scope (deferred, see TODO in that test).
+// [20260726_Tier32_Phase7Tier0Fixes] END
+import { describe, it, expect, vi } from "vitest";
+import PythonEnvironment from "../../src/helpers/pythonEnvironment";
+import {
+  validateAIBaseUrl,
+  processTextWithAI,
+  checkAIStatus,
+} from "../../src/helpers/ipc/aiHandlers";
 
 describe("Tier 0 fixes", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
-  // [20260724_TS_BigBang_TestFix] END
-
   describe("T0-2: Python version detection requires 3.8+", () => {
-    // [20260725_Tier3_Phase7Tier0FixesMigrate] require() returns the default
-    // export directly under esbuild CJS interop, so the binding holds the
-    // class constructor itself. `.default` indexes the module namespace type.
-    let PythonEnvironment: typeof import("../../src/helpers/pythonEnvironment").default;
-
-    beforeEach(() => {
-      PythonEnvironment = require("../../src/helpers/pythonEnvironment");
-    });
-
     it("rejects Python 3.6", () => {
       const env = new PythonEnvironment();
       expect(env.isPythonVersionSupported({ major: 3, minor: 6 })).toBe(false);
@@ -62,14 +58,6 @@ describe("Tier 0 fixes", () => {
   });
 
   describe("T0-4: PYTHONUTF8=1 in buildPythonEnvironment", () => {
-    // [20260725_Tier3_Phase7Tier0FixesMigrate] Same default-export shape as
-    // the T0-2 block above.
-    let PythonEnvironment: typeof import("../../src/helpers/pythonEnvironment").default;
-
-    beforeEach(() => {
-      PythonEnvironment = require("../../src/helpers/pythonEnvironment");
-    });
-
     it("sets PYTHONUTF8=1 to prevent GBK/CP936 encoding corruption on Windows", () => {
       const env = new PythonEnvironment({
         info: () => {},
@@ -83,6 +71,13 @@ describe("Tier 0 fixes", () => {
     });
 
     it("PYTHONUTF8 is set even when embedded Python is used", () => {
+      // [20260726_Tier32_DeferredDynamicRequire] The 3 require("fs") calls
+      // below mutate Node's built-in fs.existsSync for the duration of this
+      // test. They do NOT depend on vi.resetModules (fs is a Node builtin,
+      // not a source module), so removing resetModules above is safe. The
+      // require() form is retained because converting to a top-level
+      // `import fs from "fs"` would require restructuring the save/restore
+      // logic (the test patches a method on the imported object). Deferred.
       const env = new PythonEnvironment({
         info: () => {},
         warn: () => {},
@@ -102,15 +97,6 @@ describe("Tier 0 fixes", () => {
   });
 
   describe("T0-3: SSRF validation allows localhost for local models", () => {
-    // [20260725_Tier3_Phase7Tier0FixesMigrate] Named export; index the
-    // module namespace type by member name to reuse the source signature.
-    let validateAIBaseUrl: typeof import("../../src/helpers/ipc/aiHandlers").validateAIBaseUrl;
-
-    beforeEach(() => {
-      const aiHandlers = require("../../src/helpers/ipc/aiHandlers");
-      validateAIBaseUrl = aiHandlers.validateAIBaseUrl;
-    });
-
     it("rejects localhost by default (cloud mode)", () => {
       expect(validateAIBaseUrl("http://localhost:11434/v1")).toBe(false);
       expect(validateAIBaseUrl("https://localhost/v1")).toBe(false);
@@ -167,16 +153,6 @@ describe("Tier 0 fixes", () => {
   });
 
   describe("T1-1: processTextWithAI supports local models without API key", () => {
-    // [20260725_Tier3_Phase7Tier0FixesMigrate] Named async export; the
-    // mock db/logger passed at call sites satisfy the source's structural
-    // DatabaseManager/Logger interfaces.
-    let processTextWithAI: typeof import("../../src/helpers/ipc/aiHandlers").processTextWithAI;
-
-    beforeEach(() => {
-      const aiHandlers = require("../../src/helpers/ipc/aiHandlers");
-      processTextWithAI = aiHandlers.processTextWithAI;
-    });
-
     it("proceeds without API key when base URL is localhost", async () => {
       const db = {
         getSetting: vi.fn(async (key) => {
@@ -220,15 +196,6 @@ describe("Tier 0 fixes", () => {
   });
 
   describe("T1-1: checkAIStatus supports local models without API key", () => {
-    // [20260725_Tier3_Phase7Tier0FixesMigrate] Named async export; first
-    // argument is the testConfig | null per source signature.
-    let checkAIStatus: typeof import("../../src/helpers/ipc/aiHandlers").checkAIStatus;
-
-    beforeEach(() => {
-      const aiHandlers = require("../../src/helpers/ipc/aiHandlers");
-      checkAIStatus = aiHandlers.checkAIStatus;
-    });
-
     it("does not reject localhost URL in checkAIStatus", async () => {
       const db = {
         getSetting: vi.fn(async (key) => {

--- a/tests/unit/providerPresets.test.ts
+++ b/tests/unit/providerPresets.test.ts
@@ -6,22 +6,20 @@
 // `ProviderPresetData | undefined` return is narrowed with non-null assertions
 // after the prior `toBeDefined()` (suite convention). Template reference:
 // phase4-i18n.test.ts (commit d52f2e0).
-import { describe, it, expect, beforeEach } from "vitest";
+//
+// [20260726_Tier32_ProviderPresets] Tier 3.2: converted cargo-cult require()
+// + vi.resetModules() to top-level ESM import. No vi.mock() was used; shim
+// existed only to load the .ts source. `beforeEach` was ONLY the require, so
+// it is deleted entirely (it would have been an empty block). The `beforeEach`
+// import is dropped from the vitest import list since nothing else uses it.
+// [20260726_Tier32_ProviderPresets] END
+import { describe, it, expect } from "vitest";
+import {
+  getProviderPresets,
+  getProviderByName,
+} from "../../src/helpers/providerPresets";
 
 describe("providerPresets", () => {
-  // [20260726_Tier3_ProviderPresetsMigrate] Named exports; the module
-  // namespace type provides the () => ProviderPresetData[] and
-  // (name: string) => ProviderPresetData | undefined signatures directly.
-  let getProviderPresets: typeof import("../../src/helpers/providerPresets").getProviderPresets;
-  let getProviderByName: typeof import("../../src/helpers/providerPresets").getProviderByName;
-
-  beforeEach(() => {
-    vi.resetModules();
-    const presets = require("../../src/helpers/providerPresets");
-    getProviderPresets = presets.getProviderPresets;
-    getProviderByName = presets.getProviderByName;
-  });
-
   describe("getProviderPresets", () => {
     it("returns non-empty array of providers", () => {
       const presets = getProviderPresets();

--- a/tests/unit/settingsHandlers.test.ts
+++ b/tests/unit/settingsHandlers.test.ts
@@ -5,7 +5,14 @@
 // the mock args to register()'s source signature at the call site. The
 // handler return type is Record<string, unknown> so result.ai_api_key etc.
 // read without `any`. Template reference: phase4-i18n.test.ts (commit d52f2e0).
+//
+// [20260726_Tier32_SettingsHandlers] Tier 3.2: converted cargo-cult require()
+// + vi.resetModules() to top-level ESM import. No vi.mock() was used; shim
+// existed only to load the .ts source. beforeEach retains mock ipcMain /
+// managers setup and register() call.
+// [20260726_Tier32_SettingsHandlers] END
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { register } from "../../src/helpers/ipc/settingsHandlers";
 
 // [20260726_Tier3_SettingsHandlersMigrate] Handler shape: ipcMain.handle
 // registers `(event, ...args) => result` callbacks. Tests invoke them with
@@ -44,11 +51,8 @@ interface MockManagers {
 describe("settingsHandlers", () => {
   let ipcMain: MockIpcMain;
   let managers: MockManagers;
-  let register: typeof import("../../src/helpers/ipc/settingsHandlers").register;
 
   beforeEach(() => {
-    vi.resetModules();
-    register = require("../../src/helpers/ipc/settingsHandlers").register;
     ipcMain = createMockIpcMain();
 
     managers = {


### PR DESCRIPTION
Tier 3.2 batch B1: 11 files where vi.resetModules() was cargo-cult (no vi.mock) — converted to top-level ESM import + removed resetModules. require count 76→57. phase7-tier0-fixes has 3 dynamic require('fs') deferred with TODO. 770/770 tests pass, 9/9 ci:check green.