### PR TITLE
docs: fix stale roadmap data and align version bookkeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `postinstall` 用系统 Node 重编 better-sqlite3 导致 ABI 不匹配(`NODE_MODULE_VERSION 137` vs Electron 36 需要的 `135`),`pnpm run dev` 加载原生模块即崩且错误被 `concurrently` 吞掉、终端无输出。删除有害的 `pnpm rebuild better-sqlite3`,改由 `electron-builder install-app-deps` 统一用 Electron ABI 编译。
 
+## [1.1.0] - 2026-07-31
+
+> [20260731_Changelog_BackfillV110] 补录 v1.1.0。本范围内的 PR（#119/#120/#122-#126）已并入 main，但发版动作（CHANGELOG 条目 + git tag + GitHub Release）此前未同步执行。本条目为补录。
+> [20260731_Changelog_BackfillV110] END
+
+### Added
+
+- **Fox 吉祥物 rebrand + react-bits 视觉特效**（PR #119, commit `a6a8d48`）：应用图标从通用蓝绿螺旋改为可爱手绘狐狸（Duolingo/LINE Friends 风格），统一 app icon / favicon / og-image / theme-color（薰衣草紫 #c4b5fd）；狐在中国文化中象征机敏专注，契合"Murmur 轻语"的中文语音输入定位。同时引入 react-bits 视觉特效组件
+- React 组件集成测试基础设施：jsdom + React Testing Library 环境，覆盖 5 个核心组件（PR #123, commit `8d48eae`）
+- 65 个新组件/hook 单元测试，前端覆盖率从无覆盖提升到 55%（PR #124, commit `ce23981`）
+- 77 个新组件/hook 单元测试，前端覆盖率 55% → 65%（PR #125, commit `3ad10c6`）
+- 17 个 App/杂项组件测试，前端覆盖率 65% → 70%（PR #126, commit `c41aeca`）
+
+### Changed
+
+- **vitest coverage 范围扩展**：从仅 `helpers/utils/bootstrap`（~40 文件）扩展到全 `src/**`（~86 文件），对齐行业最佳实践（commit `c5087ff`, PR #122）。此前 95% 覆盖率数字基于窄范围统计口径，扩展后真实整体覆盖率回落至 ~46%，由此启动了 65% → 70% → 80% 的追赶路线图
+- **coverage 阈值抬升**：`vitest.config.ts` thresholds 从 `statements: 62 / branches: 50 / functions: 60 / lines: 63` 提升到 `statements: 66 / branches: 53 / functions: 65 / lines: 67`，锁定 v1.1.0(65%)/v1.2.0(70%) 的覆盖率成果
+
+### Fixed
+
+- **dev/prod 加载同构**（commit `2e93278`, P2.1）：dev:main 改用 esbuild bundle（`build:main && electron .`），dev/e2e/prod 加载同一 artifact（`dist-main/main.js`）。根除 tsx-direct 路径导致的 silent-hang 温床（electron 不透传命令行 `--import`，致 `main.ts` 永不加载）。详见 `docs/research/electron-dev-startup-hardening.md` §P2.1
+- **dev 启动链路加固**（commit `b917fbf`）：修复 postinstall ABI 覆盖、tsx loader silent hang（改 `NODE_OPTIONS=--import tsx`）；新增 dev:main 运行时 smoke（断言 canary，抓 silent-hang）、better-sqlite3 ABI preflight、CI test 前 rebuild ABI
+- effects 隔离检查对 CSS media query 的误报（commit `163f9bc`, PR #120）
+
+### Notes
+
+- 本版本包含一个面向用户的视觉变更（Fox rebrand）+ 多项内部工程改进。`package.json` version 仍为 `1.0.3`，未单独发版——参见后续发版决策
+- 完整覆盖率路线图与"刷覆盖率 vs 战略转向"的权衡记录在 `docs/strategic-plan-gap-analysis.md`（历史快照）与 `.omc/plans/`
+
 ## [1.0.3] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,8 +10,19 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey)](#安装)
