### PR TITLE
fix: re-include 7 excluded test files in typecheck gate (64 errors fixed)

### DIFF
--- a/tests/unit/clipboardHandlers.test.ts
+++ b/tests/unit/clipboardHandlers.test.ts
@@ -1,5 +1,17 @@
 // [20260725_TDD_ClipboardHandlers] TDD tests for clipboardHandlers.ts
 // Tests verify channel registration completeness + key handler behaviors.
+//
+// [20260726_TypeGate_ClipboardHandlers] Re-enabled in the tsconfig.test.json
+// typecheck gate. Two strict-mode patterns surface here:
+//  (A) TS18046 — handlers are typed (...args: unknown[]) => unknown, so each
+//      `const result = await handler(...)` reads fields on `unknown`. Fix:
+//      cast at the assignment site to HandlerResult (success/error).
+//  (B) TS18048 — mockClipboardManager is Record<string, ReturnType<typeof vi.fn>>,
+//      so indexed access is possibly-undefined. Methods are populated in
+//      beforeEach, so mockImplementationOnce sites take a non-null assertion.
+//      The happy-path toHaveBeenCalledWith assertions are already fine.
+// Template reference: tests/unit/modelHandlers.test.ts (MockHandler + casts).
+// [20260726_TypeGate_ClipboardHandlers] END
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock electron — dialog is referenced by sibling handlers but kept for parity
@@ -9,6 +21,13 @@ vi.mock("electron", () => ({
     showSaveDialog: vi.fn(async () => ({ canceled: true })),
   },
 }));
