### PR TITLE
refactor: dev/prod 加载同构(P2.1)— 去掉 tsx 直跑,silent-hang 温床根除

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prestart": "npm run build:main && npm run build:preload",
     "predev": "npx electron-rebuild && npm run build:preload",
     "dev": "concurrently -k -r \"npm:dev:renderer\" \"npm:dev:main\"",
-    "dev:main": "cross-env NODE_ENV=development NODE_OPTIONS='--import tsx' electron main.ts --dev",
+    "dev:main": "npm run build:main && cross-env NODE_ENV=development electron . --dev",
     "build:main": "esbuild main.ts --bundle --platform=node --format=cjs --external:electron --external:better-sqlite3 --outfile=dist-main/main.js",
     "dev:renderer": "cd src && vite",
     "build:preload": "esbuild preload.ts --bundle --platform=node --format=cjs --external:electron --outfile=dist-preload/preload.js",

--- a/tests/unit/ci-config.test.ts
+++ b/tests/unit/ci-config.test.ts
@@ -123,26 +123,23 @@ describe("CI/CD configuration", () => {
     });
   });
 
-  // [20260724_Fix_DevModeTsxLoader] Regression guard: Electron 36 loads .ts
-  // entry files via the ESM loader. --require tsx/cjs only patches CJS
-  // Module._extensions, which the ESM loader ignores, causing
-  // ERR_UNKNOWN_FILE_EXTENSION. [20260728_hardening] Empirically the CLI form
-  // `electron --import tsx/esm main.ts` does NOT work — Electron swallows the
-  // CLI --import, tsx/esm becomes the app path, and main.ts never loads
-  // (silent hang). tsx MUST register via NODE_OPTIONS='--import tsx' (the tsx
-  // main entry, not tsx/esm — which hijacks electron cli.js's require). See
-  // memory electron-tsx-esm-loader and the runtime smoke
-  // tests/unit/dev-main-smoke.test.ts (the guard that actually catches this).
+  // [20260728_P2.1_DevProdParity] dev:main loads the SAME artifact as prod:
+  // esbuild bundles main.ts → dist-main/main.js, then `electron .` reads
+  // package.json main. The tsx direct-run path (and its silent-hang class) is
+  // gone — see docs/research/electron-dev-startup-hardening.md §P2.1. The
+  // runtime guard tests/unit/dev-main-smoke.test.ts spawns electron . and
+  // asserts [main:canary].
   describe("dev mode entry point loading", () => {
     const pkg = JSON.parse(
       fs.readFileSync(path.join(root, "package.json"), "utf8"),
     );
 
-    it("dev:main registers tsx via NODE_OPTIONS (CLI --import is swallowed by Electron)", () => {
+    it("dev:main builds the bundle and loads it via electron . (dev/prod parity)", () => {
       const devMain = pkg.scripts["dev:main"];
-      expect(devMain).toMatch(/NODE_OPTIONS=['"]?.*--import tsx( |['"]|$)/);
-      expect(devMain).not.toContain("--require tsx/cjs");
-      expect(devMain).not.toContain("--import tsx/esm"); // CLI form — Electron swallows it
+      expect(devMain).toContain("build:main");
+      expect(devMain).toContain("electron ."); // loads dist-main/main.js via package.json main
+      expect(devMain).not.toContain("NODE_OPTIONS"); // tsx direct-run removed
+      expect(devMain).not.toContain("main.ts --dev"); // not running source .ts directly
     });
 
     it("prestart builds main bundle before electron . (which reads package.json main)", () => {

--- a/tests/unit/dev-main-smoke.test.ts
+++ b/tests/unit/dev-main-smoke.test.ts
@@ -1,85 +1,86 @@
-// [dev-startup-hardening P0.1] Runtime smoke for dev:main — the silent-hang guard.
-// A string-only check (ci-config.test.ts) and bundled E2E (dist-main/main.js)
-// both miss the bug class where `electron main.ts` spawns alive but never
-// loads main.ts (the c875321 regression that潜伏ed for days). This test
-// spawns the REAL dev:main load path and asserts the [main:canary] line
-// (main.ts:12) fires within a hard timeout — proving main.ts module-loaded.
-//
-// The canary fires BEFORE DatabaseManager.initialize, so this smoke is
-// independent of the better-sqlite3 ABI state (dev-135 vs test-137).
+// [dev-startup-hardening P0.1 → P2.1] Runtime smoke for dev:main.
+// P2.1: dev:main loads the SAME artifact as prod (esbuild bundles main.ts →
+// dist-main/main.js, then `electron .` reads package.json main). So this smoke
+// now spawns `electron .` and asserts [main:canary] (main.ts:12, preserved by
+// esbuild) fires. Catches any regression where the main entry never loads
+// (wrong main field, broken build, app-path resolution). The canary fires
+// before DatabaseManager.initialize, so this is independent of the
+// better-sqlite3 ABI state (dev-135 vs test-137).
 import { describe, it } from "vitest";
-import { spawn, type ChildProcess } from "child_process";
+import { spawn, execSync, type ChildProcess } from "child_process";
 import { createRequire } from "module";
 import path from "path";
+import fs from "fs";
 
 const require = createRequire(import.meta.url);
 const ROOT = path.resolve(__dirname, "../..");
 const CANARY = "[main:canary] main.ts module-load-started";
+const BUNDLE = path.join(ROOT, "dist-main/main.js");
 const TIMEOUT_MS = 20_000;
 
 describe("dev:main runtime smoke (silent-hang guard)", () => {
   it(
-    "electron loads main.ts via NODE_OPTIONS='--import tsx' — canary fires",
-    () =>
-      new Promise<void>((resolve, reject) => {
-        // require('electron') under system node → Electron.app binary path
-        // (the same binary dev:main ultimately runs, via cli.js).
+    "electron . loads dist-main/main.js — canary fires (dev/prod same artifact)",
+    () => {
+      // Self-contained: ensure the bundle exists so `pnpm test` works standalone.
+      if (!fs.existsSync(BUNDLE)) {
+        execSync("npm run build:main", { cwd: ROOT, stdio: "ignore" });
+      }
+      return new Promise<void>((resolve, reject) => {
         const electronPath = require("electron") as string;
         let buf = "";
         let settled = false;
-
-        const child: ChildProcess = spawn(electronPath, ["main.ts", "--dev"], {
-          cwd: ROOT,
-          env: {
-            ...process.env,
-            NODE_ENV: "test", // headless: app.disableHardwareAcceleration
-            NODE_OPTIONS: "--import tsx", // THE thing under test
-            ELECTRON_ENABLE_LOGGING: "1",
-            CSC_IDENTITY_AUTO_DISCOVERY: "false",
+        const child: ChildProcess = spawn(
+          electronPath,
+          [".", "--dev"], // electron . reads package.json main → dist-main/main.js
+          {
+            cwd: ROOT,
+            env: {
+              ...process.env,
+              NODE_ENV: "test", // headless: app.disableHardwareAcceleration
+              ELECTRON_ENABLE_LOGGING: "1",
+              CSC_IDENTITY_AUTO_DISCOVERY: "false",
+            },
+            stdio: ["ignore", "pipe", "pipe"],
           },
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-
-        // settled flag + unref'd timer = no clearTimeout needed, no let for timer.
+        );
         const settle = (outcome: () => void): void => {
           if (settled) return;
           settled = true;
           child.kill("SIGKILL"); // canary already proved load — stop before app boot
           outcome();
         };
-
         const onChunk = (chunk: Buffer): void => {
           buf += chunk.toString();
           if (buf.includes(CANARY)) settle(resolve);
         };
         child.stdout?.on("data", onChunk);
         child.stderr?.on("data", onChunk);
-
         const timer = setTimeout(
           () =>
             settle(() =>
               reject(
                 new Error(
-                  `dev:main smoke: canary missing after ${TIMEOUT_MS}ms — silent hang (main.ts never loaded).\ncaptured:\n${buf.slice(-800)}`,
+                  `dev:main smoke: canary missing after ${TIMEOUT_MS}ms — main entry never loaded.\ncaptured:\n${buf.slice(-800)}`,
                 ),
               ),
             ),
           TIMEOUT_MS,
         );
         timer.unref?.(); // don't keep vitest alive after the test settles
-
         child.on("exit", (code: number | null) => {
           if (!buf.includes(CANARY)) {
             settle(() =>
               reject(
                 new Error(
-                  `dev:main smoke: electron exited code=${code} before canary — main.ts did not load.\ncaptured:\n${buf.slice(-800)}`,
+                  `dev:main smoke: electron exited code=${code} before canary — main entry did not load.\ncaptured:\n${buf.slice(-800)}`,
                 ),
               ),
             );
           }
         });
-      }),
+      });
+    },
     TIMEOUT_MS + 5_000,
   );
 });


### PR DESCRIPTION
dev:main 改用 esbuild bundle,dev/e2e/prod 加载同一 artifact(dist-main/main.js),tsx-direct 路径整个消失。

## 改动
- package.json dev:main: `build:main && electron .`(原 tsx 直跑 main.ts)
- tests/unit/dev-main-smoke.test.ts: spawn electron . + 确保 bundle + canary
- tests/unit/ci-config.test.ts: 断言更新

## 为什么(数据驱动)
dev 启动相关 bug 反复 ~16 次 commit(3 子 class):tsx loader 2 次(c875321 没修对潜伏 4 天)、better-sqlite3 ABI 9 次、e2e macOS 启动 5 次(ADR-014 未解决)。P2.1 消除 dev/prod 不对称(silent-hang 结构性温床)。

## architect verdict
APPROVED。一次性 build 比 --watch 更优。完整 docs/research/electron-dev-startup-hardening.md §P2.1。

## 验证
ci:check 9/9;端到端 pnpm dev canary + 应用启动完成;smoke 在 electron . bundle 捕获 canary。

## 后续
P1.1 canary→e2e 强断言、P2.2 ABI 治本 — 见 docs/follow-ups.md。