### PR TITLE
fix: window lifecycle UX overhaul + settings auto-save + website deploy

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -3,7 +3,7 @@ name: Deploy Website
 on:
   push:
     branches: [main]
-    paths: ['website/**']
+    paths: ["website/**"]
   workflow_dispatch:
 
 permissions:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: website/package-lock.json
 
       - name: Install dependencies

--- a/docs/adr/013-platform-helper.md
+++ b/docs/adr/013-platform-helper.md
@@ -1,0 +1,312 @@
+# ADR 013: Platform Helper — 平台兼容代码收敛模块
+
+**状态**: 已采纳 (2026-06-07)
+
+**上下文**: [ADR 003 ASR 引擎抽象](003-asr-engine-abstraction.md) | [ADR 012 已知限制](012-known-limitations-tradeoffs.md)
+
+---
+
+## 上下文
+
+Murmur 当前在 **10+ 个文件**中散布了约 **800 行** `process.platform === "darwin" / "win32" / "linux"` 平台条件判断。具体分布：
+
+| 关注点                                         | 文件                                | 行数 | 影响                   |
+| ---------------------------------------------- | ----------------------------------- | ---- | ---------------------- |
+| 剪贴板粘贴（osascript / PowerShell / xdotool） | `clipboard.js`                      | ~200 | 3 套完全不同的实现     |
+| Python 安装（brew+pkg / exe / apt+yum+pacman） | `pythonInstaller.js`                | ~280 | 3 套完全不同的安装流程 |
+| macOS 辅助功能 & 系统设置                      | `clipboard.js`, `systemHandlers.js` | ~120 | macOS 独有             |
+| 进程树杀死（taskkill vs SIGKILL）              | `funasrServer.js`                   | ~15  | 关键路径               |
+| 文件系统路径（AppData / Library / .config）    | `environment.js`                    | ~30  | 散落                   |
+| PATH 配置（平台特定目录）                      | `main.js`                           | ~80  | 重复逻辑               |
+| FFmpeg 检测（`where` vs `which`）              | `audioFileHelpers.js`               | ~5   | 单行                   |
+| 路径分隔符（`;` vs `:`）                       | `pythonEnvironment.js`              | ~5   | 重复常量               |
+| 托盘图标（macOS template image）               | `tray.js`                           | ~5   | 单次检查               |
+| 更新安装包扩展名（`.dmg` / `.exe`）            | `updateManager.js`                  | ~5   | 单次检查               |
+
+### 问题
+
+1. **认知负载高**：理解 Murmur 在某平台的行为需要追踪 10+ 文件中的 `process.platform` 分支
+2. **测试困难**：大部分平台相关模块被排除在覆盖率之外（`vitest.config.js` 排除列表有 12 个文件）
+3. **扩展脆弱**：添加 Linux 支持或修改某平台行为需要同时改动多个文件
+4. **模式重复**：路径分隔符检测、FFmpeg 检测等在多处重复出现
+
+---
+
+## 决策
+
+### 方案选择过程
+
+最初考虑了完整的 **Adapter 模式**（`platformInterface.js` + `basePlatform.js` + `darwinPlatform.js` + `win32Platform.js` + `linuxPlatform.js` + `index.js` factory），经过对抗性 Review 后否决，原因：
+
+| Adapter 方案的问题                                                                | 严重度   |
+| --------------------------------------------------------------------------------- | -------- |
+| 800 行旧代码引入 1500+ 行新基础设施，膨胀比 2:1                                   | CRITICAL |
+| `PlatformAdapter` 包含 paste/kill/install/paths 所有方法，违反接口隔离原则（ISP） | CRITICAL |
+| `basePlatform` 继承结构在 JS 中脆弱，组合优于继承                                 | HIGH     |
+| Electron 已提供 `app.getPath('userData')` 等跨平台抽象，重复造轮子                | HIGH     |
+| `process.platform` 在 Vitest 中不可靠地 mock，需要传入 override 参数              | HIGH     |
+
+### 最终决策：Platform Helper（轻量版）
+
+采用**单文件、纯函数工厂、组合模式**：
+
+```
+src/helpers/platform.js          # ~250-300 行，纯函数工厂
+tests/unit/platform.test.js      # ~200-250 行，行为测试
+```
+
+#### 接口设计
+
+```js
+/**
+ * @param {string} [platformOverride] - 仅用于测试，生产环境留空
+ * @returns {PlatformHelper}
+ */
+function createPlatformHelper(platformOverride) {
+  const platform = platformOverride || process.platform;
+  const isMac = platform === 'darwin';
+  const isWin = platform === 'win32';
+
+  return {
+    // --- 身份标识 ---
+    platform,       // 当前平台字符串
+    isMac,          // macOS
+    isWin,          // Windows
+    isLinux: platform === 'linux',
+
+    // --- 路径 ---
+    pathSep: isWin ? ';' : ':',
+
+    // --- 进程管理 ---
+    killTree: (pid) => { ... },
+    spawnDefaults: () => isWin ? { windowsHide: true } : {},
+
+    // --- 剪贴板 ---
+    paste: (text, originalClipboard, logger) => { ... },
+    checkAccessibility: () => { ... },
+    openSystemSettings: () => { ... },
+
+    // --- Shell 工具 ---
+    ffmpegLocatorCmd: isWin ? 'where ffmpeg' : 'which ffmpeg',
+    installerExt: isWin ? '.exe' : isMac ? '.dmg' : '.AppImage',
+    prepareTrayIcon: (nativeImage, icon) => { ... },
+
+    // --- Python ---
+    pythonSearchPaths: () => { ... },
+    installPython: (progressCb) => { ... },
+  };
+}
+```
+
+#### 消费者集成模式
+
+```js
+// 通过构造函数参数注入，带默认值
+const { createPlatformHelper } = require("./platform");
+
+class ClipboardManager {
+  constructor(logger, platform = createPlatformHelper()) {
+    this.platform = platform;
+  }
+
+  async pasteText(text) {
+    // 不再有 pasteMacOS/pasteWindows/pasteLinux
+    return this.platform.paste(text, originalClipboard, this.logger);
+  }
+}
+```
+
+#### 设计规则
+
+1. **纯函数工厂**，不接受 class / 继承
+2. **消费者通过 DI 接收 helper**，带 `createPlatformHelper()` 默认值
+3. **单文件**，所有平台逻辑收敛于一处
+4. **测试友好**：`createPlatformHelper('darwin')` 在 Windows 机器上也能测试 macOS 逻辑
+5. **不重复 Electron 已有的抽象**：`getDataDirectory()` 直接用 `app.getPath('userData')`
+
+---
+
+## 理由
+
+### 为什么单文件而非 Adapter 层
+
+| 维度       | Adapter 层                             | Platform Helper                     |
+| ---------- | -------------------------------------- | ----------------------------------- |
+| 新增代码量 | ~1500 行（7 文件 + 10 测试文件）       | ~500 行（1 文件 + 1 测试文件）      |
+| 概念复杂度 | Factory + Interface + Inheritance + DI | 工厂函数 + 组合                     |
+| ISP        | 违反（上帝接口）                       | 无强制接口，按需取用                |
+| 维护入口   | 7+ 文件                                | 1 文件                              |
+| 升级路径   | —                                      | 若规模扩大可拆分为 `platform/` 目录 |
+
+### 为什么从简单模块开始迁移
+
+对抗性 Review 指出：从 clipboard（最复杂，200 行，涉及系统权限）开始风险极高。改为从最简单的属性（`pathSep`、`ffmpegLocatorCmd`）热身，建立模式和信心后再处理核心功能。
+
+### 排除范围
+
+以下内容**不纳入** Platform Helper：
+
+| 排除项                                         | 原因                                                        |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| `useHotkey.ts` 的 `⌘` vs `Ctrl` 检测           | 渲染进程，不同的 seam 边界（Browser API，非 Node.js）       |
+| `environment.js` 的 `getDataDirectory()`       | 应直接使用 Electron `app.getPath('userData')`，无需 adapter |
+| `windowManager.js` 的透明窗口最大化检测        | Electron API 行为差异，非平台概念                           |
+| 5-10 行的 shell utils（tray icon, update ext） | ROI 为负，标记为 Phase 2 一起处理                           |
+
+---
+
+## 实施计划（TDD，4 阶段）
+
+### Phase 1: 热身 — 简单属性收敛
+
+**先写测试（RED），再实现（GREEN）：**
+
+| 属性                          | win32                   | darwin         | linux          |
+| ----------------------------- | ----------------------- | -------------- | -------------- |
+| `pathSep`                     | `;`                     | `:`            | `:`            |
+| `ffmpegLocatorCmd`            | `where ffmpeg`          | `which ffmpeg` | `which ffmpeg` |
+| `spawnDefaults()`             | `{ windowsHide: true }` | `{}`           | `{}`           |
+| `installerExt`                | `.exe`                  | `.dmg`         | `.AppImage`    |
+| `isWin` / `isMac` / `isLinux` | ✓ / ✗ / ✗               | ✗ / ✓ / ✗      | ✗ / ✗ / ✓      |
+
+**修改的文件：**
+
+- `audioFileHelpers.js` → `platform.ffmpegLocatorCmd`
+- `pythonEnvironment.js` → `platform.pathSep`
+- `updateManager.js` → `platform.installerExt`
+- `funasrServer.js` → `platform.spawnDefaults()`
+- `tray.js` → `platform.prepareTrayIcon()`
+
+### Phase 2: 进程管理 + 路径
+
+**测试重点：**
+
+- `killTree(pid)`：win32 调用 `spawnSync("taskkill", ["/T", "/F", "/PID"])`，其他平台调用 `process.kill(pid, "SIGKILL")`
+
+**修改的文件：**
+
+- `funasrServer.js` → `platform.killTree(pid)`
+- `environment.js` → 替换 `getDataDirectory()` 为 `app.getPath('userData')`
+
+### Phase 3: 剪贴板 + 辅助功能 + Python 路径（核心价值）
+
+**测试重点：**
+
+- `paste()` 三个平台的命令构造、超时、剪贴板恢复
+- `checkAccessibility()` macOS 检查 vs 其他平台返回 true
+- `pythonSearchPaths()` 各平台路径列表
+
+**修改的文件：**
+
+- `clipboard.js` → 删除 `pasteMacOS/pasteWindows/pasteLinux`，委托 `platform.paste()`
+- `clipboard.js` → 删除 `checkAccessibilityPermissions/openSystemSettings/showAccessibilityDialog`
+- `systemHandlers.js` → `platform.checkAccessibility()` / `platform.openSystemSettings()`
+- `pythonEnvironment.js` → `platform.pythonSearchPaths()`
+- `main.js` → `platform.pythonSearchPaths()` 替换 `setupProductionPath()`
+
+### Phase 4（可选）: Python 安装
+
+仅在需要 Linux 桌面支持或安装流程重构时执行。其余情况推迟。
+
+---
+
+## 影响分析
+
+### 新增文件
+
+| 文件                          | 预估行数 | 说明                       |
+| ----------------------------- | -------- | -------------------------- |
+| `src/helpers/platform.js`     | 250-300  | 平台收敛模块               |
+| `tests/unit/platform.test.js` | 200-250  | 行为测试（非源码文本断言） |
+
+### 修改文件
+
+| 文件                                | 变更                                                                  |
+| ----------------------------------- | --------------------------------------------------------------------- |
+| `src/helpers/clipboard.js`          | 删除 ~300 行平台实现，改为委托                                        |
+| `src/helpers/environment.js`        | `getDataDirectory()` 改用 `app.getPath('userData')`                   |
+| `src/helpers/pythonEnvironment.js`  | 使用 `platform.pathSep`、`platform.pythonSearchPaths()`               |
+| `src/helpers/funasrServer.js`       | 使用 `platform.killTree()`、`platform.spawnDefaults()`                |
+| `src/helpers/audioFileHelpers.js`   | 使用 `platform.ffmpegLocatorCmd`                                      |
+| `src/helpers/tray.js`               | 使用 `platform.prepareTrayIcon()`                                     |
+| `src/helpers/updateManager.js`      | 使用 `platform.installerExt`                                          |
+| `src/helpers/ipc/systemHandlers.js` | 使用 `platform.checkAccessibility()`、`platform.openSystemSettings()` |
+| `main.js`                           | 使用 `platform.pythonSearchPaths()`                                   |
+| `vitest.config.js`                  | 从排除列表中移除已测试模块                                            |
+
+### 现有测试更新
+
+| 文件                                | 变更                                                       |
+| ----------------------------------- | ---------------------------------------------------------- |
+| `tests/unit/windows-compat.test.js` | 源码文本断言 → 行为断言（`createPlatformHelper('win32')`） |
+
+### 收敛验证
+
+最终通过以下命令验证所有 `process.platform` 检查已收敛：
+
+```bash
+grep -r "process\.platform" src/helpers/ --include="*.js" | grep -v platform.js
+# 期望输出：0 行
+```
+
+---
+
+## 风险与缓解
+
+| 风险                                  | 缓解措施                                                                |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| Phase 1 涉及多文件但改动简单          | 每个文件仅改 1 行调用方式，机械性替换                                   |
+| clipboard paste 复杂（200 行）        | Phase 3 在模式成熟后执行；独立分支开发                                  |
+| 迁移中混合状态                        | 每个 Phase 自包含；旧代码在被替换前仍然工作                             |
+| `windows-compat.test.js` 源码断言失效 | 同一 commit 中迁移为行为断言                                            |
+| 单文件增长过大                        | 若超过 400 行，拆分为 `platform/clipboard.js`、`platform/process.js` 等 |
+
+---
+
+## 对抗性 Review 记录
+
+本方案经历了三方对抗性 Review，以下是关键发现及对应措施：
+
+### Reviewer 1: 资深架构师
+
+| 发现                                          | 级别     | 处置                                                                |
+| --------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| 原方案 `PlatformAdapter` 违反 ISP，是上帝接口 | CRITICAL | → 改为无强制接口的 Helper 对象，消费者按需取用                      |
+| `basePlatform` 继承结构不适合 JS              | CRITICAL | → 改为纯函数工厂 + 组合                                             |
+| Electron 已有 `app.getPath()` 等抽象          | HIGH     | → `getDataDirectory()` 直接用 `app.getPath('userData')`，不重复抽象 |
+
+### Reviewer 2: TDD 专家
+
+| 发现                                       | 级别     | 处置                                                 |
+| ------------------------------------------ | -------- | ---------------------------------------------------- |
+| `process.platform` 是只读属性，mock 不可靠 | CRITICAL | → `createPlatformHelper(platformOverride?)` 接受参数 |
+| 10 个测试文件维护成本过高                  | HIGH     | → 精简为 1 个测试文件                                |
+| 源码文本断言迁移风险                       | HIGH     | → 同步迁移为行为断言                                 |
+| mock 覆盖率 90% 意义有限                   | MEDIUM   | → 目标调整为 85%，focus 共享逻辑                     |
+
+### Reviewer 3: 风险分析师
+
+| 发现                              | 级别     | 处置                                        |
+| --------------------------------- | -------- | ------------------------------------------- |
+| 从最复杂的 clipboard 开始风险过高 | CRITICAL | → 改为从 `pathSep`/`ffmpegLocator` 热身开始 |
+| Phase 5-6 ROI 为负                | HIGH     | → 标记为 optional，合并到 Phase 1-2         |
+| 中间混合状态可能引入 bug          | HIGH     | → 每个 Phase 自包含 + grep 审计             |
+| 回滚策略缺失                      | MEDIUM   | → 每个 Phase 在独立分支开发                 |
+
+---
+
+## 未来演进
+
+如果项目规模扩大（多团队维护、5+ 个平台适配器），可以将 `platform.js` 拆分为目录结构：
+
+```
+src/helpers/platform/
+├── index.js           # createPlatformHelper 工厂
+├── clipboard.js       # paste / checkAccessibility / openSystemSettings
+├── process.js         # killTree / spawnDefaults
+├── paths.js           # pathSep / pythonSearchPaths
+├── python.js          # installPython
+└── shell.js           # ffmpegLocatorCmd / installerExt / prepareTrayIcon
+```
+
+当前阶段不执行此拆分——YAGNI。

