### PR TITLE
refactor: convert 7 REAL-vi.mock files require→import (Tier 3.2 batch B2)

### DIFF
--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -7,7 +7,7 @@
 // through unknown to the DOM lib's Response type). The global.fetch mock's
 // `.mock.calls` is read via a vi.Mock cast. Template reference:
 // phase4-i18n.test.ts (commit d52f2e0).
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 
@@ -21,6 +21,13 @@ vi.mock("electron", () => ({
 // the four bindings (register, processTextWithAI, checkAIStatus, getAIModes)
 // infer their source signatures without restating them.
 type AiHandlersModule = typeof import("../../src/helpers/ipc/aiHandlers");
+
+// [20260726_Tier32_AiHandlers] Convert require() + vi.resetModules() to a
+// top-level ESM namespace import. The vi.mock("electron", ...) above is
+// hoisted by vitest and applies to every import of the source module across
+// all tests, so per-test isolation via resetModules was never needed here.
+// The require shim (_tsresolve.setup) was only needed to load .ts source.
+import * as aiHandlersNS from "../../src/helpers/ipc/aiHandlers";
 
 // [20260726_Tier3_AiHandlersMigrate] Fetch mock return: the source only reads
 // ok/status/statusText/json()/text(), so this is the narrowest shape that
@@ -88,19 +95,16 @@ function setupDb(overrides: Record<string, unknown> = {}): {
 }
 
 describe("aiHandlers", () => {
-  let register: AiHandlersModule["register"];
-  let processTextWithAI: AiHandlersModule["processTextWithAI"];
-  let checkAIStatus: AiHandlersModule["checkAIStatus"];
-  let getAIModes: AiHandlersModule["getAIModes"];
-
-  beforeEach(() => {
-    vi.resetModules();
-    const aiHandlers: AiHandlersModule = require("../../src/helpers/ipc/aiHandlers");
-    register = aiHandlers.register;
-    processTextWithAI = aiHandlers.processTextWithAI;
-    checkAIStatus = aiHandlers.checkAIStatus;
-    getAIModes = aiHandlers.getAIModes;
-  });
+  // [20260726_Tier32_AiHandlers] Bind source functions at top level. The
+  // module is loaded once with vi.mock("electron") applied; per-test state
+  // lives in the managers/fetch stubs each test sets up, not in the module
+  // instance. The `let` is kept only so the inner describe bodies read names
+  // without the namespace prefix; assignment happens once, not per-test.
+  const aiHandlers: AiHandlersModule = aiHandlersNS;
+  const register = aiHandlers.register;
+  const processTextWithAI = aiHandlers.processTextWithAI;
+  const checkAIStatus = aiHandlers.checkAIStatus;
+  const getAIModes = aiHandlers.getAIModes;
 
   describe("register", () => {
     it("registers process-text and check-ai-status handlers", () => {

--- a/tests/unit/database-encryption-failure.test.ts
+++ b/tests/unit/database-encryption-failure.test.ts
@@ -11,8 +11,13 @@ vi.mock("electron", () => ({
   app: { getPath: vi.fn(() => "/tmp/test-user-data") },
 }));
 
+// [20260726_Tier32_DatabaseEncryptionFailure] Convert require() +
+// vi.resetModules() to a top-level ESM default import. vi.mock is hoisted
+// and applies to this import; the require shim was only needed for .ts
+// loading. database.ts uses `export default DatabaseManager`.
+import DatabaseManager from "../../src/helpers/database";
+
 describe("DatabaseManager — encryption failure resilience", () => {
-  let DatabaseManager: ReturnType<typeof require>;
   let tmpDir: string;
   let db: {
     initialize: (dir: string) => void;
@@ -23,10 +28,22 @@ describe("DatabaseManager — encryption failure resilience", () => {
   };
 
   beforeEach(() => {
-    vi.resetModules();
-    DatabaseManager = require("../../src/helpers/database");
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-enc-test-"));
-    db = new DatabaseManager();
+    // [20260726_Tier32_DatabaseEncryptionFailure] Cast through unknown: the
+    // previous require() binding was `any` (ReturnType<typeof require>), so
+    // the hand-written `db` interface above was effectively unenforced. With
+    // the typed default import the real DatabaseManager's setSafeStorage
+    // accepts SafeStorage (not unknown), which is narrower — structurally
+    // incompatible with this local interface even though the runtime shape is
+    // identical. The `as unknown` mirrors the FunASRSurface/dbp() cast
+    // pattern used across the other suites for private-field access.
+    db = new DatabaseManager() as unknown as {
+      initialize: (dir: string) => void;
+      setSafeStorage: (s: unknown) => void;
+      setSetting: (k: string, v: unknown) => unknown;
+      getSetting: (k: string, d?: unknown) => unknown;
+      close: () => void;
+    };
     db.initialize(tmpDir);
   });
 

--- a/tests/unit/funasrServer-crash-restart.test.ts
+++ b/tests/unit/funasrServer-crash-restart.test.ts
@@ -18,6 +18,13 @@ vi.mock("electron", () => ({
 // the ESM default namespace to the class itself).
 type FunASRServerCtor = typeof import("../../src/helpers/funasrServer").default;
 
+// [20260726_Tier32_FunasrServerCrashRestart] Convert require() +
+// vi.resetModules() to a top-level ESM default import. vi.mock is hoisted.
+// funasrServer.ts uses `export default FunASRServer`, so the ESM default
+// import is the class constructor itself — same shape the setupFile unwrap
+// produced via CJS interop.
+import FunASRServer from "../../src/helpers/funasrServer";
+
 // [20260726_Tier3_FunasrServerCrashRestartMigrate] StartupParams mirrors the
 // source's private interface (pythonEnv/pythonCmd/serverPath/modelCachePath).
 // Re-declared locally rather than imported because the source interface is
@@ -64,17 +71,9 @@ interface LoggerStub {
 }
 
 describe("FunASR server auto-restart", () => {
-  let FunASRServer: FunASRServerCtor;
   let logger: LoggerStub;
 
   beforeEach(() => {
-    vi.resetModules();
-    // [20260726_Tier3_FunasrServerCrashRestartMigrate] Assign the raw require()
-    // result: tests/_sresolve.setup.js PART 3 unwraps {__esModule, default} →
-    // default for sole-default-export modules, so require() returns the class
-    // itself (not a namespace). The type annotation is still the source's
-    // `default` (the class) — the runtime and static types agree post-unwrap.
-    FunASRServer = require("../../src/helpers/funasrServer");
     logger = {
       info: vi.fn(),
       warn: vi.fn(),

--- a/tests/unit/ipc-contract-completeness.test.ts
+++ b/tests/unit/ipc-contract-completeness.test.ts
@@ -4,6 +4,16 @@
 //
 // EVENTS are one-way (main -> renderer via webContents.send), so they are
 // intentionally excluded from this two-way `ipcMain.handle` coverage check.
+//
+// [20260726_Tier32_IpcContractCompleteness] All 6 vi.mock calls above are
+// module-level (hoisted by vitest) and apply to every import of those modules
+// across all tests in this file. None are changed between tests, so no test
+// needs per-test module isolation. The vi.resetModules() that used to live
+// in afterEach only existed to make the dynamic `await import(...)` calls
+// re-evaluate — but every test calls registerAll fresh with its own mock
+// managers bag, and the registrations array is reset in beforeEach, so cached
+// imports are harmless. The require shim was never needed here (the file used
+// dynamic import, not require).
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock electron — every handler module imports named members from it.
@@ -235,7 +245,10 @@ describe("IPC contract completeness", () => {
   afterEach(() => {
     if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
     else process.env.NODE_ENV = originalNodeEnv;
-    vi.resetModules();
+    // [20260726_Tier32_IpcContractCompleteness] vi.resetModules() removed —
+    // see file header. Module-level vi.mock factories are unchanged across
+    // tests, and per-test isolation comes from the fresh `registrations` array
+    // and fresh managers bag each test constructs.
   });
 
   function createMockIpcMain() {

--- a/tests/unit/ipcRateLimitIntegration.test.ts
+++ b/tests/unit/ipcRateLimitIntegration.test.ts
@@ -7,11 +7,17 @@
 // return bare objects — `unknown` lets `result.success`/`result.error` reads
 // happen via a narrow per-call cast at the assertion sites. Template
 // reference: phase4-i18n.test.ts (commit d52f2e0).
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 vi.mock("electron", () => ({
   app: { getPath: vi.fn(() => "/tmp/test-user-data") },
 }));
+
+// [20260726_Tier32_IpcRateLimitIntegration] Convert require() +
+// vi.resetModules() to a top-level ESM import. vi.mock is hoisted and applies
+// to every import of the source module. The require shim was only needed for
+// .ts loading. registerAll is a named export on ipc/index.ts.
+import { registerAll } from "../../src/helpers/ipc/index";
 
 // [20260726_Tier3_IpcRateLimitIntegrationMigrate] Handler shape: registerAll
 // routes through a rate-limiting wrapper, so handlers may be the original
@@ -26,9 +32,9 @@ interface MockIpcMain {
 }
 
 describe("IPC rate limit integration", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_IpcRateLimitIntegration] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") applies to every import, and no test in this
+  // suite changes a mock factory between tests.
 
   // [20260726_Tier3_IpcRateLimitIntegrationMigrate] handlers map typed as
   // Record<string, IpcHandler | undefined> so the `handlers[channel] = fn`
@@ -92,8 +98,6 @@ describe("IPC rate limit integration", () => {
   }
 
   it("rate-limits process-text channel", async () => {
-    const registerAll: typeof import("../../src/helpers/ipc/index").registerAll =
-      require("../../src/helpers/ipc/index").registerAll;
     const ipcMain = createIpcMain();
     registerAll(
       ipcMain as unknown as Parameters<typeof registerAll>[0],
@@ -122,8 +126,6 @@ describe("IPC rate limit integration", () => {
   });
 
   it("rate-limits download-models with strict limit", async () => {
-    const registerAll: typeof import("../../src/helpers/ipc/index").registerAll =
-      require("../../src/helpers/ipc/index").registerAll;
     const ipcMain = createIpcMain();
     registerAll(
       ipcMain as unknown as Parameters<typeof registerAll>[0],
@@ -146,8 +148,6 @@ describe("IPC rate limit integration", () => {
   });
 
   it("does not rate-limit unrestricted channels", async () => {
-    const registerAll: typeof import("../../src/helpers/ipc/index").registerAll =
-      require("../../src/helpers/ipc/index").registerAll;
     const ipcMain = createIpcMain();
     registerAll(
       ipcMain as unknown as Parameters<typeof registerAll>[0],

--- a/tests/unit/logManager.test.ts
+++ b/tests/unit/logManager.test.ts
@@ -22,6 +22,11 @@ vi.mock("electron", () => ({
 // default namespace to the class itself).
 type LogManagerCtor = typeof import("../../src/helpers/logManager").default;
 
+// [20260726_Tier32_LogManager] Convert require() + vi.resetModules() to a
+// top-level ESM default import. vi.mock is hoisted and applies to every
+// import of the module. logManager.ts uses `export default LogManager`.
+import LogManager from "../../src/helpers/logManager";
+
 // [20260726_Tier3_LogManagerMigrate] The LogManager class declares
 // logDir/logFile/funasrLogFile/_initialized private. createManager() reassigns
 // them to redirect output into the per-test temp dir, so this surface exposes
@@ -41,15 +46,9 @@ function surface(mgr: InstanceType<LogManagerCtor>): LogManagerSurface {
 }
 
 describe("LogManager", () => {
-  let LogManager: LogManagerCtor;
   let tmpDir: string;
 
   beforeEach(() => {
-    vi.resetModules();
-    // [20260726_Tier3_LogManagerMigrate] Assign the raw require() result: the
-    // setupFile unwraps {__esModule, default} → default for sole-default-export
-    // modules, so require() returns the class itself.
-    LogManager = require("../../src/helpers/logManager");
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-log-test-"));
   });
 

--- a/tests/unit/regression-session-fixes.test.ts
+++ b/tests/unit/regression-session-fixes.test.ts
@@ -24,21 +24,39 @@
 //     `pythonEnv` / `modelManager` fields the downloadModels regression pokes
 //     directly, mirroring the `dbp()` helper in database-coverage.
 //   - `! ` non-null after `toBeDefined()` / `toHaveBeenCalled()` guards.
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 vi.mock("electron", () => ({
   app: { getPath: vi.fn(() => "/tmp/test-user-data") },
 }));
 
+// [20260726_Tier32_RegressionSessionFixes] Convert 30 require() sites +
+// 7 vi.resetModules() calls to top-level ESM imports. The single vi.mock
+// above is hoisted by vitest and applies to every import of every source
+// module across all 10 describe blocks; no describe changes a mock factory
+// between tests, so per-test module isolation was never needed. The require
+// shim (_tsresolve.setup) was only needed to load .ts source.
+//
+// Conversion approach (minimal diff to test bodies):
+//   - namespace-import each source module at top level
+//   - for direct-use sites (C, envHandlers, FunASRManager, os): delete the
+//     local require line; the namespace import already provides the name
+//   - for destructure sites ({ register }, { buildPrompt }, { processTextWithAI }):
+//     replace the require() RHS with the namespace variable and drop the
+//     `typeof import(...)` annotation (TS now infers from the typed namespace)
+import * as C from "../../src/helpers/ipc-contracts";
+import * as envHandlers from "../../src/helpers/ipc/environmentHandlers";
+import * as transcriptionHandlers from "../../src/helpers/ipc/transcriptionHandlers";
+import * as settingsHandlers from "../../src/helpers/ipc/settingsHandlers";
+import * as aiPrompts from "../../src/helpers/aiPrompts";
+import * as aiHandlers from "../../src/helpers/ipc/aiHandlers";
+import FunASRManager from "../../src/helpers/funasrManager";
+import os from "os";
+
 // ---------------------------------------------------------------------------
 // Regression tests for fixes from the 2026-05-22/23 session.
 // Each test guards against a specific bug that was fixed.
 // ---------------------------------------------------------------------------
-
-// [20260726_Tier3_RegressionSessionFixesMigrate] ipc-contracts namespace,
-// typed via the source module so every `C.FUNASR.STATUS` / `C.EVENTS.*`
-// channel constant carries its literal-string type (TS7005).
-const C: typeof import("../../src/helpers/ipc-contracts") = require("../../src/helpers/ipc-contracts");
 
 // [20260726_Tier3_RegressionSessionFixesMigrate] Handler shape: ipcMain.handle
 // registers `(event, ...args) => result` callbacks. Tests invoke them with
@@ -99,7 +117,6 @@ function fsurf(m: FunASRManagerInstance): FunASRSurface {
 // 1. FUNASR.STATUS spread order — success field computed AFTER spread
 describe("FUNASR.STATUS spread order regression", () => {
   it("defaults to success:true when checkStatus returns no success field", async () => {
-    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -134,7 +151,6 @@ describe("FUNASR.STATUS spread order regression", () => {
   });
 
   it("propagates success:false when checkStatus explicitly fails", async () => {
-    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -170,7 +186,6 @@ describe("FUNASR.STATUS spread order regression", () => {
   });
 
   it("preserves success:true from checkStatus", async () => {
-    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -234,7 +249,6 @@ describe("FUNASR.STATUS status_message", () => {
   }
 
   it("includes status_message when server is ready", async () => {
-    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
     const managers = createEnvManagers({
       modelsInitialized: true,
@@ -252,7 +266,6 @@ describe("FUNASR.STATUS status_message", () => {
   });
 
   it("includes status_message when initializing", async () => {
-    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
     const managers = createEnvManagers({
       initializationPromise: Promise.resolve(),
@@ -269,7 +282,6 @@ describe("FUNASR.STATUS status_message", () => {
   });
 
   it("includes status_message when not ready", async () => {
-    const envHandlers: typeof import("../../src/helpers/ipc/environmentHandlers") = require("../../src/helpers/ipc/environmentHandlers");
     const ipcMain = createIpcMain();
     const managers = createEnvManagers();
 
@@ -285,14 +297,13 @@ describe("FUNASR.STATUS status_message", () => {
 
 // 2. TRANSCRIPTION.SAVE canonical return shape
 describe("TRANSCRIPTION.SAVE return shape regression", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_RegressionSessionFixes] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") at the top of this file applies to every
+  // import in every describe block, and no test in this describe changes a
+  // mock factory between tests.
 
   it("returns {success:true} on successful save", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -317,9 +328,7 @@ describe("TRANSCRIPTION.SAVE return shape regression", () => {
   });
 
   it("returns {success:false, error} on failure", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
 
     const managers = {
@@ -348,9 +357,10 @@ describe("TRANSCRIPTION.SAVE return shape regression", () => {
 
 // 3. SETTINGS_UPDATE broadcast on save
 describe("SETTINGS_UPDATE broadcast regression", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_RegressionSessionFixes] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") at the top of this file applies to every
+  // import in every describe block, and no test in this describe changes a
+  // mock factory between tests.
 
   function createManagers() {
     const sendSpy = vi.fn();
@@ -376,9 +386,7 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
   }
 
   it("sends SETTINGS_UPDATE event on save-setting", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/settingsHandlers") = require("../../src/helpers/ipc/settingsHandlers");
+    const { register } = settingsHandlers;
     const ipcMain = createIpcMain();
     const { managers, sendSpy } = createManagers();
 
@@ -395,9 +403,7 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
   });
 
   it("sends SETTINGS_UPDATE event on set-setting", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/settingsHandlers") = require("../../src/helpers/ipc/settingsHandlers");
+    const { register } = settingsHandlers;
     const ipcMain = createIpcMain();
     const { managers, sendSpy } = createManagers();
 
@@ -414,9 +420,7 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
   });
 
   it("sends SETTINGS_UPDATE event on reset-settings", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/settingsHandlers") = require("../../src/helpers/ipc/settingsHandlers");
+    const { register } = settingsHandlers;
     const ipcMain = createIpcMain();
     const { managers, sendSpy } = createManagers();
 
@@ -436,9 +440,7 @@ describe("SETTINGS_UPDATE broadcast regression", () => {
 // 4. aiPrompts returns {system, user} structure
 describe("aiPrompts system/user structure regression", () => {
   it("buildPrompt returns {system, user} for optimize mode", () => {
-    const {
-      buildPrompt,
-    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
+    const { buildPrompt } = aiPrompts;
     const result = buildPrompt("optimize", "测试文本");
 
     expect(result).toHaveProperty("system");
@@ -450,9 +452,7 @@ describe("aiPrompts system/user structure regression", () => {
   });
 
   it("buildPrompt returns {system, user} for optimize_long mode", () => {
-    const {
-      buildPrompt,
-    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
+    const { buildPrompt } = aiPrompts;
     const result = buildPrompt("optimize_long", "长文本测试");
 
     expect(result).toHaveProperty("system");
@@ -461,9 +461,7 @@ describe("aiPrompts system/user structure regression", () => {
   });
 
   it("buildPrompt falls back to optimize for unknown mode", () => {
-    const {
-      buildPrompt,
-    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
+    const { buildPrompt } = aiPrompts;
     const result = buildPrompt("unknown_mode", "文本");
 
     expect(result).toHaveProperty("system");
@@ -471,9 +469,7 @@ describe("aiPrompts system/user structure regression", () => {
   });
 
   it("system prompt contains core rules", () => {
-    const {
-      buildPrompt,
-    }: typeof import("../../src/helpers/aiPrompts") = require("../../src/helpers/aiPrompts");
+    const { buildPrompt } = aiPrompts;
     const { system } = buildPrompt("optimize", "文本");
 
     expect(system).toContain("绝对禁止");
@@ -483,14 +479,13 @@ describe("aiPrompts system/user structure regression", () => {
 
 // 5. SSRF validation in processTextWithAI (not just checkAIStatus)
 describe("processTextWithAI SSRF regression", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_RegressionSessionFixes] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") at the top of this file applies to every
+  // import in every describe block, and no test in this describe changes a
+  // mock factory between tests.
 
   it("rejects internal base URL in process flow", async () => {
-    const {
-      processTextWithAI,
-    }: typeof import("../../src/helpers/ipc/aiHandlers") = require("../../src/helpers/ipc/aiHandlers");
+    const { processTextWithAI } = aiHandlers;
 
     const db = {
       getSetting: vi.fn(async (key: string) => {
@@ -513,9 +508,7 @@ describe("processTextWithAI SSRF regression", () => {
   });
 
   it("rejects http base URL in process flow", async () => {
-    const {
-      processTextWithAI,
-    }: typeof import("../../src/helpers/ipc/aiHandlers") = require("../../src/helpers/ipc/aiHandlers");
+    const { processTextWithAI } = aiHandlers;
 
     const db = {
       getSetting: vi.fn(async (key: string) => {
@@ -539,12 +532,14 @@ describe("processTextWithAI SSRF regression", () => {
 
 // 6. downloadModels must call findPythonExecutable — not use stale pythonCmd
 describe("downloadModels python path regression", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_RegressionSessionFixes] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") at the top of this file applies to every
+  // import in every describe block, and no test in this describe changes a
+  // mock factory between tests.
 
   function createManager(): FunASRManagerInstance {
-    const FunASRManager: typeof import("../../src/helpers/funasrManager").default = require("../../src/helpers/funasrManager");
+    // [20260726_Tier32_RegressionSessionFixes] FunASRManager is now the
+    // top-level default import; no per-test require needed.
     const mgr = new FunASRManager();
     // [20260726_Tier3_RegressionSessionFixesMigrate] Override internal methods
     // to avoid real filesystem/electron calls. pythonEnv/modelManager are
@@ -598,9 +593,10 @@ describe("downloadModels python path regression", () => {
 // ---------------------------------------------------------------------------
 
 describe("TRANSCRIBE_FILE allowed extensions regression", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_RegressionSessionFixes] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") at the top of this file applies to every
+  // import in every describe block, and no test in this describe changes a
+  // mock factory between tests.
 
   const mockManagers = () => ({
     funasrManager: {
@@ -623,9 +619,7 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("accepts .ogg files (was rejected before BUG 1 fix)", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
     const managers = mockManagers();
     register(
@@ -633,7 +627,6 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
       managers as unknown as Parameters<typeof register>[1],
     );
 
-    const os: typeof import("os") = require("os");
     const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       `${os.homedir()}/test.ogg`,
@@ -644,9 +637,7 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("accepts .wma files (was rejected before BUG 1 fix)", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
     const managers = mockManagers();
     register(
@@ -654,7 +645,6 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
       managers as unknown as Parameters<typeof register>[1],
     );
 
-    const os: typeof import("os") = require("os");
     const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       `${os.homedir()}/test.wma`,
@@ -665,9 +655,7 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("accepts .aac files (was rejected before BUG 1 fix)", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
     const managers = mockManagers();
     register(
@@ -675,7 +663,6 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
       managers as unknown as Parameters<typeof register>[1],
     );
 
-    const os: typeof import("os") = require("os");
     const result = await ipcMain._handlers[C.TRANSCRIPTION.TRANSCRIBE_FILE]!(
       createEvent(),
       `${os.homedir()}/test.aac`,
@@ -686,9 +673,7 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
   });
 
   it("still rejects unsupported formats like .txt", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
     const managers = mockManagers();
     register(
@@ -707,14 +692,13 @@ describe("TRANSCRIBE_FILE allowed extensions regression", () => {
 });
 
 describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_RegressionSessionFixes] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") at the top of this file applies to every
+  // import in every describe block, and no test in this describe changes a
+  // mock factory between tests.
 
   it("accepts files from /Volumes/ (was rejected before BUG 3 fix)", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
     const managers = {
       funasrManager: {
@@ -747,9 +731,7 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
   });
 
   it("allows Windows drive paths like E:\\", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
     const managers = {
       funasrManager: {
@@ -775,9 +757,7 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
   });
 
   it("still rejects paths outside homedir, tmpdir, and /Volumes/", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
     const managers = {
       funasrManager: {
@@ -810,9 +790,10 @@ describe("TRANSCRIBE_FILE /Volumes/ path validation regression", () => {
 
 // 6. TRANSCRIBE_FILE sets result.id from lastInsertRowid (not dbResult.id)
 describe("TRANSCRIBE_FILE result.id regression", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
+  // [20260726_Tier32_RegressionSessionFixes] vi.resetModules() removed — the
+  // hoisted vi.mock("electron") at the top of this file applies to every
+  // import in every describe block, and no test in this describe changes a
+  // mock factory between tests.
 
   function createEvent() {
     return {
@@ -848,9 +829,7 @@ describe("TRANSCRIBE_FILE result.id regression", () => {
   }
 
   it("sets result.id from lastInsertRowid after successful transcription", async () => {
-    const {
-      register,
-    }: typeof import("../../src/helpers/ipc/transcriptionHandlers") = require("../../src/helpers/ipc/transcriptionHandlers");
+    const { register } = transcriptionHandlers;
     const ipcMain = createIpcMain();
 
     const managers = createManagers();


### PR DESCRIPTION
Tier 3.2 batch B2: 7 files including regression-session-fixes (30 require sites). vi.resetModules was unnecessary — module-level vi.mock is hoisted and persistent. 57→20 require count. 770/770 tests pass.