### PR TITLE
test: v1.1.0 coverage 55% → 65% (+77 component/hook tests)

### DIFF
--- a/tests/unit/effects-layer-component.test.tsx
+++ b/tests/unit/effects-layer-component.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+// [20260729_Test_SettingsPanel_EffectsLayer] React component integration tests
+// for EffectsLayer. The component is the single gate for visual effects: it
+// must render nothing when disabled, when WebGL is unavailable, or when the
+// user prefers reduced motion, and must mount the Aurora layer only when all
+// three conditions pass. We mock detectWebGL to control the supported flag,
+// window.matchMedia to control reduced-motion, and the lazy-loaded Aurora so
+// the real ogl/GL dependency never loads in jsdom.
+import "../setup/react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+// Mock detectWebGL: the detection result is controlled per-test via
+// mockReturnValue. Default to supported=true so only the gate logic varies.
+vi.mock("../../src/components/effects/detectWebGL", () => ({
+  detectWebGL: vi.fn().mockReturnValue({ supported: true }),
+}));
+
+// Mock the lazy Aurora component: the real Aurora imports ogl and talks to
+// GL, which jsdom cannot provide. Render a stable marker so the happy path can
+// assert the layer actually mounts.
+vi.mock("../../src/components/effects/Aurora", () => ({
+  __esModule: true,
+  default: ({ colorStops }: { colorStops: string[] }) => (
+    <div data-testid="aurora-mock" data-stops={colorStops.join(",")} />
+  ),
+}));
+
+import { EffectsLayer } from "../../src/components/effects/EffectsLayer";
+import { detectWebGL } from "../../src/components/effects/detectWebGL";
+import { AURORA_COLOR_STOPS } from "../../src/components/effects/aurora-theme";
+
+// MatchMedia mock. jsdom does not implement matchMedia, so we provide a
+// controllable MediaQueryList whose `matches` reflects the reduced-motion
+// preference under test.
+interface MatchMediaMock extends MediaQueryList {
+  __setMatches(matches: boolean): void;
+}
+
+function installMatchMedia(initialMatches: boolean): MatchMediaMock {
+  let listeners: ((e: MediaQueryListEvent) => void)[] = [];
+  let matches = initialMatches;
+  const mql: MatchMediaMock = {
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: (
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) => {
+      const fn = listener as (e: MediaQueryListEvent) => void;
+      listeners.push(fn);
+    },
+    removeEventListener: (
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) => {
+      const fn = listener as (e: MediaQueryListEvent) => void;
+      listeners = listeners.filter((l) => l !== fn);
+    },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+    __setMatches(next: boolean) {
+      matches = next;
+      Object.defineProperty(this, "matches", {
+        value: next,
+        configurable: true,
+      });
+      const event = { matches } as MediaQueryListEvent;
+      for (const l of listeners) l(event);
+    },
+  };
+  const win = window as unknown as {
+    matchMedia: (q: string) => MediaQueryList;
+  };
+  win.matchMedia = () => mql;
+  return mql;
+}
+
+describe("[20260729_Test_SettingsPanel_EffectsLayer] EffectsLayer", () => {
+  let originalMatchMedia: ((query: string) => MediaQueryList) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset detectWebGL to the supported default between tests.
+    vi.mocked(detectWebGL).mockReturnValue({ supported: true });
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    // Restore matchMedia if it was replaced.
+    const win = window as unknown as {
+      matchMedia: (q: string) => MediaQueryList;
+    };
+    if (originalMatchMedia) {
+      win.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it("renders nothing when enabled is false", () => {
+    installMatchMedia(false);
+    const { container } = render(<EffectsLayer enabled={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when enabled but WebGL is unsupported", () => {
+    vi.mocked(detectWebGL).mockReturnValue({
+      supported: false,
+      reason: "software-renderer:swiftshader",
+    });
+    installMatchMedia(false);
+
+    const { container } = render(<EffectsLayer enabled={true} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when enabled, WebGL supported, but prefers-reduced-motion is set", () => {
+    installMatchMedia(true);
+
+    const { container } = render(<EffectsLayer enabled={true} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the Aurora layer when enabled, WebGL supported, and no reduced-motion", async () => {
+    installMatchMedia(false);
+
+    const { queryByTestId, getByTestId } = render(
+      <EffectsLayer enabled={true} />,
+    );
+
+    // The effect runs after mount (detectWebGL + matchMedia read in an
+    // effect), so the marker appears asynchronously.
+    await waitFor(() => expect(getByTestId("aurora-mock")).toBeInTheDocument());
+    // verify nothing else leaked.
+    expect(queryByTestId("aurora-mock")).not.toBeNull();
+  });
+
+  it("passes the brand colorStops to Aurora", async () => {
+    installMatchMedia(false);
+
+    const { getByTestId } = render(<EffectsLayer enabled={true} />);
+
+    await waitFor(() => expect(getByTestId("aurora-mock")).toBeInTheDocument());
+    const marker = getByTestId("aurora-mock");
+    expect(marker.getAttribute("data-stops")).toBe(
+      AURORA_COLOR_STOPS.join(","),
+    );
+  });
+
+  it("does not probe WebGL while disabled", () => {
+    installMatchMedia(false);
+    vi.mocked(detectWebGL).mockClear();
+
+    render(<EffectsLayer enabled={false} />);
+
+    expect(detectWebGL).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/settings-panel.test.tsx
+++ b/tests/unit/settings-panel.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+// [20260729_Test_SettingsPanel_EffectsLayer] React component integration tests
+// for SettingsPanel. Exercises user-visible behavior via RTL (Testing Trophy):
+// rendering of sections, the close-button callback wiring, and the AI-mode
+// select persistence via window.electronAPI. No implementation details are
+// asserted. Mocks follow the established pattern in panels.test.tsx:
+//   - react-i18next -> t echoes the fallback string (unused here but harmless)
+//   - sonner -> toast no-op
+//   - usePermissions -> stubbed so we don't exercise navigator.mediaDevices
+//   - window.electronAPI -> per-test stub (getSetting/saveSetting)
+import "../setup/react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { ElectronAPI } from "../../src/electronAPI";
+
+// Mock sonner: SettingsPanel toasts via the showAlert callback. No-op to keep
+// the DOM clean and avoid real toast UI.
+vi.mock("sonner", () => ({
+  toast: vi.fn(),
+}));
+
+// Mock usePermissions: SettingsPanel delegates permission state to this hook.
+// Stub it so we control granted state and spy on the request callbacks without
+// touching navigator.mediaDevices or window.electronAPI.pasteText.
+const mockUsePermissions = {
+  micPermissionGranted: false,
+  accessibilityPermissionGranted: false,
+  requestMicPermission: vi.fn(),
+  testAccessibilityPermission: vi.fn(),
+};
+vi.mock("../../src/hooks/usePermissions", () => ({
+  usePermissions: () => mockUsePermissions,
+}));
+
+import SettingsPanel from "../../src/components/SettingsPanel";
+
+// Window shape this test manipulates: the production type makes electronAPI
+// required, but the test deliberately deletes it, so we Omit the required prop
+// and re-add it as optional. Cast through unknown — never `any`, no @ts-ignore.
+type TestWindow = Omit<Window, "electronAPI"> & {
+  electronAPI?: Partial<ElectronAPI>;
+};
+
+function setElectronAPI(api: Partial<ElectronAPI> | undefined): void {
+  (globalThis.window as TestWindow).electronAPI = api;
+}
+
+describe("[20260729_Test_SettingsPanel_EffectsLayer] SettingsPanel", () => {
+  let originalAPI: TestWindow["electronAPI"];
+
+  beforeEach(() => {
+    originalAPI = (globalThis.window as TestWindow).electronAPI;
+    vi.clearAllMocks();
+    // Reset the mocked hook state to defaults before each test.
+    mockUsePermissions.micPermissionGranted = false;
+    mockUsePermissions.accessibilityPermissionGranted = false;
+  });
+
+  afterEach(() => {
+    const win = globalThis.window as TestWindow;
+    if (originalAPI === undefined) {
+      delete win.electronAPI;
+    } else {
+      win.electronAPI = originalAPI;
+    }
+  });
+
+  it("renders the panel with its heading and the three section headings", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+
+    // Title bar heading.
+    expect(screen.getByText("设置")).toBeInTheDocument();
+    // Permissions section.
+    expect(screen.getByText("权限管理")).toBeInTheDocument();
+    // AI processing section.
+    expect(screen.getByText("AI 处理")).toBeInTheDocument();
+    // About section.
+    expect(screen.getByText("关于 Murmur")).toBeInTheDocument();
+  });
+
+  it("renders both permission cards (microphone + accessibility)", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+
+    expect(screen.getByText("麦克风权限")).toBeInTheDocument();
+    expect(screen.getByText("辅助功能权限")).toBeInTheDocument();
+  });
+
+  it("renders the AI-mode select with all four mode options, disabled until loaded", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+
+    const select = screen.getByLabelText("默认处理模式") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    // The four mode options from the JSX.
+    const optionTexts = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(optionTexts).toContain("自动（根据文本长度智能选择）");
+    expect(optionTexts).toContain("智能润色");
+    expect(optionTexts).toContain("长文本整理");
+    expect(optionTexts).toContain("关闭自动处理");
+  });
+
+  it("disables the AI-mode select until settings have been loaded", () => {
+    // Provide a getSetting that never resolves so aiModeLoaded stays false.
+    const getSetting = vi.fn().mockReturnValue(new Promise(() => {}));
+    setElectronAPI({ getSetting });
+
+    render(<SettingsPanel onClose={() => {}} />);
+
+    const select = screen.getByLabelText("默认处理模式") as HTMLSelectElement;
+    expect(select).toBeDisabled();
+  });
+
+  it("enables the AI-mode select after reading the saved default_mode", async () => {
+    const getSetting = vi.fn().mockResolvedValue("optimize_long");
+    const saveSetting = vi.fn().mockResolvedValue(undefined);
+    setElectronAPI({ getSetting, saveSetting });
+
+    render(<SettingsPanel onClose={() => {}} />);
+
+    const select = screen.getByLabelText("默认处理模式") as HTMLSelectElement;
+    await waitFor(() => expect(select).not.toBeDisabled());
+    // The saved mode becomes the selected value.
+    expect(select.value).toBe("optimize_long");
+  });
+
+  it("falls back to enable_ai_optimization when default_mode is not saved", async () => {
+    const getSetting = vi.fn().mockImplementation((key: string) => {
+      if (key === "default_mode") return Promise.resolve(null);
+      // enable_ai_optimization -> false => aiMode "off"
+      return Promise.resolve(false);
+    });
+    setElectronAPI({ getSetting });
+
+    render(<SettingsPanel onClose={() => {}} />);
+
+    const select = screen.getByLabelText("默认处理模式") as HTMLSelectElement;
+    await waitFor(() => expect(select).not.toBeDisabled());
+    expect(select.value).toBe("off");
+  });
+
+  it("defaults to auto and disables select when electronAPI is absent", async () => {
+    delete (globalThis.window as TestWindow).electronAPI;
+
+    render(<SettingsPanel onClose={() => {}} />);
+
+    const select = screen.getByLabelText("默认处理模式") as HTMLSelectElement;
+    // Without electronAPI.getSetting, the effect short-circuits and marks
+    // loaded synchronously after the first effect tick.
+    await waitFor(() => expect(select).not.toBeDisabled());
+    expect(select.value).toBe("auto");
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<SettingsPanel onClose={onClose} />);
+
+    // The close button is the only button containing the "×" span.
+    fireEvent.click(screen.getByText("×"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls requestMicPermission when the microphone test button is clicked", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "测试麦克风" }));
+    expect(mockUsePermissions.requestMicPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls testAccessibilityPermission when the accessibility test button is clicked", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "测试权限" }));
+    expect(
+      mockUsePermissions.testAccessibilityPermission,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the selected AI mode via saveSetting when the select changes", async () => {
+    const getSetting = vi.fn().mockResolvedValue("auto");
+    const saveSetting = vi.fn().mockResolvedValue(undefined);
+    setElectronAPI({ getSetting, saveSetting });
+
+    render(<SettingsPanel onClose={() => {}} />);
+
+    const select = screen.getByLabelText("默认处理模式") as HTMLSelectElement;
+    await waitFor(() => expect(select).not.toBeDisabled());
+
+    fireEvent.change(select, { target: { value: "optimize" } });
+
+    await waitFor(() =>
+      expect(saveSetting).toHaveBeenCalledWith("default_mode", "optimize"),
+    );
+  });
+
+  it("renders the granted state instead of a button when a permission is granted", () => {
+    mockUsePermissions.micPermissionGranted = true;
+    render(<SettingsPanel onClose={() => {}} />);
+
+    expect(screen.getByText("已授予")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "测试麦克风" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/ui-components.test.tsx
+++ b/tests/unit/ui-components.test.tsx
@@ -1,0 +1,443 @@
+// @vitest-environment jsdom
+// [20260729_Test_UIComponents] React component integration tests for the shadcn
+// UI primitives. These are simple presentational components, so tests only
+// verify rendering + prop forwarding (className passthrough, children). Mocks
+// follow the established pattern in panels.test.tsx:
+//   - next-themes -> Toaster reads useTheme()
+//   - sonner -> HistoryModal toasts on copy/delete; no-op keeps DOM clean
+import "../setup/react";
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+// Mock next-themes: Toaster calls useTheme(). Default to "system" so the
+// component resolves a real theme value.
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "system" }),
+}));
+
+// Mock sonner: keep the real Toaster component (used by ui/sonner.tsx) while
+// stubbing toast (used by HistoryModal). importOriginal preserves the
+// Toaster named export; the stub keeps the DOM clean.
+vi.mock("sonner", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("sonner")>();
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+});
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "../../src/components/ui/card";
+import { Input } from "../../src/components/ui/input";
+import { Label } from "../../src/components/ui/label";
+import { StatusLight } from "../../src/components/ui/status-light";
+import HistoryModal from "../../src/components/ui/history-modal";
+import { Toaster } from "../../src/components/ui/sonner";
+
+// Minimal window shape for HistoryModal, which reads window.electronAPI.
+// Cast through unknown — never `any`, never @ts-ignore.
+type TestWindow = Omit<Window, "electronAPI"> & {
+  electronAPI?: {
+    getTranscriptions?: (limit: number, offset: number) => Promise<unknown[]>;
+    copyText?: (text: string) => Promise<void>;
+    deleteTranscription?: (id: number) => Promise<void>;
+    exportTranscriptions?: (format: string) => void;
+  };
+};
+
+function setElectronAPI(api: TestWindow["electronAPI"]): void {
+  (globalThis.window as unknown as TestWindow).electronAPI = api;
+}
+
+describe("[20260729_Test_UIComponents] Card", () => {
+  it("renders a div with its children and base classes", () => {
+    render(
+      <Card>
+        <span>card body</span>
+      </Card>,
+    );
+
+    const card = screen.getByText("card body").parentElement as HTMLElement;
+    expect(card).toBeInTheDocument();
+    expect(card.tagName).toBe("DIV");
+  });
+
+  it("forwards additional className while merging base classes", () => {
+    render(<Card className="my-custom" data-testid="card" />);
+
+    const card = screen.getByTestId("card");
+    expect(card.className).toContain("rounded-lg");
+    expect(card.className).toContain("my-custom");
+  });
+
+  it("renders each subcomponent and forwards children", () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>title text</CardTitle>
+          <CardDescription>desc text</CardDescription>
+        </CardHeader>
+        <CardContent>body text</CardContent>
+        <CardFooter>foot text</CardFooter>
+      </Card>,
+    );
+
+    expect(screen.getByText("title text")).toBeInTheDocument();
+    expect(screen.getByText("desc text")).toBeInTheDocument();
+    expect(screen.getByText("body text")).toBeInTheDocument();
+    expect(screen.getByText("foot text")).toBeInTheDocument();
+  });
+
+  it("merges className on subcomponents", () => {
+    render(
+      <CardTitle className="text-red-500" data-testid="title">
+        t
+      </CardTitle>,
+    );
+
+    const title = screen.getByTestId("title");
+    expect(title.className).toContain("font-semibold");
+    expect(title.className).toContain("text-red-500");
+  });
+});
+
+describe("[20260729_Test_UIComponents] Input", () => {
+  it("renders an input element", () => {
+    render(<Input data-testid="input" />);
+
+    const input = screen.getByTestId("input");
+    expect(input.tagName).toBe("INPUT");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("forwards type and base className", () => {
+    render(<Input type="email" data-testid="input" />);
+
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    expect(input.type).toBe("email");
+    expect(input.className).toContain("rounded-md");
+  });
+
+  it("merges additional className and forwards arbitrary props", () => {
+    render(
+      <Input className="my-input" placeholder="hello" data-testid="input" />,
+    );
+
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    expect(input.className).toContain("my-input");
+    expect(input.placeholder).toBe("hello");
+  });
+});
+
+describe("[20260729_Test_UIComponents] Label", () => {
+  it("renders a label element with children", () => {
+    render(
+      <Label data-testid="label">
+        <span>label text</span>
+      </Label>,
+    );
+
+    const label = screen.getByTestId("label");
+    expect(label.tagName).toBe("LABEL");
+    expect(screen.getByText("label text")).toBeInTheDocument();
+  });
+
+  it("merges className and forwards htmlFor", () => {
+    render(
+      <Label htmlFor="name" className="my-label" data-testid="label">
+        name
+      </Label>,
+    );
+
+    const label = screen.getByTestId("label");
+    expect(label.className).toContain("font-medium");
+    expect(label.className).toContain("my-label");
+    expect(label).toHaveAttribute("for", "name");
+  });
+});
+
+describe("[20260729_Test_UIComponents] StatusLight", () => {
+  it("renders the green light when ready", () => {
+    const { container } = render(
+      <StatusLight
+        modelStatus={{ isLoading: false, error: null, isReady: true }}
+      />,
+    );
+
+    const light = container.querySelector(".bg-\\[\\#34c759\\]");
+    expect(light).not.toBeNull();
+  });
+
+  it("renders the orange pulsing light while loading", () => {
+    const { container } = render(
+      <StatusLight
+        modelStatus={{ isLoading: true, error: null, isReady: false }}
+      />,
+    );
+
+    const light = container.querySelector(".bg-\\[\\#ff9500\\].animate-pulse");
+    expect(light).not.toBeNull();
+  });
+
+  it("renders the red light when there is an error", () => {
+    const { container } = render(
+      <StatusLight
+        modelStatus={{
+          isLoading: false,
+          error: "boom",
+          isReady: false,
+        }}
+      />,
+    );
+
+    const light = container.querySelector(".bg-\\[\\#ff3b30\\]");
+    expect(light).not.toBeNull();
+  });
+
+  it("renders the gray light for unknown state", () => {
+    const { container } = render(
+      <StatusLight
+        modelStatus={{ isLoading: false, error: null, isReady: false }}
+      />,
+    );
+
+    const light = container.querySelector(".bg-\\[\\#86868b\\]");
+    expect(light).not.toBeNull();
+  });
+
+  it("shows the tooltip text when showTooltip is true (default)", () => {
+    render(
+      <StatusLight
+        modelStatus={{ isLoading: false, error: null, isReady: true }}
+      />,
+    );
+
+    expect(screen.getByText("🟢 模型已就绪")).toBeInTheDocument();
+  });
+
+  it("omits the tooltip wrapper when showTooltip is false", () => {
+    const { container } = render(
+      <StatusLight
+        showTooltip={false}
+        modelStatus={{ isLoading: false, error: null, isReady: true }}
+      />,
+    );
+
+    // No tooltip span rendered.
+    expect(container.querySelector(".model-status-tooltip")).toBeNull();
+  });
+
+  it("honors a custom size class", () => {
+    const { container } = render(
+      <StatusLight
+        size="w-4 h-4"
+        showTooltip={false}
+        modelStatus={{ isLoading: false, error: null, isReady: true }}
+      />,
+    );
+
+    const light = container.querySelector(".w-4.h-4");
+    expect(light).not.toBeNull();
+  });
+});
+
+describe("[20260729_Test_UIComponents] HistoryModal", () => {
+  let originalAPI: TestWindow["electronAPI"];
+
+  beforeEach(() => {
+    originalAPI = (globalThis.window as unknown as TestWindow).electronAPI;
+  });
+
+  afterEach(() => {
+    const win = globalThis.window as unknown as TestWindow;
+    if (originalAPI === undefined) {
+      delete win.electronAPI;
+    } else {
+      win.electronAPI = originalAPI;
+    }
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <HistoryModal isOpen={false} onClose={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the modal header and search input when open", async () => {
+    setElectronAPI({
+      getTranscriptions: vi.fn().mockResolvedValue([]),
+    });
+
+    render(<HistoryModal isOpen={true} onClose={() => {}} />);
+
+    expect(screen.getByText("转录历史")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("搜索转录内容...")).toBeInTheDocument();
+
+    // Flush the pending getTranscriptions state update within the test.
+    await screen.findByText("暂无转录历史");
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    setElectronAPI({
+      getTranscriptions: vi.fn().mockResolvedValue([]),
+    });
+    const onClose = vi.fn();
+
+    const { container } = render(
+      <HistoryModal isOpen={true} onClose={onClose} />,
+    );
+
+    // Wait for the loader to resolve so the pending getTranscriptions state
+    // update settles within the test (avoids act() warnings).
+    await screen.findByText("暂无转录历史");
+
+    // The close button has no aria-label, so locate it via the lucide X icon
+    // (svg with class "lucide-x") and click its closest button ancestor.
+    const closeIcon = container.querySelector(".lucide-x");
+    expect(closeIcon).not.toBeNull();
+    const closeButton = closeIcon?.closest("button") as HTMLButtonElement;
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows the empty state when no transcriptions are returned", async () => {
+    setElectronAPI({
+      getTranscriptions: vi.fn().mockResolvedValue([]),
+    });
+
+    render(<HistoryModal isOpen={true} onClose={() => {}} />);
+
+    expect(await screen.findByText("暂无转录历史")).toBeInTheDocument();
+  });
+
+  it("renders a transcription item with its original text", async () => {
+    setElectronAPI({
+      getTranscriptions: vi.fn().mockResolvedValue([
+        {
+          id: 1,
+          text: "原文内容",
+          created_at: new Date().toISOString(),
+        },
+      ]),
+    });
+
+    render(<HistoryModal isOpen={true} onClose={() => {}} />);
+
+    expect(await screen.findByText("原文内容")).toBeInTheDocument();
+    expect(screen.getByText("原始识别:")).toBeInTheDocument();
+  });
+
+  it("filters transcriptions by the search query", async () => {
+    setElectronAPI({
+      getTranscriptions: vi.fn().mockResolvedValue([
+        { id: 1, text: "苹果", created_at: new Date().toISOString() },
+        { id: 2, text: "香蕉", created_at: new Date().toISOString() },
+      ]),
+    });
+
+    render(<HistoryModal isOpen={true} onClose={() => {}} />);
+
+    expect(await screen.findByText("苹果")).toBeInTheDocument();
+
+    const search = screen.getByPlaceholderText("搜索转录内容...");
+    fireEvent.change(search, { target: { value: "香蕉" } });
+
+    expect(screen.queryByText("苹果")).not.toBeInTheDocument();
+    expect(screen.getByText("香蕉")).toBeInTheDocument();
+  });
+
+  it("calls onCopy with the item text when the copy button is clicked", async () => {
+    const onCopy = vi.fn().mockResolvedValue(undefined);
+    setElectronAPI({
+      getTranscriptions: vi.fn().mockResolvedValue([
+        {
+          id: 1,
+          text: "可复制的文本",
+          created_at: new Date().toISOString(),
+        },
+      ]),
+    });
+
+    const { container } = render(
+      <HistoryModal isOpen={true} onClose={() => {}} onCopy={onCopy} />,
+    );
+
+    // Wait for the item to render, then click its copy button (lucide Copy
+    // icon's closest button).
+    expect(await screen.findByText("可复制的文本")).toBeInTheDocument();
+    const copyIcon = container.querySelector(".lucide-copy");
+    expect(copyIcon).not.toBeNull();
+    const copyButton = copyIcon?.closest("button") as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(copyButton);
+    });
+
+    expect(onCopy).toHaveBeenCalledWith("可复制的文本");
+  });
+});
+
+describe("[20260729_Test_UIComponents] Toaster", () => {
+  // The real sonner Toaster reads window.matchMedia (prefers-reduced-motion)
+  // on mount; jsdom does not implement it. Install a minimal polyfill scoped
+  // to this describe block (matches effects-layer-component.test.tsx).
+  let originalMatchMedia: ((query: string) => MediaQueryList) | undefined;
+
+  beforeAll(() => {
+    originalMatchMedia = window.matchMedia;
+    const win = window as unknown as {
+      matchMedia: (q: string) => MediaQueryList;
+    };
+    win.matchMedia = () =>
+      ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    const win = window as unknown as {
+      matchMedia: (q: string) => MediaQueryList;
+    };
+    if (originalMatchMedia) {
+      win.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it.skip("renders without crashing — sonner Toaster needs CSS portal", () => {
+    const { container } = render(<Toaster />);
+    // Sonner renders a region; assert it is present.
+    expect(container).not.toBeEmptyDOMElement();
+  });
+});

--- a/tests/unit/useFileTranscription.test.tsx
+++ b/tests/unit/useFileTranscription.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+// [20260729_Test_UseFileTranscription] Integration tests for the
+// useFileTranscription hook state machine: idle → selected → transcribing
+// → done/error. Uses renderHook from RTL under jsdom.
+import "../setup/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFileTranscription } from "../../src/hooks/useFileTranscription";
+
+// Typed electronAPI stub.
+interface TestElectronAPI {
+  validateAudioFile: ReturnType<typeof vi.fn>;
+  importAudioFile: ReturnType<typeof vi.fn>;
+  transcribeFile: ReturnType<typeof vi.fn>;
+  cancelFileTranscription: ReturnType<typeof vi.fn>;
+  onFileTranscriptionProgress: ReturnType<typeof vi.fn>;
+  processText: ReturnType<typeof vi.fn>;
+  getSetting: ReturnType<typeof vi.fn>;
+}
+
+beforeEach(() => {
+  const api: TestElectronAPI = {
+    validateAudioFile: vi.fn(),
+    importAudioFile: vi.fn(),
+    transcribeFile: vi.fn(),
+    cancelFileTranscription: vi.fn(),
+    onFileTranscriptionProgress: vi.fn(() => () => {}),
+    processText: vi.fn(),
+    getSetting: vi.fn().mockResolvedValue(null),
+  };
+  (window as unknown as { electronAPI: TestElectronAPI }).electronAPI = api;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useFileTranscription", () => {
+  it("starts in idle state with null data", () => {
+    const { result } = renderHook(() => useFileTranscription());
+    expect(result.current.state).toBe("idle");
+    expect(result.current.fileInfo).toBeNull();
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("selectFileFromPath transitions to selected on valid file", async () => {
+    const api = (window as unknown as { electronAPI: TestElectronAPI })
+      .electronAPI;
+    api.validateAudioFile.mockResolvedValue({
+      success: true,
+      filePath: "/test/audio.wav",
+      fileName: "audio.wav",
+      fileSize: 1024,
+      extension: ".wav",
+    });
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.selectFileFromPath("/test/audio.wav");
+    });
+
+    expect(result.current.state).toBe("selected");
+    expect(result.current.fileInfo?.fileName).toBe("audio.wav");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("selectFileFromPath transitions to error on invalid file", async () => {
+    const api = (window as unknown as { electronAPI: TestElectronAPI })
+      .electronAPI;
+    api.validateAudioFile.mockResolvedValue({
+      success: false,
+      error: "Unsupported format",
+    });
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.selectFileFromPath("/test/file.txt");
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toBe("Unsupported format");
+  });
+
+  it("selectFileFromPath errors when electronAPI unavailable", async () => {
+    (window as unknown as { electronAPI: unknown }).electronAPI = undefined;
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.selectFileFromPath("/test/audio.wav");
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toContain("不可用");
+  });
+
+  it("selectFile transitions to error when canceled", async () => {
+    const api = (window as unknown as { electronAPI: TestElectronAPI })
+      .electronAPI;
+    api.importAudioFile.mockResolvedValue({
+      success: false,
+      canceled: true,
+    });
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.selectFile();
+    });
+
+    // Canceled selection stays in idle (not error)
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("startTranscription transitions to done on success", async () => {
+    const api = (window as unknown as { electronAPI: TestElectronAPI })
+      .electronAPI;
+    api.validateAudioFile.mockResolvedValue({
+      success: true,
+      filePath: "/test/audio.wav",
+      fileName: "audio.wav",
+      fileSize: 1024,
+      extension: ".wav",
+    });
+    api.transcribeFile.mockResolvedValue({
+      success: true,
+      text: "转写结果",
+      duration: 10,
+    });
+    api.getSetting.mockResolvedValue("off"); // AI disabled
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.selectFileFromPath("/test/audio.wav");
+    });
+
+    await act(async () => {
+      await result.current.startTranscription();
+    });
+
+    expect(result.current.state).toBe("done");
+    expect(result.current.result?.text).toBe("转写结果");
+  });
+
+  it("startTranscription transitions to error on failure", async () => {
+    const api = (window as unknown as { electronAPI: TestElectronAPI })
+      .electronAPI;
+    api.validateAudioFile.mockResolvedValue({
+      success: true,
+      filePath: "/test/audio.wav",
+      fileName: "audio.wav",
+      fileSize: 1024,
+      extension: ".wav",
+    });
+    api.transcribeFile.mockResolvedValue({
+      success: false,
+      error: "转录超时",
+    });
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.selectFileFromPath("/test/audio.wav");
+    });
+
+    await act(async () => {
+      await result.current.startTranscription();
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toContain("转录超时");
+  });
+
+  it("cancelTranscription transitions to cancelled", async () => {
+    const api = (window as unknown as { electronAPI: TestElectronAPI })
+      .electronAPI;
+    api.cancelFileTranscription.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.cancelTranscription();
+    });
+
+    expect(result.current.state).toBe("cancelled");
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("reset returns to idle state", async () => {
+    const api = (window as unknown as { electronAPI: TestElectronAPI })
+      .electronAPI;
+    api.validateAudioFile.mockResolvedValue({
+      success: true,
+      filePath: "/test/audio.wav",
+      fileName: "audio.wav",
+      fileSize: 1024,
+      extension: ".wav",
+    });
+
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.selectFileFromPath("/test/audio.wav");
+    });
+    expect(result.current.state).toBe("selected");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(result.current.fileInfo).toBeNull();
+  });
+
+  it("startTranscription errors without file selection", async () => {
+    const { result } = renderHook(() => useFileTranscription());
+
+    await act(async () => {
+      await result.current.startTranscription();
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toContain("请先选择");
+  });
+});

--- a/tests/unit/useHotkey.test.tsx
+++ b/tests/unit/useHotkey.test.tsx
@@ -1,0 +1,267 @@
+// [20260729_Test_Hooks] Unit tests for the useHotkey React hook. Runs under
+// jsdom because the hook uses React state/effects and `navigator.userAgent`.
+// We render the hook via @testing-library/react's renderHook and exercise the
+// IPC-facing surface (register/unregister/sync) and the returned shape.
+// @vitest-environment jsdom
+import "../setup/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useHotkey } from "../../src/hooks/useHotkey";
+import type { ElectronAPI } from "../../src/electronAPI";
+
+// [20260729_Test_Hooks] The production declaration makes `electronAPI`
+// required on window, but this test installs/tears down its own stub.
+// Omit the required prop and re-add as optional. Cast through unknown only.
+type TestWindow = Omit<Window, "electronAPI"> & { electronAPI?: ElectronAPI };
+
+// [20260729_Test_Hooks] Builder for a minimal ElectronAPI stub covering only
+// the methods useHotkey touches. Methods are vi.fn() so call sites and return
+// values can be asserted. `log` is optional in the hook (guarded by
+// `window.electronAPI.log` truthiness), but we provide it so error paths can
+// be exercised.
+function makeElectronAPIStub(
+  overrides: Partial<ElectronAPI> = {},
+): ElectronAPI {
+  return {
+    getCurrentHotkey: vi.fn().mockResolvedValue("CommandOrControl+Shift+Space"),
+    registerHotkey: vi.fn().mockResolvedValue({ success: true }),
+    unregisterHotkey: vi.fn().mockResolvedValue({ success: true }),
+    setRecordingState: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ElectronAPI;
+}
+
+describe("useHotkey hook", () => {
+  let originalAPI: ElectronAPI | undefined;
+
+  beforeEach(() => {
+    originalAPI = (globalThis.window as TestWindow).electronAPI;
+  });
+
+  afterEach(() => {
+    const win = globalThis.window as TestWindow;
+    if (originalAPI === undefined) {
+      delete win.electronAPI;
+    } else {
+      win.electronAPI = originalAPI;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the expected return shape", () => {
+    (globalThis.window as TestWindow).electronAPI = makeElectronAPIStub();
+    const { result } = renderHook(() => useHotkey());
+
+    expect(typeof result.current.hotkey).toBe("string");
+    expect(typeof result.current.rawHotkey).toBe("string");
+    expect(typeof result.current.isRegistered).toBe("boolean");
+    expect(typeof result.current.registerHotkey).toBe("function");
+    expect(typeof result.current.unregisterHotkey).toBe("function");
+    expect(typeof result.current.syncRecordingState).toBe("function");
+  });
+
+  it("reports the raw default hotkey and a formatted display string on mount", () => {
+    (globalThis.window as TestWindow).electronAPI = makeElectronAPIStub();
+    const { result } = renderHook(() => useHotkey());
+
+    // rawHotkey is the unformatted accelerator; hotkey is the display string.
+    expect(result.current.rawHotkey).toBe("CommandOrControl+Shift+Space");
+    // formatHotkey replaces Shift→⇧, Space→空格, and joins with " + ". The
+    // CommandOrControl→⌘/Ctrl branch is platform-dependent, so assert only on
+    // the stable symbols to keep the test deterministic across jsdom variants.
+    expect(result.current.hotkey).toContain("⇧");
+    expect(result.current.hotkey).toContain("空格");
+    expect(result.current.hotkey).toContain(" + ");
+    expect(result.current.hotkey).not.toContain("Shift");
+    expect(result.current.hotkey).not.toContain("Space");
+  });
+
+  it("loads the persisted hotkey from getCurrentHotkey on mount", async () => {
+    (globalThis.window as TestWindow).electronAPI = makeElectronAPIStub({
+      getCurrentHotkey: vi.fn().mockResolvedValue("CommandOrControl+Alt+F2"),
+    });
+
+    const { result } = renderHook(() => useHotkey());
+
+    await waitFor(() => {
+      expect(result.current.rawHotkey).toBe("CommandOrControl+Alt+F2");
+    });
+
+    const api = (globalThis.window as TestWindow).electronAPI!;
+    expect(api.getCurrentHotkey).toHaveBeenCalledTimes(1);
+    // Alt→⌥ is a stable replacement; assert on it plus the raw value already
+    // checked above.
+    expect(result.current.hotkey).toContain("⌥");
+  });
+
+  it("starts with isRegistered=false before any registration", () => {
+    (globalThis.window as TestWindow).electronAPI = makeElectronAPIStub();
+    const { result } = renderHook(() => useHotkey());
+    expect(result.current.isRegistered).toBe(false);
+  });
+
+  it("calls registerHotkey IPC and flips isRegistered on success", async () => {
+    const stub = makeElectronAPIStub({
+      registerHotkey: vi.fn().mockResolvedValue({ success: true }),
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.registerHotkey("CommandOrControl+Shift+R");
+    });
+
+    expect(ok).toBe(true);
+    expect(stub.registerHotkey).toHaveBeenCalledWith(
+      "CommandOrControl+Shift+R",
+    );
+    expect(result.current.isRegistered).toBe(true);
+    expect(result.current.rawHotkey).toBe("CommandOrControl+Shift+R");
+  });
+
+  it("returns false and leaves isRegistered false when registration fails", async () => {
+    const stub = makeElectronAPIStub({
+      registerHotkey: vi.fn().mockResolvedValue({ success: false }),
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.registerHotkey("CommandOrControl+Shift+R");
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.isRegistered).toBe(false);
+  });
+
+  it("skips the IPC call when re-registering the already-registered hotkey", async () => {
+    const registerHotkey = vi.fn().mockResolvedValue({ success: true });
+    const stub = makeElectronAPIStub({ registerHotkey });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    // First registration hits the IPC.
+    await act(async () => {
+      await result.current.registerHotkey("CommandOrControl+Shift+R");
+    });
+    expect(registerHotkey).toHaveBeenCalledTimes(1);
+
+    // Re-registering the same accelerator is a no-op (dedup) -> still 1 call.
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.registerHotkey("CommandOrControl+Shift+R");
+    });
+    expect(ok).toBe(true);
+    expect(registerHotkey).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and returns false when registerHotkey throws", async () => {
+    const registerHotkey = vi.fn().mockRejectedValue(new Error("boom"));
+    const log = vi.fn().mockResolvedValue(undefined);
+    const stub = makeElectronAPIStub({ registerHotkey, log });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.registerHotkey("CommandOrControl+Shift+R");
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.isRegistered).toBe(false);
+    expect(log).toHaveBeenCalledWith(
+      "error",
+      "注册热键失败:",
+      expect.any(Error),
+    );
+  });
+
+  it("clears isRegistered on successful unregisterHotkey", async () => {
+    const registerHotkey = vi.fn().mockResolvedValue({ success: true });
+    const unregisterHotkey = vi.fn().mockResolvedValue({ success: true });
+    const stub = makeElectronAPIStub({ registerHotkey, unregisterHotkey });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    await act(async () => {
+      await result.current.registerHotkey("CommandOrControl+Shift+R");
+    });
+    expect(result.current.isRegistered).toBe(true);
+
+    await act(async () => {
+      await result.current.unregisterHotkey();
+    });
+
+    // unregisterHotkey falls back to the current hotkey when no arg is passed.
+    expect(unregisterHotkey).toHaveBeenCalledWith("CommandOrControl+Shift+R");
+    expect(result.current.isRegistered).toBe(false);
+  });
+
+  it("passes an explicit accelerator to unregisterHotkey", async () => {
+    const unregisterHotkey = vi.fn().mockResolvedValue({ success: true });
+    const stub = makeElectronAPIStub({ unregisterHotkey });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    await act(async () => {
+      await result.current.unregisterHotkey("CommandOrControl+Shift+F2");
+    });
+
+    expect(unregisterHotkey).toHaveBeenCalledWith("CommandOrControl+Shift+F2");
+  });
+
+  it("syncRecordingState forwards the boolean to setRecordingState", async () => {
+    const setRecordingState = vi.fn().mockResolvedValue(undefined);
+    const stub = makeElectronAPIStub({ setRecordingState });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    await act(async () => {
+      await result.current.syncRecordingState(true);
+    });
+    expect(setRecordingState).toHaveBeenCalledWith(true);
+
+    await act(async () => {
+      await result.current.syncRecordingState(false);
+    });
+    expect(setRecordingState).toHaveBeenCalledWith(false);
+  });
+
+  it("logs when syncRecordingState catches an error", async () => {
+    const setRecordingState = vi.fn().mockRejectedValue(new Error("nope"));
+    const log = vi.fn().mockResolvedValue(undefined);
+    const stub = makeElectronAPIStub({ setRecordingState, log });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderHook(() => useHotkey());
+
+    await act(async () => {
+      await result.current.syncRecordingState(true);
+    });
+
+    expect(log).toHaveBeenCalledWith(
+      "error",
+      "同步录音状态失败:",
+      expect.any(Error),
+    );
+  });
+
+  it("does not throw when window.electronAPI is absent on mount", () => {
+    // No stub installed -> electronAPI is undefined. The mount effect and all
+    // methods guard on `window.electronAPI`, so nothing should throw.
+    const { result } = renderHook(() => useHotkey());
+
+    expect(result.current.rawHotkey).toBe("CommandOrControl+Shift+Space");
+    expect(result.current.isRegistered).toBe(false);
+  });
+});

--- a/tests/unit/useModelStatus.test.tsx
+++ b/tests/unit/useModelStatus.test.tsx
@@ -1,0 +1,397 @@
+// [20260729_Test_Hooks] Integration tests for the ModelStatusProvider +
+// useModelStatus React context hook. Runs under jsdom because the hook uses
+// React state/effects, setInterval, and window.electronAPI. We wrap the
+// consumer in the provider via a small wrapper passed to renderHook, and
+// assert the model lifecycle stages (checking -> need_download -> downloading
+// -> loading -> ready / error) plus the IPC surface.
+// @vitest-environment jsdom
+import "../setup/react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  ModelStatusProvider,
+  useModelStatus,
+} from "../../src/hooks/useModelStatus";
+import type { ElectronAPI } from "../../src/electronAPI";
+import type { ModelCheckResult, FunASRStatusResult } from "../../src/types/ipc";
+
+// [20260729_Test_Hooks] See useSettings-hook test for the rationale: the
+// production declaration makes electronAPI required, but the test owns its
+// lifecycle. Omit + re-add as optional, cast through unknown only.
+type TestWindow = Omit<Window, "electronAPI"> & { electronAPI?: ElectronAPI };
+
+// [20260729_Test_Hooks] Event-listener methods (onModelDownloadProgress,
+// onProcessingUpdate, onSettingsUpdate) return an unsubscribe fn. We give them
+// no-op unsubscribers so the provider's cleanup effects don't throw. The
+// callback is captured by the provider but we don't drive it here.
+const NOOP_UNSUB = () => {};
+
+// [20260729_Test_Hooks] Canonical fixtures for the two IPC calls checkModelStatus
+// depends on. Helper below composes a stub from per-test overrides.
+const MODEL_FILES_READY: ModelCheckResult = {
+  success: true,
+  models_downloaded: true,
+  minimum_ready: true,
+  missing_models: [],
+};
+
+const MODEL_FILES_MISSING: ModelCheckResult = {
+  success: true,
+  models_downloaded: false,
+  minimum_ready: false,
+  missing_models: ["asr", "vad"],
+};
+
+const SERVER_READY: FunASRStatusResult = {
+  success: true,
+  installed: true,
+  models_downloaded: true,
+  initializing: false,
+  models_initialized: true,
+};
+
+const SERVER_INITIALIZING: FunASRStatusResult = {
+  success: true,
+  installed: true,
+  models_downloaded: true,
+  initializing: true,
+  models_initialized: false,
+};
+
+function makeElectronAPIStub(
+  overrides: Partial<ElectronAPI> = {},
+): ElectronAPI {
+  return {
+    checkModelFiles: vi.fn().mockResolvedValue(MODEL_FILES_READY),
+    checkFunASRStatus: vi.fn().mockResolvedValue(SERVER_READY),
+    downloadModels: vi.fn().mockResolvedValue({ success: true }),
+    restartFunasrServer: vi.fn().mockResolvedValue({ success: true }),
+    getDownloadProgress: vi
+      .fn()
+      .mockResolvedValue({ progress: 0, status: "idle" }),
+    onModelDownloadProgress: vi.fn().mockReturnValue(NOOP_UNSUB),
+    onProcessingUpdate: vi.fn().mockReturnValue(NOOP_UNSUB),
+    onSettingsUpdate: vi.fn().mockReturnValue(NOOP_UNSUB),
+    log: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ElectronAPI;
+}
+
+// [20260729_Test_Hooks] renderHook wrapper that mounts the consumer inside
+// the provider. The consumer forwards the context value via a ref so tests
+// can read result.current synchronously after state updates.
+function renderProviderHook() {
+  return renderHook(() => useModelStatus(), {
+    wrapper: ({ children }) => (
+      <ModelStatusProvider>{children}</ModelStatusProvider>
+    ),
+  });
+}
+
+describe("useModelStatus hook", () => {
+  let originalAPI: ElectronAPI | undefined;
+
+  beforeEach(() => {
+    originalAPI = (globalThis.window as TestWindow).electronAPI;
+  });
+
+  afterEach(() => {
+    const win = globalThis.window as TestWindow;
+    if (originalAPI === undefined) {
+      delete win.electronAPI;
+    } else {
+      win.electronAPI = originalAPI;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("throws when used outside the provider", () => {
+    (globalThis.window as TestWindow).electronAPI = makeElectronAPIStub();
+    // Suppress the expected console.error from React for the thrown render.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useModelStatus())).toThrow(
+      "useModelStatus must be used within a ModelStatusProvider",
+    );
+    spy.mockRestore();
+  });
+
+  it("starts in the checking stage and transitions to ready when models are present", async () => {
+    (globalThis.window as TestWindow).electronAPI = makeElectronAPIStub();
+    const { result } = renderProviderHook();
+
+    // Initial render before the mount effect resolves.
+    expect(result.current.stage).toBe("checking");
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("ready");
+    });
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.modelsDownloaded).toBe(true);
+    expect(result.current.progress).toBe(100);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("enters the need_download stage when minimum_ready is false", async () => {
+    const stub = makeElectronAPIStub({
+      checkModelFiles: vi.fn().mockResolvedValue(MODEL_FILES_MISSING),
+      checkFunASRStatus: vi.fn().mockResolvedValue(SERVER_READY),
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("need_download");
+    });
+
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.modelsDownloaded).toBe(false);
+    expect(result.current.missingModels).toEqual(["asr", "vad"]);
+    expect(result.current.progress).toBe(0);
+  });
+
+  it("enters the loading stage (50%) when the server is initializing but models are present", async () => {
+    const stub = makeElectronAPIStub({
+      checkModelFiles: vi.fn().mockResolvedValue(MODEL_FILES_READY),
+      checkFunASRStatus: vi.fn().mockResolvedValue(SERVER_INITIALIZING),
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("loading");
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.modelsDownloaded).toBe(true);
+    expect(result.current.progress).toBe(50);
+  });
+
+  it("enters the error stage when the server is not initializing and not initialized", async () => {
+    const notReady: FunASRStatusResult = {
+      success: true,
+      installed: true,
+      models_downloaded: true,
+      initializing: false,
+      models_initialized: false,
+      error: "服务器未就绪",
+    };
+    const stub = makeElectronAPIStub({
+      checkModelFiles: vi.fn().mockResolvedValue(MODEL_FILES_READY),
+      checkFunASRStatus: vi.fn().mockResolvedValue(notReady),
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("error");
+    });
+
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.error).toBe("服务器未就绪");
+  });
+
+  it("reports an error stage when electronAPI is absent", async () => {
+    // No stub -> checkModelStatus short-circuits with an Electron API error.
+    const { result } = renderProviderHook();
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("error");
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe("Electron API 不可用");
+  });
+
+  it("reports an error stage when checkModelFiles returns success:false", async () => {
+    const stub = makeElectronAPIStub({
+      checkModelFiles: vi
+        .fn()
+        .mockResolvedValue({
+          success: false,
+          models_downloaded: false,
+          missing_models: [],
+        }),
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("error");
+    });
+    expect(result.current.error).toBe("检查模型文件失败");
+  });
+
+  it("downloadModels calls downloadModels IPC, restarts the server, and moves to the loading stage", async () => {
+    const downloadModels = vi.fn().mockResolvedValue({ success: true });
+    const restartFunasrServer = vi.fn().mockResolvedValue({ success: true });
+    // Start from need_download so downloadModels is a meaningful transition.
+    const stub = makeElectronAPIStub({
+      checkModelFiles: vi.fn().mockResolvedValue(MODEL_FILES_MISSING),
+      checkFunASRStatus: vi.fn().mockResolvedValue(SERVER_READY),
+      downloadModels,
+      restartFunasrServer,
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+    await waitFor(() => {
+      expect(result.current.stage).toBe("need_download");
+    });
+
+    let res: { success: boolean } = { success: false };
+    await act(async () => {
+      res = await result.current.downloadModels();
+    });
+
+    expect(res.success).toBe(true);
+    expect(downloadModels).toHaveBeenCalledTimes(1);
+    // After a successful download the hook restarts FunASR and enters loading.
+    expect(restartFunasrServer).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(result.current.stage).toBe("loading");
+    });
+    expect(result.current.modelsDownloaded).toBe(true);
+    expect(result.current.downloadProgress).toBe(100);
+    expect(result.current.isDownloading).toBe(false);
+  });
+
+  it("downloadModels surfaces a failure result and enters the error stage", async () => {
+    const downloadModels = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: "网络错误" });
+    const restartFunasrServer = vi.fn();
+    const stub = makeElectronAPIStub({
+      checkModelFiles: vi.fn().mockResolvedValue(MODEL_FILES_MISSING),
+      checkFunASRStatus: vi.fn().mockResolvedValue(SERVER_READY),
+      downloadModels,
+      restartFunasrServer,
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+    await waitFor(() => {
+      expect(result.current.stage).toBe("need_download");
+    });
+
+    let res: { success: boolean; error?: string } = { success: true };
+    await act(async () => {
+      res = await result.current.downloadModels();
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("网络错误");
+    // Restart must not run when the download itself failed.
+    expect(restartFunasrServer).not.toHaveBeenCalled();
+    expect(result.current.isDownloading).toBe(false);
+    expect(result.current.stage).toBe("error");
+  });
+
+  it("getDownloadProgress forwards to the IPC method", async () => {
+    const getDownloadProgress = vi
+      .fn()
+      .mockResolvedValue({ progress: 42, status: "downloading" });
+    const stub = makeElectronAPIStub({
+      checkModelFiles: vi.fn().mockResolvedValue(MODEL_FILES_READY),
+      checkFunASRStatus: vi.fn().mockResolvedValue(SERVER_READY),
+      getDownloadProgress,
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+    await waitFor(() => {
+      expect(result.current.stage).toBe("ready");
+    });
+
+    let progress: Record<string, unknown> = {};
+    await act(async () => {
+      progress = (await result.current.getDownloadProgress?.()) as Record<
+        string,
+        unknown
+      >;
+    });
+
+    expect(getDownloadProgress).toHaveBeenCalledTimes(1);
+    expect(progress.progress).toBe(42);
+    expect(progress.status).toBe("downloading");
+  });
+
+  it("checkModelFiles context method proxies the IPC result", async () => {
+    const checkModelFiles = vi.fn().mockResolvedValue(MODEL_FILES_MISSING);
+    const stub = makeElectronAPIStub({
+      checkModelFiles,
+      checkFunASRStatus: vi.fn().mockResolvedValue(SERVER_READY),
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+    await waitFor(() => {
+      expect(result.current.stage).toBe("need_download");
+    });
+
+    let files: ModelCheckResult = MODEL_FILES_READY;
+    await act(async () => {
+      files = await result.current.checkModelFiles();
+    });
+
+    expect(checkModelFiles).toHaveBeenCalled();
+    expect(files.models_downloaded).toBe(false);
+    expect(files.missing_models).toEqual(["asr", "vad"]);
+  });
+
+  it("checkModelStatus re-runs both IPC checks when invoked again", async () => {
+    const checkModelFiles = vi.fn().mockResolvedValue(MODEL_FILES_READY);
+    const checkFunASRStatus = vi.fn().mockResolvedValue(SERVER_READY);
+    const stub = makeElectronAPIStub({ checkModelFiles, checkFunASRStatus });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    const { result } = renderProviderHook();
+    await waitFor(() => {
+      expect(result.current.stage).toBe("ready");
+    });
+
+    const filesBefore = checkModelFiles.mock.calls.length;
+    const serverBefore = checkFunASRStatus.mock.calls.length;
+
+    await act(async () => {
+      await result.current.checkModelStatus();
+    });
+
+    expect(checkModelFiles.mock.calls.length).toBe(filesBefore + 1);
+    expect(checkFunASRStatus.mock.calls.length).toBe(serverBefore + 1);
+  });
+
+  it("registers the model-download, processing-update and settings-update listeners on mount", async () => {
+    const onModelDownloadProgress = vi.fn().mockReturnValue(NOOP_UNSUB);
+    const onProcessingUpdate = vi.fn().mockReturnValue(NOOP_UNSUB);
+    const onSettingsUpdate = vi.fn().mockReturnValue(NOOP_UNSUB);
+    const stub = makeElectronAPIStub({
+      onModelDownloadProgress,
+      onProcessingUpdate,
+      onSettingsUpdate,
+    });
+    (globalThis.window as TestWindow).electronAPI = stub;
+
+    renderProviderHook();
+
+    await waitFor(() => {
+      expect(onModelDownloadProgress).toHaveBeenCalledTimes(1);
+    });
+    expect(onProcessingUpdate).toHaveBeenCalledTimes(1);
+    // onSettingsUpdate may be undefined in some electronAPI stubs.
+    if (onSettingsUpdate) {
+      expect(onSettingsUpdate).toHaveBeenCalledTimes(1);
+    }
+    // Each listener registration returns an unsubscribe that the provider
+    // returns from the effect for cleanup.
+    expect(onModelDownloadProgress.mock.results[0]?.value).toBeTypeOf(
+      "function",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,20 +57,26 @@ export default defineConfig({
       //
       // REGRESSION PLAN: as component tests are added, bump thresholds to
       // lock in gains. Target roadmap:
-      //   - v1.1.0: 55% statements (add App.tsx + settings tests)
-      //   - v1.2.0: 70% statements (add history.tsx + hooks tests)
-      //   - v1.3.0: 80%+ (full component coverage, align with industry 80%)
+      //   ✅ v1.1.0: 65% statements (hooks + settings + panels + UI components)
+      //   - v1.2.0: 75% statements (App.tsx + more component coverage)
+      //   - v1.3.0: 80%+ (align with industry 80%)
       thresholds: {
-        statements: 52,
-        branches: 43,
-        functions: 50,
-        lines: 53,
+        statements: 62,
+        branches: 50,
+        functions: 60,
+        lines: 63,
       },
     },
   },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // [20260729_Test_UIComponents] Mirror the renderer Vite config, which
+      // runs with root = src/, so bare "src/lib/utils" imports resolve. Two
+      // shadcn primitives (ui/input.tsx, ui/label.tsx) use this root-relative
+      // path; the rest of src/ uses relative paths. Without this alias those
+      // modules fail to resolve under the test runner (root = ".").
+      src: path.resolve(__dirname, "./src"),
     },
     extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
   },


### PR DESCRIPTION
## Summary

Reaches v1.1.0 roadmap target. Full-src coverage: 54.8% → **65.2%** (+10.4pp).

## New tests (77 total)

| File | Tests | Coverage target |
|---|---|---|
| `useFileTranscription.test.tsx` | 10 | Hook state machine |
| `useHotkey.test.tsx` | 13 | Register/unregister/sync |
| `useModelStatus.test.tsx` | 13 | Stage transitions + listeners |
| `settings-panel.test.tsx` | 12 | Rendering + callbacks |
| `effects-layer-component.test.tsx` | 6 | WebGL/reduced-motion gates |
| `ui-components.test.tsx` | 23+1skip | Card/Input/Label/StatusLight/HistoryModal |

## Coverage progress
- 996 → **1073 tests** (+77)
- Full src/: 54.8% → **65.2%** statements
- Threshold bumped 52→62

## Verification
- ✅ 1073 pass, 4 skip, 0 fail (100 files)
- ✅ typecheck + typecheck:tests exit 0
- ✅ lint clean
- ✅ coverage gate passes