--- a/docs/adr/015-window-lifecycle-ux-overhaul.md
+++ b/docs/adr/015-window-lifecycle-ux-overhaul.md
@@ -1,0 +1,174 @@
+# ADR 015: 窗口生命周期与设置页面 UX 全面改造
+
+**状态**: 待批准（pending approval）
+**日期**: 2026-08-02
+**关联**: ralplan 共识规划（Architect=ITERATE→已修订, Critic=ITERATE→已修订, Tracer=8/10 确认）
+
+## 上下文
+
+用户报告了 Murmur Electron 应用中六个关联的 UX 问题：
+
+1. **主窗口莫名消失** — 浮动面板（`frame: false`, `transparent: true`, `skipTaskbar: true`, `alwaysOnTop: true`）消失后无可见恢复路径。
+2. **主窗口与设置窗口冲突** — 两个窗口都继承 `alwaysOnTop`，交互时 z-order 管理混乱。
+3. **桌面不显示应用图标** — `skipTaskbar: true` 导致任务栏无图标；TrayManager 创建失败时错误被静默吞掉。
+4. **隐藏窗口时任务丢失** — `backgroundThrottling` 未关闭，渲染进程定时器被限流到 ~1次/秒，AI 优化的 100ms 延迟变成 1s+，60s 超时竞态可能误判。
+5. **AI 配置页面 UX 差** — 无字段级校验、模型选择器笨拙、提供商列表扁平、Ollama 需手动配置。
+6. **保存成功提示遮挡内容** — toast 位于 `top-right`，在 700×600 的设置窗口中与表单内容冲突。
+
+### 根因链（代码追踪验证）
+
+通过三路并行探索 + 对抗性 review 确认以下根因：
+
+| #   | 根因                                                         | 文件:行号                                         | 验证                                       |
+| --- | ------------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------ |
+| 1   | Escape 键全局隐藏窗口（`document` 级监听，无任何 guard）     | `App.tsx:387-396`                                 | ✅ Tracer 确认                             |
+| 2   | `skipTaskbar: true` — 任务栏无入口                           | `windowManager.ts:83`                             | ✅ Tracer 确认唯一引用点                   |
+| 3   | `backgroundThrottling` 未设置（Electron 默认 `true`）        | `windowManager.ts:85-93`                          | ✅ Tracer 确认全仓库无设置                 |
+| 4   | TrayManager 无 logger — 创建失败静默吞掉                     | `main.ts:145`                                     | ✅ Tracer 确认构造函数接受 logger 但未传入 |
+| 5   | 设置窗口 `closed` 仅 null 引用，不恢复主窗口焦点             | `windowManager.ts:211-213`                        | ✅ Tracer 确认                             |
+| 6   | WINDOW.SHOW 只 `.show()` 不 `.focus()`                       | `windowHandlers.ts:40-44`                         | ✅ Tracer 确认                             |
+| 7   | `transparent: true` 实际未被 CSS 使用（body/#root 已不透明） | `windowManager.ts:78`, `index.css:67-73`          | ✅ Tracer 确认                             |
+| 8   | 所有窗口共享 `alwaysOnTop`                                   | `windowManager.ts:188`, `windowHandlers.ts:89-99` | ✅ Tracer 确认 SET_TOP 遍历三窗口          |
+
+## 决策
+
+### D1: 关闭 `backgroundThrottling`
+
+在主窗口 `webPreferences` 中设置 `backgroundThrottling: false`。
+
+**理由**: 语音转文字工具的核心场景是"录音 → 隐藏窗口 → 后台处理 → 恢复查看结果"。Electron 默认的后台限流（~1次/秒）会导致 AI 优化的 `setTimeout(100ms)` 延迟到 1s+，且 60s 超时竞态可能因限流而误判超时，转录结果丢失。
+
+**CPU 缓解**: 配套在 `EffectsLayer.tsx` 中添加 `visibilitychange` 监听，隐藏时暂停 WebGL 渲染循环。
+
+### D2: 移除 `transparent: true` 和 `skipTaskbar: true`
+
+移除主窗口的 `transparent: true`（Tracer 确认 body `background-color: hsl(0 0% 96.5%)` 和 root `bg-[#f5f5f7]` 均为不透明，透明度未被视觉使用）和 `skipTaskbar: true`。
+
+**理由**:
+
+- `transparent: true` + `skipTaskbar: false` 在 Windows 上是已知坏组合（任务栏缩略图黑屏、DWM 阴影泄漏、Aero Peek 透明矩形）。仓库已有两个 transparent-window 变通方案（`[20260602_Fix_MaximizeToggle]`），不应继续叠加。
+- 移除 `skipTaskbar` 让应用在任务栏显示品牌图标，这是用户找到应用的首要入口。
+- 添加 `icon` 属性复用 `tray.ts:getTrayIconPath()` 的 dev/prod 路径解析模式。
+
+**附带收益**: `[20260602_Fix_MaximizeToggle]` workaround（`isMaximized()` 在透明窗口上总返回 false）可能不再需要——作为后续 PR 单独处理。
+
+### D3: 打开子窗口时临时取消主窗口 alwaysOnTop
+
+不改为移除设置/历史窗口的 `alwaysOnTop`（那会导致 always-on-top 主窗口覆盖设置窗口）。改为：
+
+- `showSettingsWindow()` / `showHistoryWindow()`：调用 `mainWindow.setAlwaysOnTop(false)`
+- 子窗口 `closed` 处理器：恢复 `mainWindow.setAlwaysOnTop(this._alwaysOnTop)`
+- `WINDOW.SET_TOP` 仅应用于 `mainWindow`
+
+**理由**: Architect review 发现移除子窗口 alwaysOnTop 会制造 z-order 倒置。临时取消主窗口置顶是 VS Code / macOS inspector 的标准模式。
+
+### D4: 移除全局 Escape → 隐藏窗口
+
+移除 `App.tsx:387-396` 的 `document.addEventListener("keydown", handleKeyPress)` useEffect。
+
+**理由**: Escape 在文本框中应清除输入，不应隐藏整个窗口。用户已明确确认完全移除。
+
+### D5: 子窗口关闭后恢复主窗口焦点
+
+在 `createSettingsWindow` / `createHistoryWindow` 的 `closed` 事件处理器中调用新增的 `restoreMainWindow()` 方法（`show()` + `focus()` + 恢复 `alwaysOnTop`）。
+
+**理由**: 当前关闭设置窗口后焦点不回到主窗口，用户感觉应用"消失"了。
+
+### D6: TrayManager 传入 logger
+
+`main.ts:145` 改为 `new TrayManager(logger)`。
+
+**理由**: `clipboardManager` 和 `funasrManager` 都传了 logger，唯独 trayManager 漏了。托盘创建失败时 catch 块 `if (this.logger && this.logger.error)` 永远为 false，错误被完全吞掉。
+
+### D7: Toast 移至 bottom-center + 内联按钮反馈
+
+- 设置窗口 `<Toaster position="bottom-center" />`，改用主题感知包装器 `./components/ui/sonner`
+- `saveSettings` 返回 `boolean`，保存成功时按钮闪烁 "✓ 已保存" 1.5 秒
+
+**理由**: 底部居中是表单保存反馈的业界标准（Gmail、Notion、Linear）。`saveSettings` 返回值确保 flash 只在成功时触发。
+
+## 不做的事（明确排除）
+
+| 提案                                                  | 排除原因                                                                                                                   |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 重排保存流程（先存原始文本再 AI 优化后更新）          | Review 发现无 `updateTranscription` DB 方法/IPC 通道。`backgroundThrottling: false` 已解决根因（定时器限流），不需要重排。 |
+| Ollama 自动配置（建议横幅 + 模型自动填充）            | 与报告的 bug 无关，作为独立 issue 处理。                                                                                   |
+| AI 配置表单 UX 改进（粘性底栏、字段校验、提供商分组） | 与窗口 bug 无关，作为独立 issue 处理。                                                                                     |
+| 缩窄 Escape 监听器（仅非 input 时触发）               | 用户已明确选择完全移除。                                                                                                   |
+| 移除 `[20260602_Fix_MaximizeToggle]` workaround       | 需要独立验证 transparent 移除后是否仍需要，不在本次范围。                                                                  |
+
+## 交付策略
+
+分两个 PR，降低合并风险：
+
+### PR1 — 安全修复（~50-60 行，低风险）
+
+| 变更                                                 | 文件                                    |
+| ---------------------------------------------------- | --------------------------------------- |
+| `backgroundThrottling: false`                        | `windowManager.ts`                      |
+| EffectsLayer visibilitychange 暂停                   | `EffectsLayer.tsx`                      |
+| WINDOW.SHOW 加 `.focus()`                            | `windowHandlers.ts`                     |
+| TrayManager 传入 logger                              | `main.ts`                               |
+| 移除全局 Escape useEffect                            | `App.tsx`                               |
+| 子窗口 closed 恢复主窗口焦点 + `restoreMainWindow()` | `windowManager.ts`, `windowHandlers.ts` |
+| Toast bottom-center + 主题包装器                     | `settings.tsx`                          |
+| saveSettings 返回 boolean + savedFlash               | `useSettings.ts`, `AIConfigSection.tsx` |
+
+### PR2 — 窗口架构（~40-50 行，需 Windows 手动验证）
+
+| 变更                                           | 文件                |
+| ---------------------------------------------- | ------------------- |
+| 移除 `transparent: true` + `skipTaskbar: true` | `windowManager.ts`  |
+| 添加 `icon` 属性（复用 tray 路径模式）         | `windowManager.ts`  |
+| showSettings/History 临时取消主窗口置顶        | `windowManager.ts`  |
+| SET_TOP 仅 mainWindow                          | `windowHandlers.ts` |
+
+## 验证计划
+
+### 回归测试（TDD — 先写失败测试）
+
+| 测试                        | 文件                           | 断言                                            |
+| --------------------------- | ------------------------------ | ----------------------------------------------- |
+| backgroundThrottling 配置   | `windowManager-events.test.ts` | webPreferences 含 `backgroundThrottling: false` |
+| WINDOW.SHOW focus           | `windowHandlers.test.ts`       | `.show()` 和 `.focus()` 均调用                  |
+| HIDE_SETTINGS 恢复焦点      | `windowHandlers.test.ts`       | `restoreMainWindow()` 被调用                    |
+| closed 恢复焦点             | `windowManager-events.test.ts` | `mainWindow.show()` + `.focus()` 调用           |
+| SET_TOP 仅 mainWindow       | `windowHandlers.test.ts`       | 不对 settings/history 调用 setAlwaysOnTop       |
+| showSettings 取消主窗口置顶 | `windowManager-events.test.ts` | `mainWindow.setAlwaysOnTop(false)` 调用         |
+| saveSettings 返回值         | 新建 `useSettings.test.ts`     | 成功返回 true，失败返回 false                   |
+
+### 手动验证（确定性步骤）
+
+| #   | 操作                                             | 预期                                |
+| --- | ------------------------------------------------ | ----------------------------------- |
+| 1   | 启动应用                                         | 任务栏显示 Murmur 品牌图标          |
+| 2   | 录音 → Escape 隐藏 → 等转录完成 → 点击任务栏恢复 | 转录结果完整（DB 记录数一致）       |
+| 3   | 录音 → 热键隐藏 → 等 10s → 恢复                  | AI 优化完整，`processed_text` 非空  |
+| 4   | 打开设置 → X 关闭                                | 主窗口获焦点，alwaysOnTop 恢复      |
+| 5   | 设置页文本框 → Escape                            | 清除输入，窗口不隐藏                |
+| 6   | 保存 AI 配置                                     | toast 底部居中，按钮闪烁 "✓ 已保存" |
+| 7   | 保存时断网                                       | 按钮不闪烁，toast 显示错误          |
+| 8   | 开启 EffectsLayer → 隐藏窗口 → 查 CPU            | CPU 不持续高占用                    |
+
+### CI 门禁
+
+`pnpm ci:check`：格式检查、lint、license、测试+覆盖率、build:preload、build:renderer、effects chunk 隔离检查。
+
+## 风险评估
+
+| 风险                                         | 严重性 | 缓解                                                   |
+| -------------------------------------------- | ------ | ------------------------------------------------------ |
+| 移除 `transparent: true` 改变窗口外观        | 🟡 中  | Tracer 确认 body/#root 已不透明。需 Windows 手动验证。 |
+| `backgroundThrottling: false` 增加隐藏时 CPU | 🟡 中  | EffectsLayer visibilitychange 暂停缓解。               |
+| showSettings 取消置顶后崩溃未恢复            | 🟢 低  | closed 处理器无条件恢复 alwaysOnTop。                  |
+| saveSettings 返回值变更影响调用方            | 🟢 低  | 仅 `settings.tsx:142` 调用，改为 await + 检查返回值。  |
+
+## Review 记录
+
+本计划经过 ralplan 三路对抗性 review：
+
+- **Architect (Opus)**: ITERATE → 发现 3 个 BLOCKER（无 UPDATE API、transparent+skipTaskbar 坏组合、z-order 倒置）→ 全部解决
+- **Critic (Opus)**: ITERATE → 发现 savedFlash 误触发、icon 路径未验证 prod、"surgical" 措辞误导 → 全部解决
+- **Tracer (Sonnet)**: 10 项声明验证，8 项 CONFIRMED，2 项 PARTIALLY TRUE → 已修正
+
+关键修订见"不做的事"和"交付策略"中的 PR 拆分。

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -54,6 +54,7 @@ dev:main 改用 `build:main && electron .`，dev/e2e/prod 加载同一 artifact�
 ### P1.1 — canary 提升为 E2E 强断言 ⏸ 受阻（2026-07-28 试过）
 
 目标：electron-launch.ts 缓冲 main 输出，firstWindow 后断言 `[main:canary]`。试过发现两个阻塞：
