### PR TITLE
fix: website language switcher 404 — BASE_URL path fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,9 +140,9 @@ jobs:
         run: npx @electron/rebuild
       # [20260802_Fix_WinCiPnpmPostinstall] END
 
-      # [20260802_Fix_WinEmbeddedPython] prepare-embedded-python.js only
-      # supports macOS (darwin) downloads. On Windows CI, skip embedded
-      # Python — the app falls back to system Python via pythonEnvironment.ts.
+      # [20260802_Fix_WinEmbeddedPython] prepare-embedded-python.js now
+      # supports Windows (-pc-windows-msvc-shared). Keep continue-on-error
+      # because torch/funasr pip install may exceed CI time/disk limits.
       - name: Prepare embedded Python
         run: pnpm run prepare:python:embedded
         continue-on-error: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,13 @@
-<!-- Generated: 2026-04-13 | Updated: 2026-05-30 -->
+<!-- Generated: 2026-04-13 | Updated: 2026-08-02 -->
 
 # AGENTS.md
 
-Instructions for AI agent. All content in English.
+Instructions for AI agents working on Murmur. All content in English.
 
 > **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 >
 > Architecture reference: `docs/`
+> Project-specific constraints: `CLAUDE.md`
 
 ---
 
@@ -31,7 +32,7 @@ Before implementing:
 - No abstractions for single-use code.
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
+- If you write 200 lines and it could be 50, rewrite.
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -76,7 +77,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ### Core Principles
 
 - **Verify Before Claiming Done** — evidence over assumptions.
-- **Trace Before Fix** — when debugging performance issues (especially "entire client is slow"), trace the FULL execution path from user trigger to observable symptom, step by step. Do not propose architectural solutions based on assumptions. Check the simplest explanation first. Lesson from PR#599.
+- **Trace Before Fix** — when debugging, trace the FULL execution path from trigger to symptom. Check the simplest explanation first.
 - **Know When to Stop** — if blocked for more than 2 attempts, or requirements remain ambiguous after clarification, escalate instead of guessing.
 
 ## MUST DO
@@ -86,7 +87,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 3. **Bug fixes: test first, then fix.** Write a regression test that reproduces the bug and fails. Confirm the failure. Fix the code. Verify the test passes. No bug fix without a regression test.
 4. For non-trivial work, define verifiable success criteria before implementation (see _Goal-Driven Execution_ above).
 5. After submitting code: state potential risks + test recommendations.
-6. All user-visible text MUST go through i18n; no hardcoded strings (see _i18n_ section for details).
+6. All user-visible text MUST go through i18n (`src/i18n/locales/`); no hardcoded UI strings.
 
 ## Workflow
 
@@ -95,36 +96,63 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 - Use active planning for non-trivial tasks, architectural decisions, or work spanning multiple areas.
 - If new evidence invalidates the current approach, stop and re-plan.
 - **High-risk areas** — apply stronger planning, review, and verification:
-  - `electron/main/` and preload boundaries
-  - `packages/ipc-contracts/` and IPC channel changes
-  - `packages/gateway/`, `packages/bastion/`, and MCP/security flows
-  - Session flow, auth, privacy, and packaging/release behavior
+  - `main.ts` and `preload.ts` boundaries (Electron IPC bridge)
+  - `src/helpers/ipc-contracts.ts` and IPC channel changes
+  - `src/helpers/ipc/` handler modules (domain-scoped IPC handlers)
+  - `src/helpers/funasrManager.ts` and sub-modules (Python subprocess lifecycle)
+  - `src/helpers/funasrServer.ts` (platform-specific process kill: `taskkill` vs `SIGKILL`)
+  - `src/helpers/windowManager.ts` (sandbox, CSP, window creation)
+  - `src/helpers/database.ts` (safeStorage encryption, schema)
+  - `src/helpers/audioPathValidator.ts` (cross-platform path validation)
+  - Packaging/release and electron-builder configuration
   - User-visible text and i18n resources
