### PR TITLE
release: v1.2.0 — UNC path fix + Windows test guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-02
+
 ### Fixed
+
+- **UNC 路径网络超时**（PR #133）：`audioPathValidator` 对 `\\server\share\...` 格式的 UNC 路径执行 `fs.realpathSync` 时，逐级 walk-up 触发 DNS 查找，非-existent 主机导致 13 秒以上挂起。修复：在扩展名校验后立即拒绝 UNC 路径，跳过所有 fs 调用。
+- ESLint 忽略 `website/.astro/` 自动生成的 `.d.ts` 文件（Astro 产物，不应 lint）
+- Unix-only 测试（symlink escape / SIGKILL kill）在 Windows 上用 `it.skipIf` 跳过
+
+### Changed
+
+- `postinstall` 用系统 Node 重编 better-sqlite3 导致 ABI 不匹配(`NODE_MODULE_VERSION 137` vs Electron 36 需要的 `135`),`pnpm run dev` 加载原生模块即崩且错误被 `concurrently` 吞掉、终端无输出。删除有害的 `pnpm rebuild better-sqlite3`,改由 `electron-builder install-app-deps` 统一用 Electron ABI 编译。
 
 - `postinstall` 用系统 Node 重编 better-sqlite3 导致 ABI 不匹配(`NODE_MODULE_VERSION 137` vs Electron 36 需要的 `135`),`pnpm run dev` 加载原生模块即崩且错误被 `concurrently` 吞掉、终端无输出。删除有害的 `pnpm rebuild better-sqlite3`,改由 `electron-builder install-app-deps` 统一用 Electron ABI 编译。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Murmur - 基于FunASR和可配置AI模型的中文优化语音转文字应用",
   "main": "dist-main/main.js",
   "private": true,


### PR DESCRIPTION
## Summary

- Bump version to 1.2.0
- CHANGELOG entry for v1.2.0
- Includes PR #133 (UNC path network timeout fix)

## Changes since v1.1.0

### Fixed
- **UNC 路径网络超时**：`audioPathValidator` 对 `\server\share\...` UNC 路径执行 `fs.realpathSync` 时逐级 walk-up 触发 DNS 查找，非-existent 主机导致 13 秒以上挂起。修复：扩展名校验后立即拒绝 UNC 路径。
- ESLint 忽略 `website/.astro/` 自动生成文件
- Unix-only 测试在 Windows 上用 `it.skipIf` 跳过

### Changed
- better-sqlite3 ABI 加固（postinstall 覆盖修复）

## Test Plan
- [x] `pnpm ci:check` — 10/10 gates pass
- [x] `pnpm typecheck:e2e` — pass
- [x] Windows installer built: `Murmur Setup 1.2.0.exe` (109.5 MB)