+
 1. **canary 时序**：canary（`main.ts:12`）在 electron 启动早期触发，而 `mainOutputBuf` 在 `electron.launch()` 返回后才 attach → 错过早期 canary，gate 可能断言不到。需重想捕获方式（main 写文件 / gate 用晚期信号）。
 2. **e2e 环境**：worktree firstWindow timeout（主 repo 同 e2e diag 过、worktree 不通，疑 embedded python/资源差异）；CI e2e 也 non-blocking（ADR-014 firstWindow 至今未解决）。
 

--- a/docs/plans/e2e-test-plan.md
+++ b/docs/plans/e2e-test-plan.md
@@ -10,6 +10,7 @@
 ## RALPLAN-DR Summary
 
 ### Principles
+
 1. **User-Journey Coverage** — Tests mirror real user workflows, not implementation details
 2. **Platform Parity** — Critical paths tested on macOS and Windows in CI
 3. **Flaky-Free by Design** — Mock external deps at the IPC handler boundary; never rely on real network or hardware
@@ -17,6 +18,7 @@
 5. **Deterministic Assertions** — Assert observable UI state (aria-labels, data-testid, text content) or IPC response shape; no timing-based waits
 
 ### Decision Drivers
+
 1. **CI reliability** — Current E2E tests pass inconsistently; new suite must be resilient with proper Electron binary caching
 2. **Maintenance cost** — E2E tests cost 5-10x more to maintain than unit tests; keep the suite lean and focused
 3. **Coverage gaps** — Zero E2E coverage for recording, AI processing, file import, history, updates, window management, hotkeys
@@ -26,91 +28,102 @@
 **Decision:** Use Playwright `_electron.launch()` with IPC handler mocking.
 **Drivers:** CI reliability, testing pyramid balance, maintenance cost.
 **Alternatives considered:**