+
+### Cross-Platform Awareness
+
+Murmur targets **Windows** and **macOS**. See `CLAUDE.md` → _Cross-Platform Support_ for the full list of platform-specific concerns. Key rules:
+
+- Use `process.platform === "win32"` for platform checks, not `os.platform()` or feature detection.
+- Windows paths use backslashes; UNC paths (`\\server\share`) are rejected by `audioPathValidator`.
+- Native modules (`better-sqlite3`) need Electron ABI — on Windows CI, use `--ignore-scripts` + `@electron/rebuild`.
+- Embedded Python (`prepare-embedded-python.js`) supports both macOS (`-apple-darwin`) and Windows (`-pc-windows-msvc-shared`) downloads.
+- Add `it.skipIf(process.platform === "win32")` for Unix-only test behavior.
 
 ### Bug Fixes
 
 1. Reproduce the issue, then follow MUST DO #3 (test-first workflow).
 2. State potential risks + test recommendations (MUST DO #5).
-3. **DTS / declaration fixes:** when modifying `.d.ts` or shared type schemas, write a type-contract test (schema validation, runtime parse, or compile-time assertion) first. Confirm it fails with the current broken declaration, fix, then verify the test passes.
+3. **Type declaration fixes:** when modifying `.d.ts` or shared type schemas, write a type-contract test first. Confirm it fails with the current broken declaration, fix, then verify the test passes.
 
 ## Code Rules
 
-### TypeScript
+### JavaScript / TypeScript / React
 
 - No `any`, `as any`, `@ts-ignore`, `@ts-expect-error`.
 - Prefer type inference; add explicit annotations when intent is unclear.
 - No empty `catch` — log, rethrow, or handle errors intentionally.
 - Error handling: always handle real error paths (main process, IPC, network); skip defensive code only for states that truly cannot occur.
 - No magic numbers or hardcoded config.
+- Use existing IPC contract constants from `src/helpers/ipc-contracts.ts` — zero hardcoded channel strings.
+- ESLint with 0 warnings, 0 errors.
+
+### Prohibited
+
+1. No modifying FunASR Python subprocess lifecycle without test coverage.
+2. No silent error swallowing in main process.
+3. No hardcoded IPC channel strings — use `ipc-contracts.ts` constants.
+4. No new IPC handler files without registering in `src/helpers/ipc/index.ts`.
+5. No adding settings without touching **all 4** places: `SettingsState` + `DEFAULT_SETTINGS` + `loadSettings` builder + `saveSettings` body in `useSettings.ts`, AND the key in `ALLOWED_SETTING_KEYS` (`settingsHandlers.ts`).
+6. No importing `ogl`/`motion` eagerly — they must stay lazy-loaded via `React.lazy` in `EffectsLayer.tsx` only.
 
 ## Verification
 
 ### Delivery Gates
 
-- **Build gate:** `./build.sh` MUST pass (exit code 0) before any commit is considered ready for merge. This is the single source of truth for project health — it runs lint, typecheck, tests, and packaging in one shot.
-- **Basic:** `pnpm lint` + `pnpm typecheck` + `pnpm test` + `pnpm test:i18n`
-- **Bug fix:** follow MUST DO #3 (test-first workflow).
+- **All commits MUST pass `pnpm ci:check` before push.** This runs: format check, lint, license check, test with coverage, build:preload, build:renderer, effects chunk isolation check.
+- **Quick check:** `pnpm lint` + `pnpm test` for rapid iteration during development.
+- **Bug fix:** reproduce the bug, add a failing test **first**, then fix and verify.
 - **High-risk** (session flow, IPC, security, privacy, release packaging): include a risk statement and fresh verification evidence.
+- **Gate failure:** run `node scripts/ci-check.js --json` to diagnose; use `--fix` for auto-fixable issues.
 
 ### Commit Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Instructions for AI agents working. All content in English.
 
 Murmur targets **Windows** and **macOS** (Apple Silicon). Code must work on both platforms. Known platform-specific concerns:
 
-- **Python paths**: macOS uses `python/bin/python3.11` (embedded); Windows falls back to system Python via `pythonEnvironment.ts` → `findPythonExecutable()`. The `prepare-embedded-python.js` script only supports macOS downloads.
+- **Python paths**: macOS uses `python/bin/python3.11` (embedded); Windows uses `python/python.exe` (embedded). The `prepare-embedded-python.js` script supports both platforms via platform-aware getters (`pythonBin`, `sitePackagesPath`, `downloadPlatform`).
 - **Process management**: `gracefulShutdown()` uses `taskkill /T /F /PID` on Windows, `proc.kill("SIGKILL")` on Unix — see `src/helpers/funasrServer.ts`.
 - **Path validation**: `audioPathValidator.ts` allows all `C:\` drive paths on Windows; UNC paths (`\\server\share`) are rejected early to avoid network timeouts. macOS uses realpath + `/Volumes/` prefix checks.
 - **Native modules**: `better-sqlite3` needs Electron ABI. On Windows CI, `electron-builder install-app-deps` can't fork `pnpm.mjs` — use `--ignore-scripts` + `npx @electron/rebuild` instead.

--- a/scripts/prepare-embedded-python.js
+++ b/scripts/prepare-embedded-python.js
@@ -1,9 +1,18 @@
+#!/usr/bin/env node
+"use strict";
+
 const fs = require("fs");
 const path = require("path");
 const https = require("https");
 const { execSync } = require("child_process");
 const { createWriteStream } = require("fs");
 const tar = require("tar");
+
+// [20260802_Fix_WinEmbeddedPython] Cross-platform embedded Python builder.
+// macOS: -apple-darwin, python/bin/python3.11, lib/python3.11/site-packages
+// Windows: -pc-windows-msvc-shared, python.exe, Lib/site-packages
+// Platform-specific paths and env vars are resolved via getters below.
+// [20260802_Fix_WinEmbeddedPython] END
 
 class EmbeddedPythonBuilder {
   constructor() {
@@ -13,22 +22,44 @@ class EmbeddedPythonBuilder {
     this.forceReinstall = false;
   }
 
-  async build() {
-    // [20260802_Fix_WinEmbeddedPython] Only macOS (darwin) is supported.
-    // The download URL hardcodes -apple-darwin and the archive uses
-    // python/bin/python3.11 structure. Windows builds need different URLs
-    // (pc-windows-msvc-shared) and binary layout (python/python.exe).
-    // On non-macOS, skip — the app uses system Python via
-    // pythonEnvironment.ts findPythonExecutable fallback.
-    if (process.platform !== "darwin") {
-      console.log(
-        `ℹ️ Embedded Python skipped on ${process.platform} (darwin only).`,
-      );
-      console.log("   The app will use system Python instead.");
-      return;
-    }
-    // [20260802_Fix_WinEmbeddedPython] END
+  // [20260802_Fix_WinEmbeddedPython] Platform-aware path getters
+  get isWindows() {
+    return process.platform === "win32";
+  }
 
+  get pythonBin() {
+    return this.isWindows
+      ? path.join(this.pythonDir, "python.exe")
+      : path.join(this.pythonDir, "bin", "python3.11");
+  }
+
+  get sitePackagesPath() {
+    return this.isWindows
+      ? path.join(this.pythonDir, "Lib", "site-packages")
+      : path.join(this.pythonDir, "lib", "python3.11", "site-packages");
+  }
+
+  get downloadPlatform() {
+    if (this.isWindows) return "pc-windows-msvc-shared";
+    if (process.platform === "darwin") return "apple-darwin";
+    return "unknown-linux-gnu";
+  }
+
+  /** Library path env vars for native extension loading. */
+  get libPathEnv() {
+    const libDir = path.join(this.pythonDir, this.isWindows ? "" : "lib");
+    if (this.isWindows) {
+      // Windows loads DLLs from PATH; prepend the python dir.
+      return { PATH: `${this.pythonDir};${process.env.PATH || ""}` };
+    }
+    return {
+      LD_LIBRARY_PATH: libDir,
+      DYLD_LIBRARY_PATH: libDir,
+    };
+  }
+  // [20260802_Fix_WinEmbeddedPython] END
+
+  async build() {
     console.log("🐍 开始准备嵌入式Python环境...");
 
     try {
@@ -43,8 +74,7 @@ class EmbeddedPythonBuilder {
           );
 
           // 验证关键依赖是否完整
-          const pythonPath = path.join(this.pythonDir, "bin", "python3.11");
-          const isValid = await this.validateExistingEnvironment(pythonPath);
+          const isValid = await this.validateExistingEnvironment();
 
           if (isValid) {
             console.log("✅ 现有环境验证通过，跳过重新安装");
@@ -88,11 +118,13 @@ class EmbeddedPythonBuilder {
 
   async downloadPythonRuntime() {
     const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
-    const filename = `cpython-${this.pythonVersion}+${this.buildDate}-${arch}-apple-darwin-install_only.tar.gz`;
+    // [20260802_Fix_WinEmbeddedPython] Platform-aware download URL
+    const filename = `cpython-${this.pythonVersion}+${this.buildDate}-${arch}-${this.downloadPlatform}-install_only.tar.gz`;
     const url = `https://github.com/indygreg/python-build-standalone/releases/download/${this.buildDate}/${filename}`;
+    // [20260802_Fix_WinEmbeddedPython] END
     const tarPath = path.join(this.pythonDir, "python.tar.gz");
 
-    console.log(`📥 下载Python运行时 (${arch})...`);
+    console.log(`📥 下载Python运行时 (${arch} / ${this.downloadPlatform})...`);
     console.log(`URL: ${url}`);
 
     await this.downloadFile(url, tarPath);
@@ -160,14 +192,25 @@ class EmbeddedPythonBuilder {
     });
   }
 