+
+// [20260726_TypeGate_ClipboardHandlers] Structural shape for handler return
+// values read in assertions. Handlers are typed (...args: unknown[]) => unknown.
+interface HandlerResult {
+  success: boolean;
+  error?: string;
+}
 
 describe("clipboardHandlers", () => {
   let registeredHandlers: Map<string, (...args: unknown[]) => unknown>;
@@ -102,13 +121,15 @@ describe("clipboardHandlers", () => {
     });
 
     it("returns error result when pasteText throws", async () => {
-      mockClipboardManager.pasteText.mockImplementationOnce(() => {
+      // [20260726_TypeGate_ClipboardHandlers] mockClipboardManager indexed
+      // access is possibly-undefined; the method is populated in beforeEach.
+      mockClipboardManager.pasteText!.mockImplementationOnce(() => {
         throw new Error("paste failed");
       });
       const C = await setup();
       const handler = registeredHandlers.get(C.CLIPBOARD.PASTE)!;
 
-      const result = await handler({}, "boom");
+      const result = (await handler({}, "boom")) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("paste failed");
     });
@@ -127,13 +148,15 @@ describe("clipboardHandlers", () => {
     });
 
     it("returns error result when copyText throws", async () => {
-      mockClipboardManager.copyText.mockImplementationOnce(() => {
+      // [20260726_TypeGate_ClipboardHandlers] mockClipboardManager indexed
+      // access is possibly-undefined; the method is populated in beforeEach.
+      mockClipboardManager.copyText!.mockImplementationOnce(() => {
         throw new Error("copy failed");
       });
       const C = await setup();
       const handler = registeredHandlers.get(C.CLIPBOARD.COPY)!;
 
-      const result = await handler({}, "boom");
+      const result = (await handler({}, "boom")) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("copy failed");
     });
@@ -150,13 +173,15 @@ describe("clipboardHandlers", () => {
     });
 
     it("returns error result when readClipboard throws", async () => {
-      mockClipboardManager.readClipboard.mockImplementationOnce(() => {
+      // [20260726_TypeGate_ClipboardHandlers] mockClipboardManager indexed
+      // access is possibly-undefined; the method is populated in beforeEach.
+      mockClipboardManager.readClipboard!.mockImplementationOnce(() => {
         throw new Error("read failed");
       });
       const C = await setup();
       const handler = registeredHandlers.get(C.CLIPBOARD.READ)!;
 
-      const result = await handler({});
+      const result = (await handler({})) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("read failed");
     });
@@ -175,13 +200,15 @@ describe("clipboardHandlers", () => {
     });
 
     it("returns error result when writeClipboard throws", async () => {
-      mockClipboardManager.writeClipboard.mockImplementationOnce(() => {
+      // [20260726_TypeGate_ClipboardHandlers] mockClipboardManager indexed
+      // access is possibly-undefined; the method is populated in beforeEach.
+      mockClipboardManager.writeClipboard!.mockImplementationOnce(() => {
         throw new Error("write failed");
       });
       const C = await setup();
       const handler = registeredHandlers.get(C.CLIPBOARD.WRITE)!;
 
-      const result = await handler({}, "boom");
+      const result = (await handler({}, "boom")) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("write failed");
     });

--- a/tests/unit/database-error-paths.test.ts
+++ b/tests/unit/database-error-paths.test.ts
@@ -7,6 +7,14 @@
 //
 // Setup mirrors the existing database.test.js / database-coverage.test.js
 // pattern: temp dir, initialize, close + cleanup.
+//
+// [20260726_TypeGate_DbErrorPaths] Re-enabled in the tsconfig.test.json
+// typecheck gate. The mock `logger` (vi.fn() returning Mock<Procedure>) is not
+// structurally assignable to DatabaseManager's local `Logger` interface
+// (its methods are `(...args: unknown[]) => void`). Cast at the constructor
+// call via the source's own parameter type — `unknown` bridge, no `any`.
+// Template reference: tests/unit/modelHandlers.test.ts (as unknown as ...).
+// [20260726_TypeGate_DbErrorPaths] END
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import path from "path";
 import fs from "fs";
@@ -50,7 +58,12 @@ describe("DatabaseManager - error paths (TDD)", () => {
       warn: vi.fn(),
       error: vi.fn(),
     };
-    db = new DatabaseManager(logger);
+    // [20260726_TypeGate_DbErrorPaths] Cast the vi.fn()-based logger to the
+    // DatabaseManager constructor's expected parameter type — Mock<Procedure>
+    // is not structurally assignable to the source's local Logger interface.
+    db = new DatabaseManager(
+      logger as unknown as ConstructorParameters<typeof DatabaseManager>[0],
+    );
     db.initialize(tmpDir);
   });
 

--- a/tests/unit/hotkeyHandlers.test.ts
+++ b/tests/unit/hotkeyHandlers.test.ts
@@ -1,5 +1,18 @@
 // [20260725_TDD_HotkeyHandlers] TDD tests for hotkeyHandlers.ts
 // Tests verify channel registration completeness + key handler behaviors.
+//
+// [20260726_TypeGate_HotkeyHandlers] Re-enabled in the tsconfig.test.json
+// typecheck gate. Two strict-mode patterns surface here:
+//  (A) TS18046 — handlers are typed (...args: unknown[]) => unknown, so each
+//      `const result = await handler(...)` reads fields on `unknown`. Fix:
+//      cast at the assignment site to HandlerResult (success/error/isRecording)
+//      or to string for the GET_CURRENT getter.
+//  (B) TS18048 — mockHotkeyManager is Record<string, ReturnType<typeof vi.fn>>,
+//      so indexed access is possibly-undefined. Methods are populated in
+//      beforeEach, so assertion/mockClear/mockReturnValueOnce sites take a
+//      non-null assertion. No `any`.
+// Template reference: tests/unit/modelHandlers.test.ts (MockHandler + casts).
+// [20260726_TypeGate_HotkeyHandlers] END
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock electron — hotkeyHandlers imports BrowserWindow for the F2 path
@@ -8,6 +21,14 @@ vi.mock("electron", () => ({
     getAllWindows: vi.fn(() => []),
   },
 }));
+
+// [20260726_TypeGate_HotkeyHandlers] Structural shape for handler return
+// values read in assertions. Handlers are typed (...args: unknown[]) => unknown.
+interface HandlerResult {
+  success: boolean;
+  error?: string;
+  isRecording?: boolean;
+}
 
 describe("hotkeyHandlers", () => {
   let registeredHandlers: Map<string, (...args: unknown[]) => unknown>;
@@ -116,7 +137,12 @@ describe("hotkeyHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.REGISTER)!;
 
-      const result = await handler(mockEvent, "CommandOrControl+Shift+Space");
+      // [20260726_TypeGate_HotkeyHandlers] handler returns unknown; cast to
+      // HandlerResult to read success.
+      const result = (await handler(
+        mockEvent,
+        "CommandOrControl+Shift+Space",
+      )) as HandlerResult;
       expect(result.success).toBe(true);
       expect(mockHotkeyManager.registerHotkey).toHaveBeenCalledWith(
         "CommandOrControl+Shift+Space",
@@ -140,8 +166,13 @@ describe("hotkeyHandlers", () => {
       const handler = registeredHandlers.get(C.HOTKEY.REGISTER)!;
 
       await handler(mockEvent, "CommandOrControl+Shift+Space");
-      mockHotkeyManager.registerHotkey.mockClear();
-      const second = await handler(mockEvent, "CommandOrControl+Shift+Space");
+      // [20260726_TypeGate_HotkeyHandlers] mockHotkeyManager indexed access is
+      // possibly-undefined; the method is populated in beforeEach so assert.
+      mockHotkeyManager.registerHotkey!.mockClear();
+      const second = (await handler(
+        mockEvent,
+        "CommandOrControl+Shift+Space",
+      )) as HandlerResult;
 
       expect(second.success).toBe(true);
       expect(mockHotkeyManager.registerHotkey).not.toHaveBeenCalled();
@@ -161,7 +192,10 @@ describe("hotkeyHandlers", () => {
       const C = await import("../../src/helpers/ipc-contracts");
       const handler = registeredHandlers.get(C.HOTKEY.REGISTER)!;
 
-      const result = await handler(mockEvent, "CommandOrControl+Shift+Space");
+      const result = (await handler(
+        mockEvent,
+        "CommandOrControl+Shift+Space",
+      )) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("未初始化");
     });
@@ -172,7 +206,10 @@ describe("hotkeyHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.UNREGISTER)!;
 
-      const result = await handler(mockEvent, "CommandOrControl+Shift+Space");
+      const result = (await handler(
+        mockEvent,
+        "CommandOrControl+Shift+Space",
+      )) as HandlerResult;
       expect(result.success).toBe(true);
       expect(mockHotkeyManager.unregisterHotkey).toHaveBeenCalledWith(
         "CommandOrControl+Shift+Space",
@@ -185,7 +222,9 @@ describe("hotkeyHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.GET_CURRENT)!;
 
-      const result = await handler(mockEvent);
+      // [20260726_TypeGate_HotkeyHandlers] GET_CURRENT returns the hotkey
+      // string (not an object); cast unknown to string.
+      const result = (await handler(mockEvent)) as string;
       expect(mockHotkeyManager.getRegisteredHotkeys).toHaveBeenCalled();
       expect(result).toBe("CommandOrControl+Shift+Space");
     });
@@ -193,12 +232,14 @@ describe("hotkeyHandlers", () => {
     it("filters out the F2 key and returns the main hotkey", async () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.GET_CURRENT)!;
-      mockHotkeyManager.getRegisteredHotkeys.mockReturnValueOnce([
+      // [20260726_TypeGate_HotkeyHandlers] mockHotkeyManager indexed access is
+      // possibly-undefined; the method is populated in beforeEach so assert.
+      mockHotkeyManager.getRegisteredHotkeys!.mockReturnValueOnce([
         "F2",
         "CommandOrControl+Shift+Space",
       ]);
 
-      const result = await handler(mockEvent);
+      const result = (await handler(mockEvent)) as string;
       expect(result).toBe("CommandOrControl+Shift+Space");
     });
   });
@@ -208,7 +249,7 @@ describe("hotkeyHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.REGISTER_F2)!;
 
-      const result = await handler(mockEvent);
+      const result = (await handler(mockEvent)) as HandlerResult;
       expect(result.success).toBe(true);
       expect(mockHotkeyManager.registerF2DoubleClick).toHaveBeenCalledWith(
         expect.any(Function),
@@ -220,11 +261,13 @@ describe("hotkeyHandlers", () => {
       const handler = registeredHandlers.get(C.HOTKEY.REGISTER_F2)!;
 
       await handler(mockEvent);
-      mockHotkeyManager.registerF2DoubleClick.mockClear();
+      // [20260726_TypeGate_HotkeyHandlers] mockHotkeyManager indexed access is
+      // possibly-undefined; the method is populated in beforeEach so assert.
+      mockHotkeyManager.registerF2DoubleClick!.mockClear();
 
       // Second sender — different id
       const secondEvent = { sender: { id: 2, on: vi.fn() } };
-      const result = await handler(secondEvent);
+      const result = (await handler(secondEvent)) as HandlerResult;
       expect(result.success).toBe(true);
       expect(mockHotkeyManager.registerF2DoubleClick).not.toHaveBeenCalled();
     });
@@ -237,7 +280,7 @@ describe("hotkeyHandlers", () => {
       const unregisterHandler = registeredHandlers.get(C.HOTKEY.UNREGISTER_F2)!;
 
       await registerHandler(mockEvent);
-      const result = await unregisterHandler(mockEvent);
+      const result = (await unregisterHandler(mockEvent)) as HandlerResult;
       expect(result.success).toBe(true);
     });
 
@@ -245,7 +288,7 @@ describe("hotkeyHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.UNREGISTER_F2)!;
 
-      const result = await handler(mockEvent);
+      const result = (await handler(mockEvent)) as HandlerResult;
       expect(result.success).toBe(false);
     });
   });
@@ -255,7 +298,7 @@ describe("hotkeyHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.SET_STATE)!;
 
-      const result = await handler(mockEvent, true);
+      const result = (await handler(mockEvent, true)) as HandlerResult;
       expect(result.success).toBe(true);
       expect(mockHotkeyManager.setRecordingState).toHaveBeenCalledWith(true);
     });
@@ -274,7 +317,7 @@ describe("hotkeyHandlers", () => {
       const C = await import("../../src/helpers/ipc-contracts");
       const handler = registeredHandlers.get(C.HOTKEY.SET_STATE)!;
 
-      const result = await handler(mockEvent, true);
+      const result = (await handler(mockEvent, true)) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("未初始化");
     });
@@ -284,9 +327,11 @@ describe("hotkeyHandlers", () => {
     it("returns the recording state from hotkeyManager.getRecordingState", async () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.HOTKEY.GET_STATE)!;
-      mockHotkeyManager.getRecordingState.mockReturnValueOnce(true);
+      // [20260726_TypeGate_HotkeyHandlers] mockHotkeyManager indexed access is
+      // possibly-undefined; the method is populated in beforeEach so assert.
+      mockHotkeyManager.getRecordingState!.mockReturnValueOnce(true);
 
-      const result = await handler(mockEvent);
+      const result = (await handler(mockEvent)) as HandlerResult;
       expect(result.success).toBe(true);
       expect(result.isRecording).toBe(true);
       expect(mockHotkeyManager.getRecordingState).toHaveBeenCalled();
@@ -306,7 +351,7 @@ describe("hotkeyHandlers", () => {
       const C = await import("../../src/helpers/ipc-contracts");
       const handler = registeredHandlers.get(C.HOTKEY.GET_STATE)!;
 
-      const result = await handler(mockEvent);
+      const result = (await handler(mockEvent)) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("未初始化");
     });

--- a/tests/unit/ipc-contract-completeness.test.ts
+++ b/tests/unit/ipc-contract-completeness.test.ts
@@ -14,6 +14,12 @@
 // managers bag, and the registrations array is reset in beforeEach, so cached
 // imports are harmless. The require shim was never needed here (the file used
 // dynamic import, not require).
+//
+// [20260726_TypeGate_IpcContractCompleteness] Re-enabled in the
+// tsconfig.test.json typecheck gate. The single strict-mode error (TS2345) is
+// the contract-group flatMap producing a literal union that `.includes(ch)`
+// rejects when ch is a plain string; widened to string[] at the assignment.
+// [20260726_TypeGate_IpcContractCompleteness] END
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock electron — every handler module imports named members from it.
@@ -284,7 +290,10 @@ describe("IPC contract completeness", () => {
       C.UPDATE,
       C.SYSTEM,
     ];
-    const expectedChannels = contractGroups.flatMap((group) =>
+    // [20260726_TypeGate_IpcContractCompleteness] flatMap over typed contract
+    // groups yields a narrow literal union; widen to string[] so the
+    // `.includes(ch)` filter below (ch is string from registrations) typechecks.
+    const expectedChannels: string[] = contractGroups.flatMap((group) =>
       Object.values(group),
     );
 

--- a/tests/unit/preload-bridge-contract.test.ts
+++ b/tests/unit/preload-bridge-contract.test.ts
@@ -9,6 +9,14 @@
 //   1. exposeInMainWorld was called with the key "electronAPI"
 //   2. the exposed object has >= 50 methods (regression guard for surface area)
 //   3. specific critical methods exist with typeof === "function"
+//
+// [20260726_TypeGate_PreloadBridgeContract] Re-enabled in the tsconfig.test.json
+// typecheck gate. The smoke-call test invokes critical methods on the exposed
+// electronAPI, which is cast to Record<string, (...args) => unknown>. With
+// noUncheckedIndexedAccess each indexed access is possibly-undefined (TS2722),
+// so each invocation takes a non-null assertion — the prior test already
+// asserts typeof api[name] === "function" for every critical name. No `any`.
+// [20260726_TypeGate_PreloadBridgeContract] END
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // vi.mock factories are hoisted above all other code, so any variable they
@@ -117,16 +125,19 @@ describe("preload bridge contract", () => {
     const invokeMock = ipcRenderer.invoke as ReturnType<typeof vi.fn>;
     invokeMock.mockClear();
 
-    api.processText("hello", "optimize");
-    api.checkModelFiles();
-    api.saveTranscription({ text: "x" });
-    api.getTranscriptions(10, 0);
-    api.setSetting("foo", "bar");
-    api.getSetting("foo");
-    api.minimizeWindow();
-    api.registerHotkey("CmdOrCtrl+Shift+Space");
-    api.pasteText("hi");
-    api.checkForUpdates();
+    // [20260726_TypeGate_PreloadBridgeContract] Record<string, ...> indexed
+    // access is possibly-undefined under noUncheckedIndexedAccess; the prior
+    // test asserts every name below is typeof === "function", so non-null.
+    api.processText!("hello", "optimize");
+    api.checkModelFiles!();
+    api.saveTranscription!({ text: "x" });
+    api.getTranscriptions!(10, 0);
+    api.setSetting!("foo", "bar");
+    api.getSetting!("foo");
+    api.minimizeWindow!();
+    api.registerHotkey!("CmdOrCtrl+Shift+Space");
+    api.pasteText!("hi");
+    api.checkForUpdates!();
 
     expect(invokeMock).toHaveBeenCalledTimes(10);
   });

--- a/tests/unit/rejection-assertions-awaited.test.ts
+++ b/tests/unit/rejection-assertions-awaited.test.ts
@@ -250,8 +250,10 @@ function flatOffsetToLineNo(
   let lineIdx = 0;
   let pos = 0;
   while (pos < offset && lineIdx < codeLines.length - 1) {
-    // +1 for the newline separator
-    const lineLen = codeLines[lineIdx].text.length + 1;
+    // +1 for the newline separator. [20260726_TypeGate_RejectionAssertions]
+    // loop guard `lineIdx < codeLines.length - 1` guarantees the index is in
+    // bounds; non-null assertion satisfies noUncheckedIndexedAccess.
+    const lineLen = codeLines[lineIdx]!.text.length + 1;
     if (pos + lineLen > offset) break;
     pos += lineLen;
     lineIdx += 1;

--- a/tests/unit/transcriptionHandlers.test.ts
+++ b/tests/unit/transcriptionHandlers.test.ts
@@ -1,5 +1,18 @@
 // [20260724_TDD_TranscriptionHandlers] TDD tests for transcriptionHandlers.ts
 // Tests verify channel registration completeness + key handler behaviors.
+//
+// [20260726_TypeGate_TranscriptionHandlers] Re-enabled in the tsconfig.test.json
+// typecheck gate. Two strict-mode patterns surface here:
+//  (A) TS18046 — handlers are typed (...args: unknown[]) => unknown, so each
+//      `const result = await handler(...)` reads fields on `unknown`. Fix:
+//      cast at the assignment site to the structural shape the assertions
+//      read (HandlerResult below covers success/error/canceled/lastInsertRowid).
+//  (B) TS18048 — mockDb is Record<string, ReturnType<typeof vi.fn>>, so indexed
+//      access is possibly-undefined. The mock is fully populated in beforeEach,
+//      so `.mockImplementationOnce`/`.mockReturnValueOnce` sites take a
+//      non-null assertion. No `any`.
+// Template reference: tests/unit/modelHandlers.test.ts (MockHandler + casts).
+// [20260726_TypeGate_TranscriptionHandlers] END
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock electron — dialog.showSaveDialog for EXPORT, dialog.showMessageBox
@@ -33,6 +46,16 @@ vi.mock("../../src/helpers/audioPathValidator", () => ({
     resolved: "/fake/path.wav",
   })),
 }));
+
+// [20260726_TypeGate_TranscriptionHandlers] Structural shape for handler
+// return values read in assertions below. Handlers are typed as returning
+// `unknown`; this cast bridges to the fields the tests inspect without `any`.
+interface HandlerResult {
+  success: boolean;
+  error?: string;
+  canceled?: boolean;
+  lastInsertRowid?: number;
+}
 
 describe("transcriptionHandlers", () => {
   let registeredHandlers: Map<string, (...args: unknown[]) => unknown>;
@@ -143,20 +166,24 @@ describe("transcriptionHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.SAVE)!;
 
-      const result = await handler({}, { text: "hello" });
+      // [20260726_TypeGate_TranscriptionHandlers] handler returns unknown;
+      // cast to HandlerResult to read success/lastInsertRowid.
+      const result = (await handler({}, { text: "hello" })) as HandlerResult;
       expect(result.success).toBe(true);
       expect(result.lastInsertRowid).toBe(42);
       expect(mockDb.saveTranscription).toHaveBeenCalledWith({ text: "hello" });
     });
 
     it("returns error on exception", async () => {
-      mockDb.saveTranscription.mockImplementationOnce(() => {
+      // [20260726_TypeGate_TranscriptionHandlers] mockDb indexed access is
+      // possibly-undefined; the method is populated in beforeEach so assert.
+      mockDb.saveTranscription!.mockImplementationOnce(() => {
         throw new Error("DB locked");
       });
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.SAVE)!;
 
-      const result = await handler({}, { text: "hello" });
+      const result = (await handler({}, { text: "hello" })) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("DB locked");
     });
@@ -173,7 +200,7 @@ describe("transcriptionHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.VALIDATE_FILE)!;
 
-      const result = await handler({}, "/fake/file.xyz");
+      const result = (await handler({}, "/fake/file.xyz")) as HandlerResult;
       expect(result.success).toBe(false);
     });
 
@@ -183,7 +210,7 @@ describe("transcriptionHandlers", () => {
 
       // validateAudioPath mock returns valid:true, but fs.statSync will fail
       // on /fake/path.wav since the file doesn't exist
-      const result = await handler({}, "/fake/path.wav");
+      const result = (await handler({}, "/fake/path.wav")) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("不存在");
     });
@@ -199,17 +226,19 @@ describe("transcriptionHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.EXPORT)!;
 
-      const result = await handler({}, 42, "txt");
+      const result = (await handler({}, 42, "txt")) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.canceled).toBe(true);
     });
 
     it("returns error when transcription not found", async () => {
-      mockDb.getTranscriptionById.mockReturnValueOnce(null);
+      // [20260726_TypeGate_TranscriptionHandlers] mockDb indexed access —
+      // non-null; method populated in beforeEach.
+      mockDb.getTranscriptionById!.mockReturnValueOnce(null);
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.EXPORT)!;
 
-      const result = await handler({}, 999, "txt");
+      const result = (await handler({}, 999, "txt")) as HandlerResult;
       expect(result.success).toBe(false);
     });
   });
@@ -219,17 +248,19 @@ describe("transcriptionHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.AI_REVIEW)!;
 
-      const result = await handler({}, 42, "optimize");
+      const result = (await handler({}, 42, "optimize")) as HandlerResult;
       expect(mockProcessTextWithAI).toHaveBeenCalled();
       expect(result.success).toBe(true);
     });
 
     it("returns error when transcription not found", async () => {
-      mockDb.getTranscriptionById.mockReturnValueOnce(null);
+      // [20260726_TypeGate_TranscriptionHandlers] mockDb indexed access —
+      // non-null; method populated in beforeEach.
+      mockDb.getTranscriptionById!.mockReturnValueOnce(null);
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.AI_REVIEW)!;
 
-      const result = await handler({}, 999, "optimize");
+      const result = (await handler({}, 999, "optimize")) as HandlerResult;
       expect(result.success).toBe(false);
     });
 
@@ -240,7 +271,7 @@ describe("transcriptionHandlers", () => {
       const C = await setup();
       const handler = registeredHandlers.get(C.TRANSCRIPTION.AI_REVIEW)!;
 
-      const result = await handler({}, 42, "optimize");
+      const result = (await handler({}, 42, "optimize")) as HandlerResult;
       expect(result.success).toBe(false);
       expect(result.error).toContain("不可用");
     });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -17,13 +17,6 @@
     "dist-main",
     "dist-preload",
     "tests/e2e/**",
-    "tests/**/*.js",
-    "tests/unit/clipboardHandlers.test.ts",
-    "tests/unit/hotkeyHandlers.test.ts",
-    "tests/unit/transcriptionHandlers.test.ts",
-    "tests/unit/preload-bridge-contract.test.ts",
-    "tests/unit/ipc-contract-completeness.test.ts",
-    "tests/unit/database-error-paths.test.ts",
-    "tests/unit/rejection-assertions-awaited.test.ts"
+    "tests/**/*.js"
   ]
 }


### PR DESCRIPTION
All 7 per-file exclusions removed. 64 strict-mode errors fixed via HandlerResult casts + ! non-null assertions. ZERO per-file exclusions remain in tsconfig.test.json. 9/9 ci:check, 772/772 tests. Closes tech-debt audit High #2.