+
 - Option B (IPC-only integration): Rejected — would miss UI/IPC integration bugs like the Windows maximize bug (#29)
 - Option C (Hybrid E2E + integration): Rejected — two test patterns adds complexity; IPC mocking within Playwright achieves same result
-**Why chosen:** Single test pattern that covers real Electron lifecycle + UI state + IPC flow; mocks at the right boundary.
-**Consequences:** Suite runs ~2-3 min; requires Electron binary in CI; platform matrix doubles CI time.
-**Follow-ups:** Add Windows CI runner after macOS suite stabilizes (Phase 2).
+  **Why chosen:** Single test pattern that covers real Electron lifecycle + UI state + IPC flow; mocks at the right boundary.
+  **Consequences:** Suite runs ~2-3 min; requires Electron binary in CI; platform matrix doubles CI time.
+  **Follow-ups:** Add Windows CI runner after macOS suite stabilizes (Phase 2).
 
 ---
 
 ## Test Scenarios (28 cases across 10 suites)
 
 ### Suite 1: Application Lifecycle (5 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 1.1 | Launch and show main window | P0 | `window.isVisible() === true`; title matches /Murmur/; `window.electronAPI` defined |
-| 1.2 | Settings page route renders | P0 | Navigate to `?page=settings`; `aria-label="设置页面"` visible |
-| 1.3 | History page route renders | P0 | Navigate to `?page=history`; heading "转录历史" visible |
-| 1.4 | Close behavior "hide" | P1 | Set `close_behavior=hide`; click close button; `electronApp.isRunning() === true` |
-| 1.5 | Close behavior "quit" | P1 | Set `close_behavior=quit`; click close button; process exits with code 0 |
+
+| #   | Test Case                   | Priority | Acceptance Criteria                                                                 |
+| --- | --------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| 1.1 | Launch and show main window | P0       | `window.isVisible() === true`; title matches /Murmur/; `window.electronAPI` defined |
+| 1.2 | Settings page route renders | P0       | Navigate to `?page=settings`; `aria-label="设置页面"` visible                       |
+| 1.3 | History page route renders  | P0       | Navigate to `?page=history`; heading "转录历史" visible                             |
+| 1.4 | Close behavior "hide"       | P1       | Set `close_behavior=hide`; click close button; `electronApp.isRunning() === true`   |
+| 1.5 | Close behavior "quit"       | P1       | Set `close_behavior=quit`; click close button; process exits with code 0            |
 
 ### Suite 2: Model Download & Loading (4 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 2.1 | Initial state: need_download | P0 | Text "需要下载" visible; mic button has `disabled` attribute |
-| 2.2 | Download progress updates | P0 | Emit `model-download-progress` event with `{progress: 50}`; `aria-valuenow="50"` on progress bar |
-| 2.3 | Model ready enables recording | P0 | Mock model status to `ready`; mic button `disabled === false` |
-| 2.4 | Download failure + retry | P1 | Mock download failure; error toast visible; retry button triggers re-download |
+
+| #   | Test Case                     | Priority | Acceptance Criteria                                                                              |
+| --- | ----------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| 2.1 | Initial state: need_download  | P0       | Text "需要下载" visible; mic button has `disabled` attribute                                     |
+| 2.2 | Download progress updates     | P0       | Emit `model-download-progress` event with `{progress: 50}`; `aria-valuenow="50"` on progress bar |
+| 2.3 | Model ready enables recording | P0       | Mock model status to `ready`; mic button `disabled === false`                                    |
+| 2.4 | Download failure + retry      | P1       | Mock download failure; error toast visible; retry button triggers re-download                    |
 
 ### Suite 3: Real-time Recording Flow (6 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 3.1 | Start recording via mic button | P0 | Click mic; `aria-label` changes to "停止录音"; `recording-pulse` CSS class present |
-| 3.2 | Stop recording and show processing | P0 | Click mic again; `aria-label="开始录音"` or processing indicator; `isRecording === false` |
-| 3.3 | Recording blocked when model not ready | P0 | With model `not ready`; click mic; toast contains "模型" |
-| 3.4 | Transcription result displayed | P0 | Mock `transcribe-audio` IPC response; `data-testid="transcription-result"` contains expected text |
-| 3.5 | AI optimization replaces text | P0 | Mock `process-text` IPC response; processed text shown, "AI文本优化完成" toast |
-| 3.6 | AI failure falls back to original | P1 | Mock `process-text` error; original text auto-pasted; toast contains "AI优化失败" |
+
+| #   | Test Case                              | Priority | Acceptance Criteria                                                                               |
+| --- | -------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| 3.1 | Start recording via mic button         | P0       | Click mic; `aria-label` changes to "停止录音"; `recording-pulse` CSS class present                |
+| 3.2 | Stop recording and show processing     | P0       | Click mic again; `aria-label="开始录音"` or processing indicator; `isRecording === false`         |
+| 3.3 | Recording blocked when model not ready | P0       | With model `not ready`; click mic; toast contains "模型"                                          |
+| 3.4 | Transcription result displayed         | P0       | Mock `transcribe-audio` IPC response; `data-testid="transcription-result"` contains expected text |
+| 3.5 | AI optimization replaces text          | P0       | Mock `process-text` IPC response; processed text shown, "AI文本优化完成" toast                    |
+| 3.6 | AI failure falls back to original      | P1       | Mock `process-text` error; original text auto-pasted; toast contains "AI优化失败"                 |
 
 ### Suite 4: Hotkey Management (3 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 4.1 | Default hotkey shown in UI | P0 | Text contains "⌘" on macOS or "Ctrl" on Windows |
-| 4.2 | Hotkey IPC event toggles recording | P0 | Emit `hotkey-triggered` event; recording state toggles |
-| 4.3 | Platform shows correct modifier | P1 | Assert hotkey text matches `process.platform` |
+
+| #   | Test Case                          | Priority | Acceptance Criteria                                    |
+| --- | ---------------------------------- | -------- | ------------------------------------------------------ |
+| 4.1 | Default hotkey shown in UI         | P0       | Text contains "⌘" on macOS or "Ctrl" on Windows        |
+| 4.2 | Hotkey IPC event toggles recording | P0       | Emit `hotkey-triggered` event; recording state toggles |
+| 4.3 | Platform shows correct modifier    | P1       | Assert hotkey text matches `process.platform`          |
 
 ### Suite 5: File Import & Transcription (3 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 5.1 | Switch to file-import mode | P0 | Click "文件导入" tab; `data-testid="file-drop-zone"` visible |
-| 5.2 | Validate supported audio file | P0 | Mock `validate-audio-file` IPC to return valid; file accepted |
-| 5.3 | Reject unsupported file type | P1 | Mock validation IPC error; error message visible |
+
+| #   | Test Case                     | Priority | Acceptance Criteria                                           |
+| --- | ----------------------------- | -------- | ------------------------------------------------------------- |
+| 5.1 | Switch to file-import mode    | P0       | Click "文件导入" tab; `data-testid="file-drop-zone"` visible  |
+| 5.2 | Validate supported audio file | P0       | Mock `validate-audio-file` IPC to return valid; file accepted |
+| 5.3 | Reject unsupported file type  | P1       | Mock validation IPC error; error message visible              |
 
 ### Suite 6: Clipboard & Auto-Paste (3 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 6.1 | Copy text to clipboard | P0 | `writeClipboard("test")` then `readClipboard()` returns "test" |
-| 6.2 | Auto-paste "paste" mode | P1 | Set `auto_paste=paste`; mock transcription; `pasteText` IPC called |
-| 6.3 | Auto-paste "clipboard_only" mode | P1 | Set `auto_paste=clipboard_only`; mock transcription; only `copyText` IPC called |
+
+| #   | Test Case                        | Priority | Acceptance Criteria                                                             |
+| --- | -------------------------------- | -------- | ------------------------------------------------------------------------------- |
+| 6.1 | Copy text to clipboard           | P0       | `writeClipboard("test")` then `readClipboard()` returns "test"                  |
+| 6.2 | Auto-paste "paste" mode          | P1       | Set `auto_paste=paste`; mock transcription; `pasteText` IPC called              |
+| 6.3 | Auto-paste "clipboard_only" mode | P1       | Set `auto_paste=clipboard_only`; mock transcription; only `copyText` IPC called |
 
 ### Suite 7: Settings Persistence (4 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 7.1 | Theme setting persists | P0 | Set theme "dark"; restart app; `getSetting("theme") === "dark"` |
-| 7.2 | AI provider preset auto-fills | P0 | Select "DeepSeek" preset; `ai_base_url` field contains "deepseek.com" |
-| 7.3 | API key show/hide toggle | P1 | Click eye icon; input `type` toggles between "password" and "text" |
-| 7.4 | Settings roundtrip export/import | P1 | Export settings JSON; import into fresh app; all values match |
+
+| #   | Test Case                        | Priority | Acceptance Criteria                                                   |
+| --- | -------------------------------- | -------- | --------------------------------------------------------------------- |
+| 7.1 | Theme setting persists           | P0       | Set theme "dark"; restart app; `getSetting("theme") === "dark"`       |
+| 7.2 | AI provider preset auto-fills    | P0       | Select "DeepSeek" preset; `ai_base_url` field contains "deepseek.com" |
+| 7.3 | API key show/hide toggle         | P1       | Click eye icon; input `type` toggles between "password" and "text"    |
+| 7.4 | Settings roundtrip export/import | P1       | Export settings JSON; import into fresh app; all values match         |
 
 ### Suite 8: History Management (3 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 8.1 | Open history with data | P0 | Insert test records; open history; `N 条记录` counter matches |
-| 8.2 | Search filters results | P0 | Insert records; search for keyword; only matching records shown |
-| 8.3 | Delete single transcription | P1 | Delete record; counter decrements; record gone from list |
+
+| #   | Test Case                   | Priority | Acceptance Criteria                                             |
+| --- | --------------------------- | -------- | --------------------------------------------------------------- |
+| 8.1 | Open history with data      | P0       | Insert test records; open history; `N 条记录` counter matches   |
+| 8.2 | Search filters results      | P0       | Insert records; search for keyword; only matching records shown |
+| 8.3 | Delete single transcription | P1       | Delete record; counter decrements; record gone from list        |
 
 ### Suite 9: Window Management (3 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 9.1 | Minimize window | P0 | `minimizeWindow()` called; `window.isMinimized() === true` |
-| 9.2 | Maximize/restore toggle | P0 | `maximizeWindow()` then again; `isMaximized` toggles each time |
-| 9.3 | Always-on-top toggle | P1 | `setAlwaysOnTop(true)`; `window.isAlwaysOnTop() === true` |
+
+| #   | Test Case               | Priority | Acceptance Criteria                                            |
+| --- | ----------------------- | -------- | -------------------------------------------------------------- |
+| 9.1 | Minimize window         | P0       | `minimizeWindow()` called; `window.isMinimized() === true`     |
+| 9.2 | Maximize/restore toggle | P0       | `maximizeWindow()` then again; `isMaximized` toggles each time |
+| 9.3 | Always-on-top toggle    | P1       | `setAlwaysOnTop(true)`; `window.isAlwaysOnTop() === true`      |
 
 ### Suite 10: Error Resilience (2 tests)
-| # | Test Case | Priority | Acceptance Criteria |
-|---|-----------|----------|---------------------|
-| 10.1 | FunASR crash triggers auto-restart | P0 | Kill Python process; health check detects; server restarts within 90s |
-| 10.2 | AI network error graceful fallback | P1 | Mock `process-text` to reject; original text shown; error toast displayed |
+
+| #    | Test Case                          | Priority | Acceptance Criteria                                                       |
+| ---- | ---------------------------------- | -------- | ------------------------------------------------------------------------- |
+| 10.1 | FunASR crash triggers auto-restart | P0       | Kill Python process; health check detects; server restarts within 90s     |
+| 10.2 | AI network error graceful fallback | P1       | Mock `process-text` to reject; original text shown; error toast displayed |
 
 ---
 
@@ -144,14 +157,14 @@ tests/e2e/
 
 All mocks intercept at the Electron IPC layer via `electronApp.evaluate()`:
 
-| Dependency | Mock Method | Example |
-|------------|-------------|---------|
+| Dependency           | Mock Method                                                   | Example                                                                                         |
+| -------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | FunASR transcription | Override `ipcMain.handle('transcribe-audio')` in main process | `app.evaluate(() => ipcMain.handle('transcribe-audio', () => ({success: true, text: '测试'})))` |
-| AI processing | Override `ipcMain.handle('process-text')` | Return `{success: true, text: '优化后', enhanced_by_ai: true}` |
-| Model download | Override `ipcMain.handle('download-models')` | Return `{success: true}` instantly |
-| Model status | Override `ipcMain.handle('check-model-files')` | Return `{stage: 'ready', isReady: true}` |
-| AI API HTTP calls | `page.route()` to intercept XHR | `page.route('**/chat/completions', route => route.fulfill({...}))` |
-| Update check | Override `ipcMain.handle('check-update')` | Return `{hasUpdate: false, currentVersion: '1.0.1'}` |
+| AI processing        | Override `ipcMain.handle('process-text')`                     | Return `{success: true, text: '优化后', enhanced_by_ai: true}`                                  |
+| Model download       | Override `ipcMain.handle('download-models')`                  | Return `{success: true}` instantly                                                              |
+| Model status         | Override `ipcMain.handle('check-model-files')`                | Return `{stage: 'ready', isReady: true}`                                                        |
+| AI API HTTP calls    | `page.route()` to intercept XHR                               | `page.route('**/chat/completions', route => route.fulfill({...}))`                              |
+| Update check         | Override `ipcMain.handle('check-update')`                     | Return `{hasUpdate: false, currentVersion: '1.0.1'}`                                            |
 
 ### Test Isolation Strategy
 
@@ -160,7 +173,7 @@ All mocks intercept at the Electron IPC layer via `electronApp.evaluate()`:
 beforeAll(async () => {
   app = await launchElectronApp({
     // Use in-memory or temp database
-    env: { ...process.env, NODE_ENV: 'test', MURMUR_DB_PATH: ':memory:' }
+    env: { ...process.env, NODE_ENV: "test", MURMUR_DB_PATH: ":memory:" },
   });
   window = await app.firstWindow();
 });
@@ -176,6 +189,7 @@ afterEach(async () => {
 ```
 
 **Key isolation guarantees:**
+
 - Fresh Electron app per suite (not per test — too slow)
 - In-memory SQLite database (`:memory:`) via `MURMUR_DB_PATH` env var
 - Settings reset between tests within a suite
@@ -185,24 +199,25 @@ afterEach(async () => {
 
 ```js
 export default defineConfig({
-  testDir: './suites',
-  timeout: 45000,           // 45s per test (Electron startup takes time)
-  retries: 0,               // Start with 0 — increase to 1 only after suite stabilizes
-  workers: 1,               // Sequential execution (Electron can't parallelize)
+  testDir: "./suites",
+  timeout: 45000, // 45s per test (Electron startup takes time)
+  retries: 0, // Start with 0 — increase to 1 only after suite stabilizes
+  workers: 1, // Sequential execution (Electron can't parallelize)
   use: {
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
   },
-  reporter: [['list'], ['html', { open: 'never' }]],
+  reporter: [["list"], ["html", { open: "never" }]],
 });
 ```
 
 ### CI Integration
 
 **Phase 1 (macOS primary):**
+
 ```yaml
 e2e-tests:
   runs-on: macos-latest
-  needs: [lint-and-test]     # Run after unit tests pass
+  needs: [lint-and-test] # Run after unit tests pass
   steps:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
@@ -217,6 +232,7 @@ e2e-tests:
 ```
 
 **Phase 2 (add Windows, after suite stabilizes):**
+
 ```yaml
 strategy:
   matrix:
@@ -230,28 +246,33 @@ strategy:
 ## Implementation Phases
 
 ### Phase 1: Infrastructure (2-3 hours)
+
 - [ ] Create test helpers (`electron-launch.js`, `ipc-mock.js`, `fixtures.js`)
 - [ ] Update `playwright.config.js` with proper timeouts
 - [ ] Add `MURMUR_DB_PATH` support to `database.js` for test isolation
 - [ ] Verify infrastructure with Suite 1 (lifecycle) smoke tests
 
 ### Phase 2: Core User Flows (3-4 hours)
+
 - [ ] Suite 2: Model download & loading
 - [ ] Suite 3: Real-time recording flow
 - [ ] Suite 5: File import
 - [ ] Suite 6: Clipboard & auto-paste
 
 ### Phase 3: Settings & History (2-3 hours)
+
 - [ ] Suite 7: Settings persistence
 - [ ] Suite 8: History management
 - [ ] Suite 4: Hotkey management
 
 ### Phase 4: Window & Error Resilience (1-2 hours)
+
 - [ ] Suite 9: Window management
 - [ ] Suite 10: Error resilience
 - [ ] CI integration
 
 ### Phase 5: CI & Documentation (1 hour)
+
 - [ ] Add E2E CI job to `.github/workflows/ci.yml`
 - [ ] Update CONTRIBUTING.md with E2E test guidelines
 - [ ] Verify all 28 tests pass in CI

--- a/docs/promotion/prompts/bento-features.html
+++ b/docs/promotion/prompts/bento-features.html
@@ -1,199 +1,235 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-CN">
-<head>
-<meta charset="UTF-8">
-<title>Murmur Features</title>
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", sans-serif;
-    background: #F5F5F7;
-    padding: 40px 48px;
-    width: 1280px;
-    height: 720px;
-  }
-  .container {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: auto 1fr 1fr auto;
-    gap: 14px;
-    height: 100%;
-  }
-  .header {
-    grid-column: 1 / -1;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 4px;
-  }
-  .title {
-    font-size: 30px;
-    font-weight: 700;
-    color: #1D1D1F;
-    letter-spacing: -0.5px;
-  }
-  .subtitle {
-    font-size: 14px;
-    color: #86868B;
-  }
-  .badge {
-    background: #0071e3;
-    color: #FFFFFF;
-    padding: 6px 14px;
-    border-radius: 16px;
-    font-size: 12px;
-    font-weight: 600;
-  }
-  .card {
-    background: #FFFFFF;
-    border-radius: 16px;
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
-    transition: transform 0.2s;
-  }
-  .card .icon {
-    font-size: 28px;
-    margin-bottom: 8px;
-  }
-  .card .name {
-    font-size: 16px;
-    font-weight: 600;
-    color: #1D1D1F;
-    margin-bottom: 4px;
-  }
-  .card .name-en {
-    font-size: 11px;
-    color: #AEAEB2;
-    font-weight: 400;
-    margin-bottom: 8px;
-  }
-  .card .desc {
-    font-size: 12px;
-    color: #86868B;
-    line-height: 1.5;
-  }
-  /* Featured card (large) */
-  .card-large {
-    grid-column: span 2;
-    grid-row: span 1;
-    background: linear-gradient(135deg, #0071e3 0%, #0091ff 100%);
-    color: #FFFFFF;
-  }
-  .card-large .name, .card-large .name-en { color: #FFFFFF; }
-  .card-large .name-en { color: rgba(255,255,255,0.7); }
-  .card-large .desc { color: rgba(255,255,255,0.85); font-size: 13px; }
-  .card-large .icon { font-size: 36px; }
-  .card-large .name { font-size: 20px; }
+  <head>
+    <meta charset="UTF-8" />
+    <title>Murmur Features</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue",
+          sans-serif;
+        background: #f5f5f7;
+        padding: 40px 48px;
+        width: 1280px;
+        height: 720px;
+      }
+      .container {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        grid-template-rows: auto 1fr 1fr auto;
+        gap: 14px;
+        height: 100%;
+      }
+      .header {
+        grid-column: 1 / -1;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 4px;
+      }
+      .title {
+        font-size: 30px;
+        font-weight: 700;
+        color: #1d1d1f;
+        letter-spacing: -0.5px;
+      }
+      .subtitle {
+        font-size: 14px;
+        color: #86868b;
+      }
+      .badge {
+        background: #0071e3;
+        color: #ffffff;
+        padding: 6px 14px;
+        border-radius: 16px;
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .card {
+        background: #ffffff;
+        border-radius: 16px;
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+        transition: transform 0.2s;
+      }
+      .card .icon {
+        font-size: 28px;
+        margin-bottom: 8px;
+      }
+      .card .name {
+        font-size: 16px;
+        font-weight: 600;
+        color: #1d1d1f;
+        margin-bottom: 4px;
+      }
+      .card .name-en {
+        font-size: 11px;
+        color: #aeaeb2;
+        font-weight: 400;
+        margin-bottom: 8px;
+      }
+      .card .desc {
+        font-size: 12px;
+        color: #86868b;
+        line-height: 1.5;
+      }
+      /* Featured card (large) */
+      .card-large {
+        grid-column: span 2;
+        grid-row: span 1;
+        background: linear-gradient(135deg, #0071e3 0%, #0091ff 100%);
+        color: #ffffff;
+      }
+      .card-large .name,
+      .card-large .name-en {
+        color: #ffffff;
+      }
+      .card-large .name-en {
+        color: rgba(255, 255, 255, 0.7);
+      }
+      .card-large .desc {
+        color: rgba(255, 255, 255, 0.85);
+        font-size: 13px;
+      }
+      .card-large .icon {
+        font-size: 36px;
+      }
+      .card-large .name {
+        font-size: 20px;
+      }
 
-  /* Second featured */
-  .card-medium-accent {
-    grid-column: span 2;
-    background: #FFFFFF;
-    border: 2px solid #0071e3;
-  }
-  .card-medium-accent .name { color: #0071e3; }
+      /* Second featured */
+      .card-medium-accent {
+        grid-column: span 2;
+        background: #ffffff;
+        border: 2px solid #0071e3;
+      }
+      .card-medium-accent .name {
+        color: #0071e3;
+      }
 
-  .footer {
-    grid-column: 1 / -1;
-    text-align: center;
-    font-size: 12px;
-    color: #86868B;
-    margin-top: 4px;
-  }
-  .footer a { color: #0071e3; text-decoration: none; font-weight: 500; }
-</style>
-</head>
-<body>
-<div class="container">
-  <div class="header">
-    <div>
-      <div class="title">Murmur 功能特性</div>
-      <div class="subtitle">Open Source · Local · AI Voice Input</div>
+      .footer {
+        grid-column: 1 / -1;
+        text-align: center;
+        font-size: 12px;
+        color: #86868b;
+        margin-top: 4px;
+      }
+      .footer a {
+        color: #0071e3;
+        text-decoration: none;
+        font-weight: 500;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <div>
+          <div class="title">Murmur 功能特性</div>
+          <div class="subtitle">Open Source · Local · AI Voice Input</div>
+        </div>
+        <div class="badge">Apache 2.0 · 开源免费</div>
+      </div>
+
+      <!-- Row 1: 2 large featured cards -->
+      <div class="card card-large">
+        <div>
+          <div class="icon">🎤</div>
+          <div class="name">高精度中文识别</div>
+          <div class="name-en">Accurate Chinese Recognition</div>
+        </div>
+        <div class="desc">
+          FunASR Paraformer-large 模型，专为中国用户优化<br />中文精度优于
+          Whisper，本地推理
+        </div>
+      </div>
+
+      <div class="card card-medium-accent">
+        <div>
+          <div class="icon">🔒</div>
+          <div class="name">完全本地运行</div>
+          <div class="name-en">Fully Local · Zero Upload</div>
+        </div>
+        <div class="desc">
+          所有音频处理在本地完成<br />数据不离开你的电脑，隐私无忧
+        </div>
+      </div>
+
+      <!-- Row 2: 4 medium cards -->
+      <div class="card">
+        <div class="icon">🤖</div>
+        <div>
+          <div class="name">AI 智能润色</div>
+          <div class="name-en">AI Refinement</div>
+        </div>
+        <div class="desc">自动去除口头禅<br />修正语法，整理段落</div>
+      </div>
+
+      <div class="card">
+        <div class="icon">🌐</div>
+        <div>
+          <div class="name">11+ AI 模型</div>
+          <div class="name-en">Model Variety</div>
+        </div>
+        <div class="desc">
+          DeepSeek · 通义 · 智谱<br />Groq · Ollama · LM Studio
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="icon">⌨️</div>
+        <div>
+          <div class="name">全局热键</div>
+          <div class="name-en">Global Hotkey</div>
+        </div>
+        <div class="desc">⌘⇧Space 一键录音<br />说完自动粘贴到光标</div>
+      </div>
+
+      <div class="card">
+        <div class="icon">📁</div>
+        <div>
+          <div class="name">音频文件转录</div>
+          <div class="name-en">File Transcription</div>
+        </div>
+        <div class="desc">wav/mp3/m4a/flac<br />导出 SRT/MD/DOCX</div>
+      </div>
+
+      <!-- Row 3: 2 wide cards -->
+      <div class="card" style="grid-column: span 2">
+        <div class="icon">💾</div>
+        <div>
+          <div class="name">转录历史 · 全文搜索</div>
+          <div class="name-en">History · FTS5 Full-Text Search</div>
+        </div>
+        <div class="desc">
+          SQLite + safeStorage 加密存储，FTS5 中文全文搜索，652 测试 95% 覆盖率
+        </div>
+      </div>
+
+      <div class="card" style="grid-column: span 2">
+        <div class="icon">🌍</div>
+        <div>
+          <div class="name">双语支持 · 无障碍</div>
+          <div class="name-en">i18n · Accessibility</div>
+        </div>
+        <div class="desc">
+          中文 / English 完整国际化，ARIA 标签 + 键盘导航，macOS + Windows
+        </div>
+      </div>
+
+      <div class="footer">
+        <a href="#">github.com/TeFuirnever/Murmur</a> · brew install --cask
+        murmur · winget install TeFuirnever.Murmur
+      </div>
     </div>
-    <div class="badge">Apache 2.0 · 开源免费</div>
-  </div>
-
-  <!-- Row 1: 2 large featured cards -->
-  <div class="card card-large">
-    <div>
-      <div class="icon">🎤</div>
-      <div class="name">高精度中文识别</div>
-      <div class="name-en">Accurate Chinese Recognition</div>
-    </div>
-    <div class="desc">FunASR Paraformer-large 模型，专为中国用户优化<br>中文精度优于 Whisper，本地推理</div>
-  </div>
-
-  <div class="card card-medium-accent">
-    <div>
-      <div class="icon">🔒</div>
-      <div class="name">完全本地运行</div>
-      <div class="name-en">Fully Local · Zero Upload</div>
-    </div>
-    <div class="desc">所有音频处理在本地完成<br>数据不离开你的电脑，隐私无忧</div>
-  </div>
-
-  <!-- Row 2: 4 medium cards -->
-  <div class="card">
-    <div class="icon">🤖</div>
-    <div>
-      <div class="name">AI 智能润色</div>
-      <div class="name-en">AI Refinement</div>
-    </div>
-    <div class="desc">自动去除口头禅<br>修正语法，整理段落</div>
-  </div>
-
-  <div class="card">
-    <div class="icon">🌐</div>
-    <div>
-      <div class="name">11+ AI 模型</div>
-      <div class="name-en">Model Variety</div>
-    </div>
-    <div class="desc">DeepSeek · 通义 · 智谱<br>Groq · Ollama · LM Studio</div>
-  </div>
-
-  <div class="card">
-    <div class="icon">⌨️</div>
-    <div>
-      <div class="name">全局热键</div>
-      <div class="name-en">Global Hotkey</div>
-    </div>
-    <div class="desc">⌘⇧Space 一键录音<br>说完自动粘贴到光标</div>
-  </div>
-
-  <div class="card">
-    <div class="icon">📁</div>
-    <div>
-      <div class="name">音频文件转录</div>
-      <div class="name-en">File Transcription</div>
-    </div>
-    <div class="desc">wav/mp3/m4a/flac<br>导出 SRT/MD/DOCX</div>
-  </div>
-
-  <!-- Row 3: 2 wide cards -->
-  <div class="card" style="grid-column: span 2;">
-    <div class="icon">💾</div>
-    <div>
-      <div class="name">转录历史 · 全文搜索</div>
-      <div class="name-en">History · FTS5 Full-Text Search</div>
-    </div>
-    <div class="desc">SQLite + safeStorage 加密存储，FTS5 中文全文搜索，652 测试 95% 覆盖率</div>
-  </div>
-
-  <div class="card" style="grid-column: span 2;">
-    <div class="icon">🌍</div>
-    <div>
-      <div class="name">双语支持 · 无障碍</div>
-      <div class="name-en">i18n · Accessibility</div>
-    </div>
-    <div class="desc">中文 / English 完整国际化，ARIA 标签 + 键盘导航，macOS + Windows</div>
-  </div>
-
-  <div class="footer">
-    <a href="#">github.com/TeFuirnever/Murmur</a> · brew install --cask murmur · winget install TeFuirnever.Murmur
-  </div>
-</div>
-</body>
+  </body>
 </html>

--- a/docs/promotion/prompts/comparison-matrix.html
+++ b/docs/promotion/prompts/comparison-matrix.html
@@ -1,170 +1,220 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-CN">
-<head>
-<meta charset="UTF-8">
-<title>Murmur Competitor Comparison</title>
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", sans-serif;
-    background: #FAF8F3;
-    padding: 48px 56px;
-    width: 1280px;
-    height: 720px;
-  }
-  .container {
-    background: #FFFFFF;
-    border-radius: 24px;
-    padding: 40px 48px;
-    box-shadow: 0 4px 24px rgba(0,0,0,0.06);
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-  }
-  .header {
-    text-align: center;
-    margin-bottom: 28px;
-  }
-  .title {
-    font-size: 32px;
-    font-weight: 700;
-    color: #1D1D1F;
-    letter-spacing: -0.5px;
-  }
-  .subtitle {
-    font-size: 15px;
-    color: #86868B;
-    margin-top: 6px;
-  }
-  table {
-    width: 100%;
-    border-collapse: separate;
-    border-spacing: 0;
-    flex: 1;
-  }
-  th, td {
-    padding: 16px 12px;
-    text-align: center;
-    font-size: 15px;
-    border-bottom: 1px solid #F0F0F2;
-  }
-  th {
-    font-size: 16px;
-    font-weight: 600;
-    color: #1D1D1F;
-    padding-bottom: 18px;
-    padding-top: 8px;
-  }
-  th:first-child, td:first-child {
-    text-align: left;
-    font-weight: 600;
-    color: #1D1D1F;
-    padding-left: 16px;
-    font-size: 14px;
-  }
-  /* Murmur column highlight */
-  th.murmur-col {
-    background: #0071e3;
-    color: #FFFFFF;
-    border-radius: 12px 12px 0 0;
-    font-size: 17px;
-  }
-  td.murmur-col {
-    background: rgba(0, 113, 227, 0.04);
-    font-weight: 600;
-    color: #0071e3;
-  }
-  .stars {
-    color: #FFB800;
-    font-size: 16px;
-    letter-spacing: 1px;
-  }
-  .stars-dim {
-    color: #FFB800;
-    opacity: 0.35;
-    font-size: 16px;
-    letter-spacing: 1px;
-  }
-  .check { color: #34C759; font-size: 22px; font-weight: 700; }
-  .cross { color: #FF3B30; opacity: 0.5; font-size: 22px; font-weight: 700; }
-  .dim-text { color: #86868B; font-size: 13px; }
-  .footer {
-    text-align: center;
-    margin-top: 20px;
-    font-size: 13px;
-    color: #86868B;
-  }
-  .footer a { color: #0071e3; text-decoration: none; }
-  .tool-name { font-size: 18px; }
-  .tool-sub { font-size: 12px; color: #86868B; font-weight: 400; display: block; margin-top: 2px; }
-  th:not(.murmur-col) .tool-sub { color: #AEAEB2; }
-  th.murmur-col .tool-sub { color: rgba(255,255,255,0.8); }
-</style>
-</head>
-<body>
-<div class="container">
-  <div class="header">
-    <div class="title">🎤 语音输入工具对比</div>
-    <div class="subtitle">Voice Input Tool Comparison · 4 款主流方案 · 6 个核心维度</div>
-  </div>
-  <table>
-    <thead>
-      <tr>
-        <th></th>
-        <th class="murmur-col">Murmur<span class="tool-sub">开源 · 本地 · AI</span></th>
-        <th>macOS 听写<span class="tool-sub">系统内置</span></th>
-        <th>讯飞语记<span class="tool-sub">云端付费</span></th>
-        <th>Whisper<span class="tool-sub">开源 · 本地</span></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>中文精度<br><span class="dim-text">Chinese Accuracy</span></td>
-        <td class="murmur-col"><span class="stars">★★★★★</span></td>
-        <td><span class="stars">★★★</span><span class="stars-dim">★★</span></td>
-        <td><span class="stars">★★★★★</span></td>
-        <td><span class="stars">★★★</span><span class="stars-dim">★★</span></td>
-      </tr>
-      <tr>
-        <td>完全本地<br><span class="dim-text">Fully Local</span></td>
-        <td class="murmur-col"><span class="check">✓</span></td>
-        <td><span class="check">✓</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="check">✓</span></td>
-      </tr>
-      <tr>
-        <td>AI 后处理<br><span class="dim-text">AI Refinement</span></td>
-        <td class="murmur-col"><span class="check">✓</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="cross">✕</span></td>
-      </tr>
-      <tr>
-        <td>开源免费<br><span class="dim-text">Open Source</span></td>
-        <td class="murmur-col"><span class="check">✓</span></td>
-        <td><span class="check">✓</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="check">✓</span></td>
-      </tr>
-      <tr>
-        <td>11+ AI 模型<br><span class="dim-text">Model Variety</span></td>
-        <td class="murmur-col"><span class="check">✓</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="cross">✕</span></td>
-      </tr>
-      <tr>
-        <td>自定义 Prompt<br><span class="dim-text">Custom Prompts</span></td>
-        <td class="murmur-col"><span class="check">✓</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="cross">✕</span></td>
-        <td><span class="cross">✕</span></td>
-      </tr>
-    </tbody>
-  </table>
-  <div class="footer">
-    Murmur — 开源 · 本地 · AI 语音输入 ｜ <a href="#">github.com/TeFuirnever/Murmur</a>
-  </div>
-</div>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Murmur Competitor Comparison</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue",
+          sans-serif;
+        background: #faf8f3;
+        padding: 48px 56px;
+        width: 1280px;
+        height: 720px;
+      }
+      .container {
+        background: #ffffff;
+        border-radius: 24px;
+        padding: 40px 48px;
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .header {
+        text-align: center;
+        margin-bottom: 28px;
+      }
+      .title {
+        font-size: 32px;
+        font-weight: 700;
+        color: #1d1d1f;
+        letter-spacing: -0.5px;
+      }
+      .subtitle {
+        font-size: 15px;
+        color: #86868b;
+        margin-top: 6px;
+      }
+      table {
+        width: 100%;
+        border-collapse: separate;
+        border-spacing: 0;
+        flex: 1;
+      }
+      th,
+      td {
+        padding: 16px 12px;
+        text-align: center;
+        font-size: 15px;
+        border-bottom: 1px solid #f0f0f2;
+      }
+      th {
+        font-size: 16px;
+        font-weight: 600;
+        color: #1d1d1f;
+        padding-bottom: 18px;
+        padding-top: 8px;
+      }
+      th:first-child,
+      td:first-child {
+        text-align: left;
+        font-weight: 600;
+        color: #1d1d1f;
+        padding-left: 16px;
+        font-size: 14px;
+      }
+      /* Murmur column highlight */
+      th.murmur-col {
+        background: #0071e3;
+        color: #ffffff;
+        border-radius: 12px 12px 0 0;
+        font-size: 17px;
+      }
+      td.murmur-col {
+        background: rgba(0, 113, 227, 0.04);
+        font-weight: 600;
+        color: #0071e3;
+      }
+      .stars {
+        color: #ffb800;
+        font-size: 16px;
+        letter-spacing: 1px;
+      }
+      .stars-dim {
+        color: #ffb800;
+        opacity: 0.35;
+        font-size: 16px;
+        letter-spacing: 1px;
+      }
+      .check {
+        color: #34c759;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .cross {
+        color: #ff3b30;
+        opacity: 0.5;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .dim-text {
+        color: #86868b;
+        font-size: 13px;
+      }
+      .footer {
+        text-align: center;
+        margin-top: 20px;
+        font-size: 13px;
+        color: #86868b;
+      }
+      .footer a {
+        color: #0071e3;
+        text-decoration: none;
+      }
+      .tool-name {
+        font-size: 18px;
+      }
+      .tool-sub {
+        font-size: 12px;
+        color: #86868b;
+        font-weight: 400;
+        display: block;
+        margin-top: 2px;
+      }
+      th:not(.murmur-col) .tool-sub {
+        color: #aeaeb2;
+      }
+      th.murmur-col .tool-sub {
+        color: rgba(255, 255, 255, 0.8);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <div class="title">🎤 语音输入工具对比</div>
+        <div class="subtitle">
+          Voice Input Tool Comparison · 4 款主流方案 · 6 个核心维度
+        </div>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th class="murmur-col">
+              Murmur<span class="tool-sub">开源 · 本地 · AI</span>
+            </th>
+            <th>macOS 听写<span class="tool-sub">系统内置</span></th>
+            <th>讯飞语记<span class="tool-sub">云端付费</span></th>
+            <th>Whisper<span class="tool-sub">开源 · 本地</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              中文精度<br /><span class="dim-text">Chinese Accuracy</span>
+            </td>
+            <td class="murmur-col"><span class="stars">★★★★★</span></td>
+            <td>
+              <span class="stars">★★★</span><span class="stars-dim">★★</span>
+            </td>
+            <td><span class="stars">★★★★★</span></td>
+            <td>
+              <span class="stars">★★★</span><span class="stars-dim">★★</span>
+            </td>
+          </tr>
+          <tr>
+            <td>完全本地<br /><span class="dim-text">Fully Local</span></td>
+            <td class="murmur-col"><span class="check">✓</span></td>
+            <td><span class="check">✓</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="check">✓</span></td>
+          </tr>
+          <tr>
+            <td>AI 后处理<br /><span class="dim-text">AI Refinement</span></td>
+            <td class="murmur-col"><span class="check">✓</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="cross">✕</span></td>
+          </tr>
+          <tr>
+            <td>开源免费<br /><span class="dim-text">Open Source</span></td>
+            <td class="murmur-col"><span class="check">✓</span></td>
+            <td><span class="check">✓</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="check">✓</span></td>
+          </tr>
+          <tr>
+            <td>
+              11+ AI 模型<br /><span class="dim-text">Model Variety</span>
+            </td>
+            <td class="murmur-col"><span class="check">✓</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="cross">✕</span></td>
+          </tr>
+          <tr>
+            <td>
+              自定义 Prompt<br /><span class="dim-text">Custom Prompts</span>
+            </td>
+            <td class="murmur-col"><span class="check">✓</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="cross">✕</span></td>
+            <td><span class="cross">✕</span></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="footer">
+        Murmur — 开源 · 本地 · AI 语音输入 ｜
+        <a href="#">github.com/TeFuirnever/Murmur</a>
+      </div>
+    </div>
+  </body>
 </html>

--- a/docs/research/deep-test-design-error-paths.md
+++ b/docs/research/deep-test-design-error-paths.md
@@ -384,9 +384,9 @@ are untested.
 ### 2.1 MAX_FILE_SIZE (500MB) rejection in VALIDATE_FILE
 
 **File**: `src/helpers/ipc/transcriptionHandlers.ts:117-141` (line 127-129)
-**Current coverage**: not tested — the existing VALIDATE_FILE test only covers
+**Current coverage**: not tested — the existing VALIDATE*FILE test only covers
 "unsupported extension" and "non-existent file".
-**Trigger**: `fs.statSync` returns a size > 500 _ 1024 _ 1024.
+**Trigger**: `fs.statSync` returns a size > 500 * 1024 \_ 1024.
 **Expected behavior**: returns `{ success: false, error: "文件超过500MB限制" }`
 without invoking the FunASR server.
 **Test case**:

--- a/main.ts
+++ b/main.ts
@@ -142,7 +142,7 @@ const windowManager = new WindowManager();
 const databaseManager = new DatabaseManager();
 const clipboardManager = new ClipboardManager(logger); // Pass logger instance
 const funasrManager = new FunASRManager(logger); // Pass logger instance
-const trayManager = new TrayManager();
+const trayManager = new TrayManager(logger);
 const hotkeyManager = new HotkeyManager();
 
 // Initialize database

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -383,17 +383,9 @@ export default function App() {
     }
   }, [isRecording, syncRecordingState]);
 
-  // 监听键盘事件
-  useEffect(() => {
-    const handleKeyPress = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        handleClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyPress);
-    return () => document.removeEventListener("keydown", handleKeyPress);
-  }, []);
+  // [ADR-015] Removed global Escape→hideWindow listener. Escape in a text
+  // field should clear input, not hide the entire window. The close button
+  // (default: hide) and tray icon remain as hide paths.
 
   // 错误处理
   useEffect(() => {

--- a/src/helpers/ipc/windowHandlers.ts
+++ b/src/helpers/ipc/windowHandlers.ts
@@ -21,6 +21,7 @@ interface WindowManager {
   showSettingsWindow(): void;
   closeSettingsWindow(): void;
   hideSettingsWindow(): void;
+  restoreMainWindow(): void;
 }
 
 interface Managers {
@@ -40,6 +41,9 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   ipcMain.handle(C.WINDOW.SHOW, () => {
     if (windowManager.mainWindow) {
       windowManager.mainWindow.show();
+      // [ADR-015] focus() is required — show() alone does not bring the
+      // window to the foreground on Windows.
+      windowManager.mainWindow.focus();
     }
     return true;
   });
@@ -88,12 +92,10 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
 
   ipcMain.handle(C.WINDOW.SET_TOP, (_event, enabled: boolean) => {
     windowManager.setDefaultAlwaysOnTop(enabled);
-    for (const win of [
-      windowManager.mainWindow,
-      windowManager.historyWindow,
-      windowManager.settingsWindow,
-    ]) {
-      if (win) win.setAlwaysOnTop(enabled);
+    // [ADR-015] Only apply to mainWindow — settings/history windows have
+    // their alwaysOnTop managed by the show/close lifecycle in WindowManager.
+    if (windowManager.mainWindow) {
+      windowManager.mainWindow.setAlwaysOnTop(enabled);
     }
     return { success: true };
   });
@@ -110,6 +112,8 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
 
   ipcMain.handle(C.WINDOW.HIDE_HISTORY, () => {
     windowManager.hideHistoryWindow();
+    // [ADR-015] Restore focus to main window after hiding history
+    windowManager.restoreMainWindow();
     return true;
   });
 
@@ -125,6 +129,8 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
 
   ipcMain.handle(C.WINDOW.HIDE_SETTINGS, () => {
     windowManager.hideSettingsWindow();
+    // [ADR-015] Restore focus to main window after hiding settings
+    windowManager.restoreMainWindow();
     return true;
   });
 

--- a/src/helpers/windowManager.ts
+++ b/src/helpers/windowManager.ts
@@ -75,17 +75,26 @@ class WindowManager {
         width: 520,
         height: 640,
         frame: false,
-        transparent: true,
+        // [ADR-015] Removed transparent:true — Tracer confirmed body/#root CSS
+        // backgrounds are opaque, so transparency was unused. transparent +
+        // skipTaskbar:false is a known-broken combination on Windows.
         alwaysOnTop: this._alwaysOnTop,
         resizable: true,
         minWidth: 400,
         minHeight: 500,
-        skipTaskbar: true,
+        // [ADR-015] Removed skipTaskbar:true — the app must show a taskbar
+        // icon so users can find and restore the window.
+        icon: this.getMainWindowIconPath(),
         movable: true,
         webPreferences: {
           nodeIntegration: false,
           contextIsolation: true,
           sandbox: true,
+          // [ADR-015] Disable background throttling so renderer timers (AI
+          // optimization setTimeout, model status polling) are not throttled
+          // when the main window is hidden. Without this, a 100ms delay
+          // becomes ~1s and transcription results can be lost.
+          backgroundThrottling: false,
           // [20260724_TS_BigBang_DirnameFix] Use app.getAppPath() instead of
           // __dirname so the path survives esbuild bundling.
           preload: path.join(app.getAppPath(), "dist-preload", "preload.js"),
@@ -169,6 +178,8 @@ class WindowManager {
 
     this.historyWindow.on("closed", () => {
       this.historyWindow = null;
+      // [ADR-015] Restore focus to main window so the app doesn't "disappear"
+      this.restoreMainWindow();
     });
 
     return this.historyWindow;
@@ -210,16 +221,22 @@ class WindowManager {
 
     this.settingsWindow.on("closed", () => {
       this.settingsWindow = null;
+      // [ADR-015] Restore focus to main window so the app doesn't "disappear"
+      this.restoreMainWindow();
     });
 
     return this.settingsWindow;
   }
 
   showHistoryWindow(): void {
+    // [ADR-015] Temporarily disable main window alwaysOnTop so the history
+    // window is not covered by the floating panel. Restored on close.
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.setAlwaysOnTop(false);
+    }
     const show = () => {
       this.historyWindow!.show();
       this.historyWindow!.focus();
-      this.historyWindow!.setAlwaysOnTop(this._alwaysOnTop);
     };
     if (this.historyWindow) {
       show();
@@ -241,10 +258,14 @@ class WindowManager {
   }
 
   showSettingsWindow(): void {
+    // [ADR-015] Temporarily disable main window alwaysOnTop so the settings
+    // window is not covered by the floating panel. Restored on close.
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.setAlwaysOnTop(false);
+    }
     const show = () => {
       this.settingsWindow!.show();
       this.settingsWindow!.focus();
-      this.settingsWindow!.setAlwaysOnTop(this._alwaysOnTop);
     };
     if (this.settingsWindow) {
       show();
@@ -263,6 +284,27 @@ class WindowManager {
     if (this.settingsWindow) {
       this.settingsWindow.close();
     }
+  }
+
+  // [ADR-015] Restore main window visibility, focus, and alwaysOnTop state.
+  // Called when a child window (settings/history) closes or hides, so the app
+  // doesn't appear to "disappear" after the child window is gone.
+  restoreMainWindow(): void {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.setAlwaysOnTop(this._alwaysOnTop);
+      this.mainWindow.show();
+      this.mainWindow.focus();
+    }
+  }
+
+  // [ADR-015] Dev/prod icon path resolution — mirrors tray.ts:getTrayIconPath()
+  // pattern. In production, assets live under process.resourcesPath (asar).
+  private getMainWindowIconPath(): string {
+    const isDev = process.env.NODE_ENV === "development";
+    if (isDev) {
+      return path.join(app.getAppPath(), "assets", "icon.png");
+    }
+    return path.join(process.resourcesPath, "assets", "icon.png");
   }
 
   closeAllWindows(): void {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -27,6 +27,7 @@
     "saveFailed": "Failed to save settings",
     "save": "Save Settings",
     "saving": "Saving...",
+    "saved": "Saved",
     "reset": "Reset",
     "close": "Close",
     "about": "About Murmur",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -27,6 +27,7 @@
     "saveFailed": "保存设置失败",
     "save": "保存设置",
     "saving": "保存中...",
+    "saved": "已保存",
     "reset": "重置",
     "close": "关闭",
     "about": "关于 Murmur",

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-import { Toaster } from "sonner";
+// [ADR-015] Use theme-aware wrapper instead of bare sonner, and position at
+// bottom-center so the toast never overlaps form content or action buttons.
+import { Toaster } from "./components/ui/sonner";
 import { useTranslation } from "react-i18next";
 import { Loader2, X } from "lucide-react";
 import { assertElectronAPI } from "./bootstrap/assertElectronAPI.js";
@@ -170,7 +172,7 @@ if (document.getElementById("settings-root") && assertElectronAPI()) {
   root.render(
     <React.Fragment>
       <SettingsPage />
-      <Toaster position="top-right" />
+      <Toaster position="bottom-center" />
     </React.Fragment>,
   );
 }

--- a/src/settings/sections/AIConfigSection.tsx
+++ b/src/settings/sections/AIConfigSection.tsx
@@ -1,6 +1,6 @@
 // [20260713_Fix_NoHardcodedChinese] All user-visible strings now go through
 // t() — no hardcoded Chinese remains in JSX.
-import type React from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Eye,
@@ -12,6 +12,7 @@ import {
   Save,
   ExternalLink,
   Sparkles,
+  Check,
 } from "lucide-react";
 import type { AICheckStatusResult } from "../../types/ipc";
 import type { SettingsState, ProviderPreset } from "../useSettings";
@@ -41,7 +42,7 @@ interface AIConfigSectionProps {
   // of an inline subset to prevent type drift when fields are added.
   testResult: AICheckStatusResult | null;
   testAIConfiguration: () => void;
-  saveSettings: () => void;
+  saveSettings: () => Promise<boolean>;
   saving: boolean;
   showQuickStart: boolean;
 }
@@ -65,6 +66,28 @@ export const AIConfigSection: React.FC<AIConfigSectionProps> = ({
   showQuickStart,
 }) => {
   const { t } = useTranslation();
+  // [ADR-015] savedFlash: briefly show "✓ 已保存" on the save button after
+  // a successful save. Only triggers when saveSettings returns true.
+  const [savedFlash, setSavedFlash] = useState(false);
+  // [CodeReview] Track timeout so it can be cleared on unmount to prevent
+  // React "state update on unmounted component" warning.
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSave = useCallback(async () => {
+    const ok = await saveSettings();
+    if (ok) {
+      setSavedFlash(true);
+      if (flashTimer.current) clearTimeout(flashTimer.current);
+      flashTimer.current = setTimeout(() => setSavedFlash(false), 1500);
+    }
+  }, [saveSettings]);
+
+  // [CodeReview] Cleanup: clear any pending flash timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (flashTimer.current) clearTimeout(flashTimer.current);
+    };
+  }, []);
 
   return (
     <div className="space-y-5">
@@ -497,20 +520,26 @@ export const AIConfigSection: React.FC<AIConfigSectionProps> = ({
         </button>
         <button
           type="button"
-          onClick={saveSettings}
+          onClick={handleSave}
           aria-label={t("settings.save", "保存设置")}
           disabled={saving}
-          className="flex items-center space-x-2 px-4 py-1.5 text-sm bg-[#0071e3] hover:bg-[#0077ed] text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className={`flex items-center space-x-2 px-4 py-1.5 text-sm text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+            savedFlash ? "bg-[#34c759]" : "bg-[#0071e3] hover:bg-[#0077ed]"
+          }`}
         >
           {saving ? (
             <Loader2 className="w-3 h-3 animate-spin" />
+          ) : savedFlash ? (
+            <Check className="w-3 h-3" />
           ) : (
             <Save className="w-3 h-3" />
           )}
           <span>
             {saving
               ? t("settings.saving", "保存中...")
-              : t("settings.save", "保存设置")}
+              : savedFlash
+                ? t("settings.saved", "已保存")
+                : t("settings.save", "保存设置")}
           </span>
         </button>
       </div>

--- a/src/settings/useSettings.ts
+++ b/src/settings/useSettings.ts
@@ -151,7 +151,9 @@ export function useSettings() {
   }, [t]);
 
   // --- 保存设置 ---
-  const saveSettings = useCallback(async () => {
+  // [ADR-015] Returns boolean so callers can show inline success feedback
+  // (savedFlash) only on actual success, not on the catch path.
+  const saveSettings = useCallback(async (): Promise<boolean> => {
     try {
       setSaving(true);
       if (window.electronAPI) {
@@ -199,18 +201,30 @@ export function useSettings() {
         );
 
         toast.success(t("settings.saveSuccess", "设置已保存"));
+        return true;
       }
+      return false;
     } catch (error) {
       console.error("Failed to save settings:", error);
       toast.error(t("settings.saveFailed", "保存设置失败"));
+      return false;
     } finally {
       setSaving(false);
     }
   }, [settings, t]);
 
   // --- 输入变更 ---
+  // [Fix] Auto-persist each setting immediately via setSetting — industry
+  // standard for settings pages (macOS System Preferences, VS Code, iOS
+  // Settings all apply changes instantly, no Save button). Previously only
+  // the AI Config tab's Save button called saveSettings(), so General tab
+  // settings (effects_enabled, theme, auto_paste, close_behavior) were stuck
+  // in React state and lost when the settings window was destroyed (Alt+F4).
   const handleInputChange = useCallback((key: string, value: unknown) => {
     setSettings((prev) => ({ ...prev, [key]: value }));
+    if (window.electronAPI?.setSetting) {
+      window.electronAPI.setSetting(key, value);
+    }
   }, []);
 
   // --- Provider presets ---

--- a/tests/unit/components/FileDropZone.test.tsx
+++ b/tests/unit/components/FileDropZone.test.tsx
@@ -16,9 +16,14 @@ describe("FileDropZone", () => {
       />,
     );
 
-    const dropZone = screen.getByText("点击选择音频文件或拖拽到此处").closest("div")!;
+    const dropZone = screen
+      .getByText("点击选择音频文件或拖拽到此处")
+      .closest("div")!;
     const file = new File(["audio"], "test.wav", { type: "audio/wav" });
-    Object.defineProperty(file, "path", { value: "/fake/test.wav", writable: false });
+    Object.defineProperty(file, "path", {
+      value: "/fake/test.wav",
+      writable: false,
+    });
 
     fireEvent.drop(dropZone, {
       dataTransfer: { files: [file] },
@@ -39,7 +44,9 @@ describe("FileDropZone", () => {
       />,
     );
 
-    const dropZone = screen.getByText("点击选择音频文件或拖拽到此处").closest("div")!;
+    const dropZone = screen
+      .getByText("点击选择音频文件或拖拽到此处")
+      .closest("div")!;
     const file = new File(["audio"], "test.wav", { type: "audio/wav" });
     // File in browser has no .path property — simulates non-Electron env
 

--- a/tests/unit/components/TranscriptionProgress.test.tsx
+++ b/tests/unit/components/TranscriptionProgress.test.tsx
@@ -43,7 +43,12 @@ describe("TranscriptionProgress", () => {
 
   it("shows progress bar with correct width for ASR with progressPct", () => {
     const { container } = render(
-      <TranscriptionProgress phase="asr" totalMs={60000} progressPct={50} onCancel={() => {}} />,
+      <TranscriptionProgress
+        phase="asr"
+        totalMs={60000}
+        progressPct={50}
+        onCancel={() => {}}
+      />,
     );
     expect(screen.getByText(/音频时长/)).toBeTruthy();
     expect(container.querySelector(".animate-indeterminate")).toBeNull();
@@ -53,7 +58,12 @@ describe("TranscriptionProgress", () => {
 
   it("shows progress bar without percentage text", () => {
     const { container } = render(
-      <TranscriptionProgress phase="asr" totalMs={5000} progressPct={50} onCancel={() => {}} />,
+      <TranscriptionProgress
+        phase="asr"
+        totalMs={5000}
+        progressPct={50}
+        onCancel={() => {}}
+      />,
     );
     expect(screen.getByText(/音频时长/)).toBeTruthy();
     expect(screen.queryByText(/50%/)).toBeNull();
@@ -72,7 +82,11 @@ describe("TranscriptionProgress", () => {
 
   it("shows progress bar for punc phase with progressPct", () => {
     const { container } = render(
-      <TranscriptionProgress phase="punc" progressPct={96} onCancel={() => {}} />,
+      <TranscriptionProgress
+        phase="punc"
+        progressPct={96}
+        onCancel={() => {}}
+      />,
     );
     expect(screen.getByText("标点恢复中")).toBeTruthy();
     const bar = container.querySelector("[style]");
@@ -81,7 +95,11 @@ describe("TranscriptionProgress", () => {
 
   it("shows progress bar for convert phase with progressPct", () => {
     const { container } = render(
-      <TranscriptionProgress phase="convert" progressPct={2} onCancel={() => {}} />,
+      <TranscriptionProgress
+        phase="convert"
+        progressPct={2}
+        onCancel={() => {}}
+      />,
     );
     expect(screen.getByText("格式转换中")).toBeTruthy();
     const bar = container.querySelector("[style]");
@@ -98,7 +116,11 @@ describe("TranscriptionProgress", () => {
 
   it("shows green checkmark and bar when done", () => {
     const { container } = render(
-      <TranscriptionProgress phase="done" progressPct={100} onCancel={() => {}} />,
+      <TranscriptionProgress
+        phase="done"
+        progressPct={100}
+        onCancel={() => {}}
+      />,
     );
     expect(screen.getByText("转录完成")).toBeTruthy();
     const bar = container.querySelector("[style]");
@@ -107,9 +129,7 @@ describe("TranscriptionProgress", () => {
   });
 
   it("shows fileName when provided", () => {
-    render(
-      <TranscriptionProgress fileName="test.m4a" onCancel={() => {}} />,
-    );
+    render(<TranscriptionProgress fileName="test.m4a" onCancel={() => {}} />);
     expect(screen.getByText("test.m4a")).toBeTruthy();
   });
 });

--- a/tests/unit/components/TranscriptionResult.test.tsx
+++ b/tests/unit/components/TranscriptionResult.test.tsx
@@ -113,17 +113,13 @@ describe("TranscriptionResult", () => {
   // --- New: rawText stacking ---
 
   it("shows blue AI card when rawText differs from text", () => {
-    render(
-      <TranscriptionResult text="优化后" rawText="原始文本" />,
-    );
+    render(<TranscriptionResult text="优化后" rawText="原始文本" />);
     expect(screen.getByText("优化后")).toBeTruthy();
     expect(screen.getByText("查看原文")).toBeTruthy();
   });
 
   it("does not show raw section when rawText equals text", () => {
-    render(
-      <TranscriptionResult text="same" rawText="same" />,
-    );
+    render(<TranscriptionResult text="same" rawText="same" />);
     expect(screen.queryByText("查看原文")).toBeNull();
   });
 
@@ -133,9 +129,7 @@ describe("TranscriptionResult", () => {
   });
 
   it("toggles raw text visibility on click", () => {
-    render(
-      <TranscriptionResult text="optimized" rawText="raw content" />,
-    );
+    render(<TranscriptionResult text="optimized" rawText="raw content" />);
     fireEvent.click(screen.getByText("查看原文"));
     expect(screen.getByText("raw content")).toBeTruthy();
     expect(screen.getByText("收起原文")).toBeTruthy();
@@ -144,16 +138,12 @@ describe("TranscriptionResult", () => {
   // --- New: isOptimizing ---
 
   it("shows loading state when isOptimizing is true", () => {
-    render(
-      <TranscriptionResult text="raw text" isOptimizing={true} />,
-    );
+    render(<TranscriptionResult text="raw text" isOptimizing={true} />);
     expect(screen.getByText("AI正在优化文本...")).toBeTruthy();
   });
 
   it("hides loading state when isOptimizing is false", () => {
-    render(
-      <TranscriptionResult text="raw text" isOptimizing={false} />,
-    );
+    render(<TranscriptionResult text="raw text" isOptimizing={false} />);
     expect(screen.queryByText("AI正在优化文本...")).toBeNull();
   });
 
@@ -200,9 +190,7 @@ describe("TranscriptionResult", () => {
 
   it("calls onAIOptimize fallback when processText unavailable", () => {
     const onAIOptimize = vi.fn().mockResolvedValue("优化结果");
-    render(
-      <TranscriptionResult text="original" onAIOptimize={onAIOptimize} />,
-    );
+    render(<TranscriptionResult text="original" onAIOptimize={onAIOptimize} />);
     // Without electronAPI, component should render without crash
     expect(screen.getByText("original")).toBeTruthy();
   });

--- a/tests/unit/useModelStatus.test.tsx
+++ b/tests/unit/useModelStatus.test.tsx
@@ -210,13 +210,11 @@ describe("useModelStatus hook", () => {
 
   it("reports an error stage when checkModelFiles returns success:false", async () => {
     const stub = makeElectronAPIStub({
-      checkModelFiles: vi
-        .fn()
-        .mockResolvedValue({
-          success: false,
-          models_downloaded: false,
-          missing_models: [],
-        }),
+      checkModelFiles: vi.fn().mockResolvedValue({
+        success: false,
+        models_downloaded: false,
+        missing_models: [],
+      }),
     });
     (globalThis.window as TestWindow).electronAPI = stub;
 

--- a/tests/unit/windowHandlers.test.ts
+++ b/tests/unit/windowHandlers.test.ts
@@ -53,6 +53,7 @@ type MockFn = ReturnType<typeof vi.fn>;
 interface MockWindow {
   hide: MockFn;
   show: MockFn;
+  focus: MockFn;
   minimize: MockFn;
   maximize: MockFn;
   unmaximize: MockFn;
@@ -76,6 +77,7 @@ interface MockWindowManager {
   showSettingsWindow: MockFn;
   closeSettingsWindow: MockFn;
   hideSettingsWindow: MockFn;
+  restoreMainWindow: MockFn;
   // [20260726_Tier3_WindowHandlersMigrate] Mutated per-test by the macOS
   // compat case to simulate OS-initiated unmaximize.
   _preMaximizeBounds?: Bounds | null;
@@ -95,6 +97,7 @@ describe("windowHandlers", () => {
     const mainWindow: MockWindow = {
       hide: vi.fn(),
       show: vi.fn(),
+      focus: vi.fn(),
       minimize: vi.fn(),
       maximize: vi.fn(),
       unmaximize: vi.fn(),
@@ -125,6 +128,7 @@ describe("windowHandlers", () => {
         showSettingsWindow: vi.fn(),
         closeSettingsWindow: vi.fn(),
         hideSettingsWindow: vi.fn(),
+        restoreMainWindow: vi.fn(),
       },
     };
 
@@ -151,9 +155,10 @@ describe("windowHandlers", () => {
     expect(result).toBe(true);
   });
 
-  it("show-window shows the main window", () => {
+  it("show-window shows and focuses the main window", () => {
     const result = ipcMain._handlers["show-window"]!();
     expect(managers.windowManager.mainWindow.show).toHaveBeenCalled();
+    expect(managers.windowManager.mainWindow.focus).toHaveBeenCalled();
     expect(result).toBe(true);
   });
 
@@ -259,7 +264,9 @@ describe("windowHandlers", () => {
     expect(result).toBe(true);
   });
 
-  it("set-always-on-top sets the flag on all windows", () => {
+  // [ADR-015] SET_TOP now only applies to mainWindow — settings/history
+  // windows have their alwaysOnTop managed by the show/close lifecycle.
+  it("set-always-on-top sets the flag only on main window", () => {
     const result = ipcMain._handlers["set-always-on-top"]!({}, true);
     expect(managers.windowManager.setDefaultAlwaysOnTop).toHaveBeenCalledWith(
       true,
@@ -267,12 +274,19 @@ describe("windowHandlers", () => {
     expect(
       managers.windowManager.mainWindow.setAlwaysOnTop,
     ).toHaveBeenCalledWith(true);
-    expect(
-      managers.windowManager.historyWindow.setAlwaysOnTop,
-    ).toHaveBeenCalledWith(true);
-    expect(
-      managers.windowManager.settingsWindow.setAlwaysOnTop,
-    ).toHaveBeenCalledWith(true);
     expect(result).toEqual({ success: true });
+  });
+
+  // [ADR-015] Hiding the settings window must restore focus to main window
+  it("hide-settings-window calls restoreMainWindow", () => {
+    ipcMain._handlers["hide-settings-window"]!();
+    expect(managers.windowManager.hideSettingsWindow).toHaveBeenCalled();
+    expect(managers.windowManager.restoreMainWindow).toHaveBeenCalled();
+  });
+
+  it("hide-history-window calls restoreMainWindow", () => {
+    ipcMain._handlers["hide-history-window"]!();
+    expect(managers.windowManager.hideHistoryWindow).toHaveBeenCalled();
+    expect(managers.windowManager.restoreMainWindow).toHaveBeenCalled();
   });
 });

--- a/tests/unit/windowManager-events.test.ts
+++ b/tests/unit/windowManager-events.test.ts
@@ -71,6 +71,7 @@ interface BrowserWindowInstance {
   maximize: ReturnType<typeof vi.fn>;
   isMaximized: ReturnType<typeof vi.fn>;
   isDestroyed: ReturnType<typeof vi.fn>;
+  setAlwaysOnTop: ReturnType<typeof vi.fn>;
 }
 
 // [20260726_Tier32_WindowManagerEvents] event-name -> listener. The
@@ -110,6 +111,7 @@ describe("windowManager — real module execution with mocked electron", () => {
       this.loadFile = vi.fn(() => Promise.resolve());
       this.focus = vi.fn();
       this.show = vi.fn();
+      this.setAlwaysOnTop = vi.fn();
       this.maximize = vi.fn();
       this.isMaximized = vi.fn(() => false);
       this.isDestroyed = vi.fn(() => false);
@@ -211,43 +213,84 @@ describe("windowManager — real module execution with mocked electron", () => {
     );
   });
 
-  it("showHistoryWindow uses current alwaysOnTop value", async () => {
+  // [ADR-015] showSettingsWindow now disables main window alwaysOnTop
+  // temporarily so settings is not covered by the floating panel.
+  it("showSettingsWindow disables main window alwaysOnTop", async () => {
     const WindowManager = await loadWindowManager();
     const wm = new WindowManager();
-    wm.setDefaultAlwaysOnTop(false);
     process.env.NODE_ENV = "development";
-    await wm.createHistoryWindow();
-
-    const setAlwaysOnTopSpy = vi.fn();
-    // [20260726_Tier32_WindowManagerEvents] historyWindow is a public field
-    // typed as Electron.BrowserWindow | null; non-null after
-    // createHistoryWindow resolved. Assign the spy via a structural cast so
-    // the source's readonly-ish surface accepts the override.
-    (
-      wm.historyWindow as unknown as {
-        setAlwaysOnTop: typeof setAlwaysOnTopSpy;
-      }
-    ).setAlwaysOnTop = setAlwaysOnTopSpy;
-
-    wm.showHistoryWindow();
-    expect(setAlwaysOnTopSpy).toHaveBeenCalledWith(false);
-  });
-
-  it("showSettingsWindow uses current alwaysOnTop value", async () => {
-    const WindowManager = await loadWindowManager();
-    const wm = new WindowManager();
-    wm.setDefaultAlwaysOnTop(false);
-    process.env.NODE_ENV = "development";
+    await wm.createMainWindow();
     await wm.createSettingsWindow();
 
-    const setAlwaysOnTopSpy = vi.fn();
-    (
-      wm.settingsWindow as unknown as {
-        setAlwaysOnTop: typeof setAlwaysOnTopSpy;
-      }
-    ).setAlwaysOnTop = setAlwaysOnTopSpy;
-
     wm.showSettingsWindow();
-    expect(setAlwaysOnTopSpy).toHaveBeenCalledWith(false);
+    expect(wm.mainWindow!.setAlwaysOnTop).toHaveBeenCalledWith(false);
+  });
+
+  // [ADR-015] showHistoryWindow also disables main window alwaysOnTop.
+  it("showHistoryWindow disables main window alwaysOnTop", async () => {
+    const WindowManager = await loadWindowManager();
+    const wm = new WindowManager();
+    process.env.NODE_ENV = "development";
+    await wm.createMainWindow();
+    await wm.createHistoryWindow();
+
+    wm.showHistoryWindow();
+    expect(wm.mainWindow!.setAlwaysOnTop).toHaveBeenCalledWith(false);
+  });
+
+  // [ADR-015] backgroundThrottling must be false so renderer timers are not
+  // throttled when the main window is hidden — otherwise AI optimization
+  // setTimeout(100ms) stalls to ~1s and transcription results can be lost.
+  it("main window has backgroundThrottling: false in webPreferences", async () => {
+    const WindowManager = await loadWindowManager();
+    const wm = new WindowManager();
+    process.env.NODE_ENV = "development";
+    await wm.createMainWindow();
+
+    expect(MockBrowserWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webPreferences: expect.objectContaining({
+          backgroundThrottling: false,
+        }),
+      }),
+    );
+  });
+
+  // [ADR-015] Closing the settings window must restore focus to the main
+  // window so the app doesn't appear to "disappear".
+  it("settings window closed handler restores main window focus", async () => {
+    const WindowManager = await loadWindowManager();
+    const wm = new WindowManager();
+    process.env.NODE_ENV = "development";
+    await wm.createMainWindow();
+    await wm.createSettingsWindow();
+
+    // Simulate settings window close
+    expect(typeof onHandlers.closed).toBe("function");
+    onHandlers.closed!();
+
+    expect(wm.settingsWindow).toBeNull();
+    expect(wm.mainWindow!.show).toHaveBeenCalled();
+    expect(wm.mainWindow!.focus).toHaveBeenCalled();
+    // [CodeReview] restoreMainWindow must also restore alwaysOnTop
+    expect(wm.mainWindow!.setAlwaysOnTop).toHaveBeenCalled();
+  });
+
+  // [ADR-015] Same for history window.
+  it("history window closed handler restores main window focus", async () => {
+    const WindowManager = await loadWindowManager();
+    const wm = new WindowManager();
+    process.env.NODE_ENV = "development";
+    await wm.createMainWindow();
+    await wm.createHistoryWindow();
+
+    expect(typeof onHandlers.closed).toBe("function");
+    onHandlers.closed!();
+
+    expect(wm.historyWindow).toBeNull();
+    expect(wm.mainWindow!.show).toHaveBeenCalled();
+    expect(wm.mainWindow!.focus).toHaveBeenCalled();
+    // [CodeReview] restoreMainWindow must also restore alwaysOnTop
+    expect(wm.mainWindow!.setAlwaysOnTop).toHaveBeenCalled();
   });
 });

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,6 +8,13 @@ export default defineConfig({
   integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],
+    // [Fix] Explicitly empty PostCSS config prevents Vite from walking up
+    // to the repo root postcss.config.ts (which references @tailwindcss/postcss,
+    // not installed in website/node_modules). Tailwind v4 is handled by the
+    // Vite plugin above — PostCSS is not needed.
+    css: {
+      postcss: {},
+    },
   },
   i18n: {
     defaultLocale: "en",


### PR DESCRIPTION
## Summary

Three independent fixes bundled in one PR:

### 1. Website deployment fix (`eef98f2`)
Vite PostCSS config resolution walks up the directory tree. The website had no `postcss.config`, so it found the repo root `postcss.config.ts` referencing `@tailwindcss/postcss` (not installed in website). Added `css.postcss: {}` to `astro.config.mjs`.

### 2. Window lifecycle UX overhaul — ADR-015 (`475ed6b`)
Fixes 6 user-reported issues:
- `backgroundThrottling: false` — hidden window no longer stalls AI timers
- Remove `transparent` + `skipTaskbar` — taskbar shows brand icon
- `restoreMainWindow()` on child close/hide — focus returns to main window
- `WINDOW.SHOW` adds `.focus()` — restore from tray brings window to foreground
- Toggle main `alwaysOnTop` when child windows open — no z-order conflict
- Remove global Escape→hideWindow — Escape in text fields no longer hides window
- `TrayManager(logger)` — tray creation errors no longer silently swallowed
- `handleInputChange` auto-persists — settings auto-save (industry standard)
- Toast moved to `bottom-center` — no longer overlaps form content
- `saveSettings` returns `Promise<boolean>` — green flash only on success

### 3. Prettier formatting (`d6fb984`)
Auto-formatted docs and test files.

## Verification
- TypeScript: 0 errors
- ESLint: 0 errors, 0 warnings
- Prettier: all formatted
- Tests: 1100 passed (23 window tests, 7 new)
- Architect review: APPROVED
- Website build: passes locally (4 pages, 1.22s)

## Test plan
- [ ] Taskbar shows Murmur brand icon
- [ ] Record → hide window → restore → transcription intact
- [ ] Open settings → close → main window regains focus
- [ ] Press Escape in text field → clears input, window stays
- [ ] Toggle effects → close settings (Alt+F4) → reopen → still ON
- [ ] Save AI config → green flash + bottom-center toast
- [ ] Website deploys successfully on merge to main