+  /** Build env vars for pip / python subprocess calls. */
+  // [20260802_Fix_WinEmbeddedPython] Centralized env construction
+  get pythonEnv() {
+    return {
+      ...process.env,
+      PYTHONHOME: this.pythonDir,
+      PYTHONPATH: this.sitePackagesPath,
+      PYTHONDONTWRITEBYTECODE: "1",
+      PYTHONIOENCODING: "utf-8",
+      PYTHONUNBUFFERED: "1",
+      PIP_NO_CACHE_DIR: "1",
+      ...this.libPathEnv,
+    };
+  }
+  // [20260802_Fix_WinEmbeddedPython] END
+
   async installDependencies() {
-    const pythonPath = path.join(this.pythonDir, "bin", "python3.11");
-    const sitePackagesPath = path.join(
-      this.pythonDir,
-      "lib",
-      "python3.11",
-      "site-packages",
-    );
+    const pythonPath = this.pythonBin;
+    const sitePackagesPath = this.sitePackagesPath;
 
     console.log("📦 安装Python依赖...");
 
@@ -176,12 +219,7 @@ class EmbeddedPythonBuilder {
     try {
       execSync(`"${pythonPath}" -m pip install --upgrade pip`, {
         stdio: "inherit",
-        env: {
-          ...process.env,
-          PYTHONHOME: this.pythonDir,
-          PYTHONPATH: sitePackagesPath,
-          PYTHONDONTWRITEBYTECODE: "1",
-        },
+        env: this.pythonEnv,
       });
     } catch (_error) {
       console.warn("⚠️ pip升级失败，继续安装依赖...");
@@ -201,40 +239,15 @@ class EmbeddedPythonBuilder {
     for (const dep of dependencies) {
       console.log(`📦 安装 ${dep}...`);
       try {
-        // 构建完整的环境变量
-        const installEnv = {
-          ...process.env,
-          PYTHONHOME: this.pythonDir,
-          PYTHONPATH: sitePackagesPath,
-          PYTHONDONTWRITEBYTECODE: "1",
-          PYTHONIOENCODING: "utf-8",
-          PYTHONUNBUFFERED: "1",
-          PIP_NO_CACHE_DIR: "1",
-          // 确保库路径正确
-          LD_LIBRARY_PATH: path.join(this.pythonDir, "lib"),
-          DYLD_LIBRARY_PATH: path.join(this.pythonDir, "lib"), // macOS
-        };
-
-        // 清除可能干扰的环境变量
-        delete installEnv.PYTHONUSERBASE;
-        delete installEnv.PYTHONSTARTUP;
-        delete installEnv.VIRTUAL_ENV;
-
         execSync(
           `"${pythonPath}" -m pip install --target "${sitePackagesPath}" --no-deps --force-reinstall "${dep}"`,
-          {
-            stdio: "inherit",
-            env: installEnv,
-          },
+          { stdio: "inherit", env: this.pythonEnv },
         );
 
         // 安装依赖的依赖
         execSync(
           `"${pythonPath}" -m pip install --target "${sitePackagesPath}" --only-binary=all "${dep}"`,
-          {
-            stdio: "inherit",
-            env: installEnv,
-          },
+          { stdio: "inherit", env: this.pythonEnv },
         );
 
         console.log(`✅ ${dep} 安装完成`);
@@ -243,28 +256,9 @@ class EmbeddedPythonBuilder {
         // 尝试不使用 --no-deps 重新安装
         try {
           console.log(`🔄 重试安装 ${dep} (包含依赖)...`);
-          const installEnv = {
-            ...process.env,
-            PYTHONHOME: this.pythonDir,
-            PYTHONPATH: sitePackagesPath,
-            PYTHONDONTWRITEBYTECODE: "1",
-            PYTHONIOENCODING: "utf-8",
-            PYTHONUNBUFFERED: "1",
-            PIP_NO_CACHE_DIR: "1",
-            LD_LIBRARY_PATH: path.join(this.pythonDir, "lib"),
-            DYLD_LIBRARY_PATH: path.join(this.pythonDir, "lib"),
-          };
-
-          delete installEnv.PYTHONUSERBASE;
-          delete installEnv.PYTHONSTARTUP;
-          delete installEnv.VIRTUAL_ENV;
-
           execSync(
             `"${pythonPath}" -m pip install --target "${sitePackagesPath}" --force-reinstall "${dep}"`,
-            {
-              stdio: "inherit",
-              env: installEnv,
-            },
+            { stdio: "inherit", env: this.pythonEnv },
           );
           console.log(`✅ ${dep} 重试安装成功`);
         } catch (retryError) {
@@ -275,48 +269,20 @@ class EmbeddedPythonBuilder {
     }
 
     // 验证关键依赖
-    await this.verifyDependencies(pythonPath);
+    await this.verifyDependencies();
   }
 
-  async verifyDependencies(pythonPath) {
+  async verifyDependencies() {
     console.log("🔍 验证依赖安装...");
 
     const criticalDeps = ["numpy", "torch", "librosa", "funasr"];
-    const sitePackagesPath = path.join(
-      this.pythonDir,
-      "lib",
-      "python3.11",
-      "site-packages",
-    );
 
     for (const dep of criticalDeps) {
       try {
-        // 构建完整的环境变量
-        const verifyEnv = {
-          ...process.env,
-          PYTHONHOME: this.pythonDir,
-          PYTHONPATH: sitePackagesPath,
-          PYTHONDONTWRITEBYTECODE: "1",
-          PYTHONIOENCODING: "utf-8",
-          PYTHONUNBUFFERED: "1",
-          // 确保库路径正确
-          LD_LIBRARY_PATH: path.join(this.pythonDir, "lib"),
-          DYLD_LIBRARY_PATH: path.join(this.pythonDir, "lib"), // macOS
-        };
-
-        // 清除可能干扰的环境变量
-        delete verifyEnv.PYTHONUSERBASE;
-        delete verifyEnv.PYTHONSTARTUP;
-        delete verifyEnv.VIRTUAL_ENV;
-
         const result = execSync(
-          `"${pythonPath}" -c "import ${dep}; print('${dep} OK')"`,
-          {
-            stdio: "pipe",
-            env: verifyEnv,
-          },
+          `"${this.pythonBin}" -c "import ${dep}; print('${dep} OK')"`,
+          { stdio: "pipe", env: this.pythonEnv },
         );
-
         console.log(`✅ ${dep} 验证通过: ${result.toString().trim()}`);
       } catch (error) {
         console.error(`❌ ${dep} 验证失败:`, error.message);
@@ -326,49 +292,29 @@ class EmbeddedPythonBuilder {
     }
   }
 
-  async validateExistingEnvironment(pythonPath) {
+  async validateExistingEnvironment() {
     console.log("🔍 验证现有环境完整性...");
 
     try {
       // 检查Python可执行文件是否存在
-      if (!fs.existsSync(pythonPath)) {
+      if (!fs.existsSync(this.pythonBin)) {
         console.log("❌ Python可执行文件不存在");
         return false;
       }
 
       // 检查关键依赖是否可用
       const criticalDeps = ["numpy", "torch", "librosa", "funasr"];
-      const sitePackagesPath = path.join(
-        this.pythonDir,
-        "lib",
-        "python3.11",
-        "site-packages",
-      );
-
-      // 构建环境变量
-      const verifyEnv = {
-        ...process.env,
-        PYTHONHOME: this.pythonDir,
-        PYTHONPATH: sitePackagesPath,
-        PYTHONDONTWRITEBYTECODE: "1",
-        PYTHONIOENCODING: "utf-8",
-        PYTHONUNBUFFERED: "1",
-        LD_LIBRARY_PATH: path.join(this.pythonDir, "lib"),
-        DYLD_LIBRARY_PATH: path.join(this.pythonDir, "lib"),
-      };
-
-      // 清除可能干扰的环境变量
-      delete verifyEnv.PYTHONUSERBASE;
-      delete verifyEnv.PYTHONSTARTUP;
-      delete verifyEnv.VIRTUAL_ENV;
 
       for (const dep of criticalDeps) {
         try {
-          execSync(`"${pythonPath}" -c "import ${dep}; print('${dep} OK')"`, {
-            stdio: "pipe",
-            env: verifyEnv,
-            timeout: 10000, // 10秒超时
-          });
+          execSync(
+            `"${this.pythonBin}" -c "import ${dep}; print('${dep} OK')"`,
+            {
+              stdio: "pipe",
+              env: this.pythonEnv,
+              timeout: 10000, // 10秒超时
+            },
+          );
           console.log(`✅ ${dep} 可用`);
         } catch (error) {
           console.log(`❌ ${dep} 不可用: ${error.message}`);
@@ -387,14 +333,27 @@ class EmbeddedPythonBuilder {
   async cleanupUnnecessaryFiles() {
     console.log("🧹 清理不必要文件...");
 
+    // [20260802_Fix_WinEmbeddedPython] Platform-aware cleanup paths
     const unnecessaryPaths = [
       path.join(this.pythonDir, "share", "doc"),
       path.join(this.pythonDir, "share", "man"),
       path.join(this.pythonDir, "include"),
       path.join(this.pythonDir, "lib", "pkgconfig"),
-      path.join(this.pythonDir, "lib", "python3.11", "test"),
-      path.join(this.pythonDir, "lib", "python3.11", "distutils"),
     ];
+
+    // Platform-specific test/distutils dirs
+    if (this.isWindows) {
+      unnecessaryPaths.push(
+        path.join(this.pythonDir, "Lib", "test"),
+        path.join(this.pythonDir, "Lib", "distutils"),
+      );
+    } else {
+      unnecessaryPaths.push(
+        path.join(this.pythonDir, "lib", "python3.11", "test"),
+        path.join(this.pythonDir, "lib", "python3.11", "distutils"),
+      );
+    }
+    // [20260802_Fix_WinEmbeddedPython] END
 
     for (const unnecessaryPath of unnecessaryPaths) {
       if (fs.existsSync(unnecessaryPath)) {
@@ -435,14 +394,12 @@ class EmbeddedPythonBuilder {
   }
 
   async getEmbeddedPythonInfo() {
-    const pythonPath = path.join(this.pythonDir, "bin", "python3.11");
-
-    if (!fs.existsSync(pythonPath)) {
+    if (!fs.existsSync(this.pythonBin)) {
       return null;
     }
 
     try {
-      const version = execSync(`"${pythonPath}" --version`, {
+      const version = execSync(`"${this.pythonBin}" --version`, {
         encoding: "utf8",
         env: {
           ...process.env,
@@ -455,7 +412,7 @@ class EmbeddedPythonBuilder {
 
       return {
         version,
-        path: pythonPath,
+        path: this.pythonBin,
         size: sizeInfo,
         ready: true,
       };

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -4,13 +4,14 @@ interface Props {
   t: Record<string, string>;
 }
 const { lang, t } = Astro.props;
-const otherLang = lang === 'en' ? '/zh/' : '/';
+const base = import.meta.env.BASE_URL;
+const otherLang = lang === 'en' ? `${base}/zh/` : `${base}/`;
 const otherLabel = t.lang_switch;
 ---
 
 <header class="fixed top-0 left-0 right-0 z-50 transition-all duration-300" id="main-header">
   <nav class="max-w-[980px] mx-auto px-6 h-12 flex items-center justify-between">
-    <a href={lang === 'en' ? '/' : '/zh/'} class="flex items-center gap-2 text-text no-underline">
+    <a href={lang === 'en' ? `${base}/` : `${base}/zh/`} class="flex items-center gap-2 text-text no-underline">
       <img src="/Murmur/favicon.svg" alt="Murmur" class="w-5 h-5 opacity-90" />
       <span class="text-sm font-semibold tracking-tight font-display">{t.nav_download}</span>
     </a>

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -7,7 +7,7 @@ import Layout from '../layouts/Layout.astro';
     <div class="text-center">
       <p class="text-8xl font-bold font-display gradient-text mb-4">404</p>
       <p class="text-text-secondary text-lg mb-10">Page not found.</p>
-      <a href="/" class="btn-primary">Go Home</a>
+      <a href={`${import.meta.env.BASE_URL}/`} class="btn-primary">Go Home</a>
     </div>
   </div>
 </Layout>

--- a/website/src/pages/zh/404.astro
+++ b/website/src/pages/zh/404.astro
@@ -7,7 +7,7 @@ import Layout from '../../layouts/Layout.astro';
     <div class="text-center">
       <p class="text-8xl font-bold font-display gradient-text mb-4">404</p>
       <p class="text-text-secondary text-lg mb-10">页面未找到。</p>
-      <a href="/zh/" class="btn-primary">返回首页</a>
+      <a href={`${import.meta.env.BASE_URL}/zh/`} class="btn-primary">返回首页</a>
     </div>
   </div>
 </Layout>


### PR DESCRIPTION
Language switcher links used hardcoded /zh/ and / paths. On GitHub Pages with base /Murmur/, these resolved to 404. Fixed to use import.meta.env.BASE_URL.

Verified: build output shows correct /Murmur/ and /Murmur/zh/ links.