-[![Tests](https://img.shields.io/badge/tests-672%20passing-brightgreen)](tests/)
-[![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](tests/)
+
+<!-- [20260731_README_DynamicBadge] Replaced hardcoded "tests-672 passing" /
+     "coverage-95%" badges (which were stale — the 95% figure used the old
+     narrow coverage scope of ~40 helper files; current full-src scope is
+     ~46%, see CHANGELOG [1.1.0]) with a dynamic CI status badge. Coverage
+     badge removed entirely because no codecov/coveralls uploader is wired
+     into CI yet — to restore it, add codecov-action to .github/workflows
+     and then link a codecov badge. -->
+
+[![CI](https://img.shields.io/github/actions/workflow/status/TeFuirnever/Murmur/ci.yml?branch=main&label=CI&style=flat)](https://github.com/TeFuirnever/Murmur/actions/workflows/ci.yml)
+
+<!-- [20260731_README_DynamicBadge] END -->
+
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Stars](https://img.shields.io/github/stars/TeFuirnever/Murmur?style=social)](https://github.com/TeFuirnever/Murmur)
 
@@ -126,7 +137,7 @@ pnpm dev
 
 ```bash
 pnpm dev          # 启动开发模式
-pnpm test         # 运行测试（672 tests）
+pnpm test         # 运行测试（1000+ tests）
 pnpm lint         # 代码检查（0 warnings）
 pnpm typecheck    # TypeScript 类型检查
 pnpm ci:check     # 本地运行所有 CI 门禁
@@ -158,7 +169,7 @@ pnpm ci:check     # 本地运行所有 CI 门禁
 - [x] 半自动更新（SHA256 校验）
 - [x] 无障碍（ARIA + 键盘导航）
 - [x] GPU 自动检测（CUDA > MPS > CPU）
-- [x] TypeScript 严格模式（672 测试，95% 覆盖率）
+- [x] TypeScript 严格模式（全 src 覆盖率门禁，测试与覆盖率详见 CI）
 - [x] 文件配置支持（`~/.murmur.json`）
 - [x] AI Provider 快速开始引导（免费 API Key 获取）
 
@@ -289,7 +300,7 @@ pnpm dev
 - [x] Semi-auto update (SHA256 verified)
 - [x] Accessibility (ARIA + keyboard nav)
 - [x] GPU auto-detection (CUDA > MPS > CPU)
-- [x] TypeScript strict mode (672 tests, 95% coverage)
+- [x] TypeScript strict mode (full-src coverage gated, see CI for test count)
 - [x] File config support (`~/.murmur.json`)
 - [x] AI Provider quick-start guide (free API key)
 

--- a/docs/strategic-plan-gap-analysis.md
+++ b/docs/strategic-plan-gap-analysis.md
@@ -1,5 +1,16 @@
 # Murmur GAP 分析：对标业界顶级开源项目
 
+> ⚠️ **STATUS: HISTORICAL SNAPSHOT (2026-05-24)**
+>
+> [20260731_StrategicPlan_Freeze] 本文件是 2026-05-24 的战略快照，**不是当前活跃的路线图**。具体过时之处：
+>
+> - 文中 `main.js`、`preload.js`、`src/helpers/*.js` 等 `.js` 引用已全部迁移到 `.ts`（ADR-010 big-bang, 2026-07-24）
+> - §十一"执行进度"的覆盖率数字（94%+/97%）基于旧的窄范围统计口径（仅 ~40 个 helper 文件），当前全 `src/**` 口径约 46%，详见 `vitest.config.ts` 注释
+> - "待执行"清单（T2-1 中国社区、T3-1 CLI 等）从未启动；"DEFER v1.1"表中的超时项已在 v1.0.3-v1.1.0 期间修复，见 ADR-012
+>
+> **当前权威路线图**：`docs/follow-ups.md`（遗留事项）+ `CHANGELOG.md`（已交付）+ `docs/adr/`（架构决策）。本文件保留为历史档案与战略思考记录，不再维护。
+> [20260731_StrategicPlan_Freeze] END
+
 > [20260725_Autopilot_T1.5] 本文档写于 ADR-010 big-bang 之前。文中 `main.js`、`preload.js`、`src/helpers/*.js` 等引用是历史快照（写作时确实是 `.js`）。当前源码已全部迁移到 `.ts`（见 `docs/adr/010-backend-ts-migration-strategy.md`）。下文保留原始文件名作为决策时的快照。
 
 ## Context


### PR DESCRIPTION
## Summary

Roadmap hygiene pass after auditing the strategic plan against actual git state. Three issues fixed:

### 1. CHANGELOG: backfill missing [1.1.0] entry
PRs #119/#120/#122-#126 merged to main but never recorded in CHANGELOG. Documents the Fox rebrand, react-bits effects, vitest coverage scope expansion (helpers only → full src/**) and threshold bump (62→66 stmts) that caused the 95%→46% apparent coverage drop (same tests, wider scope). Also adds a Fixed section for dev/prod load isomorphism and dev startup hardening.

### 2. README: replace hardcoded badges with dynamic CI badge
The old '672 tests / 95% coverage' numbers were stale (95% used the narrow ~40-file scope; full-src reality is ~46%). Replaced with a dynamic CI status badge. Coverage badge removed since no codecov/coveralls uploader is wired into CI yet — to restore, add codecov-action and link a codecov badge. Roadmap section numbers also de-hardcoded to 'see CI'.

### 3. strategic-plan-gap-analysis.md: historical snapshot freeze
README linked this as the authoritative 'full plan' but the doc is a 2026-05-24 snapshot with stale .js refs (pre ADR-010 big-bang) and outdated 97% coverage figure. Added a prominent HISTORICAL SNAPSHOT notice at top pointing readers to follow-ups.md + CHANGELOG + ADRs as the live sources of truth.

## Context
v1.0.3 and v1.1.0 GitHub Releases were just published (tags v1.0.3 → `f659b45`, v1.1.0 → `66cb263`). This PR merges the CHANGELOG/README/strategic-plan fixes that the v1.1.0 release notes reference, so main stays consistent with the published releases.

## Verification
- `pnpm format:check` ✅
- `git diff` reviewed: 3 files, +56/-5, every line traces to a plan item
- No code changes, no package.json version bump, no new tags