### PR TITLE
fix: include bindings runtime helper in packaged app

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "clsx": "^2.1.1",
     "docx": "^9.6.1",
     "dotenv": "^16.3.1",
+    "file-uri-to-path": "1.0.0",
     "form-data": "^4.0.4",
     "i18next": "^26.2.0",
     "lucide-react": "^0.518.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1
+      file-uri-to-path:
+        specifier: 1.0.0
+        version: 1.0.0
       form-data:
         specifier: ^4.0.4
         version: 4.0.6

--- a/tests/unit/package-runtime-dependencies.test.ts
+++ b/tests/unit/package-runtime-dependencies.test.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+
+describe("packaged runtime dependencies", () => {
+  it("includes the bindings helper in the top-level app dependency tree", () => {
+    const helperEntry = path.join(
+      PROJECT_ROOT,
+      "node_modules",
+      "file-uri-to-path",
+      "index.js",
+    );
+
+    expect(fs.existsSync(helperEntry)).toBe(true);
+  });
+});

--- a/tests/unit/phase0-security.test.ts
+++ b/tests/unit/phase0-security.test.ts
@@ -146,7 +146,6 @@ describe("Phase 0: Ghost dependencies removed from package.json", () => {
     "es-errors",
     "es-object-atoms",
     "es-set-tostringtag",
-    "file-uri-to-path",
     "get-intrinsic",
     "math-intrinsics",
     "mime-db",
@@ -162,6 +161,10 @@ describe("Phase 0: Ghost dependencies removed from package.json", () => {
 describe("Phase 0: Native sqlite runtime dependencies", () => {
   it("should keep bindings as a direct production dependency", () => {
     expect(pkg.dependencies).toHaveProperty("bindings");
+  });
+
+  it("should keep the bindings helper as a direct production dependency", () => {
+    expect(pkg.dependencies).toHaveProperty("file-uri-to-path", "1.0.0");
   });
 });
 // [20260612_Fix_BindingsPackaging] END


### PR DESCRIPTION
## Summary

- add `file-uri-to-path@1.0.0` as a direct production dependency so electron-builder includes the runtime helper required by `bindings`
- replace the obsolete ghost-dependency assertion with an explicit native SQLite packaging contract
- add a regression test for the top-level dependency tree that electron-builder packages

Fixes #157.

## Root cause

`better-sqlite3` loads `bindings@1.5.0`, whose top-level `require("file-uri-to-path")` is a transitive dependency. With the pnpm dependency layout, electron-builder copied the direct `bindings` package but omitted its non-top-level helper.

I reproduced the issue from the official v1.2.0 Windows installer (`Murmur.Setup.1.2.0.exe`, SHA256 `39a6520a6b9058d97beca8b2e3832a61b67edca0f2a004761a73b8f88eaaa7ce`): `app.asar` contains `bindings/bindings.js` and `better-sqlite3`, but no `file-uri-to-path`. Loading the extracted `bindings.js` produces the same `MODULE_NOT_FOUND` reported in #157. Current `main` produced the same broken dependency closure before this change.

The helper is pure JavaScript, so it remains inside `app.asar`; no `asarUnpack` expansion is needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm test` coverage gate passes for all locally runnable suites
- [x] New code has corresponding tests
- [x] Commit messages follow Conventional Commits

## Testing

- regression red/green: the new top-level dependency test failed before the manifest change and passes afterward
- focused dependency/security suites: 27 passed
- Linux coverage run excluding the existing root-only Electron smoke and Windows-path-only suites: 105 files passed, 1,149 tests passed, 1 skipped; all coverage thresholds passed
- Prettier, ESLint, application typecheck, test typecheck, native ABI check, license check, and `git diff --check` passed
- `pnpm run pack` completed successfully
- fixed `app.asar` contains `node_modules/file-uri-to-path/index.js`
- loading both `bindings.js` and `file-uri-to-path` from the extracted packaged application succeeds
- cross-built Windows payload contains a PE32+ `Murmur.exe`, a Win64 `better_sqlite3.node`, and the fixed helper in `app.asar`; the extracted Windows runtime dependency chain resolves successfully

The local cross-build reached the Windows signing step, where it stopped because the Linux host does not have Wine. The complete unsigned Windows application payload is verified; the official PR workflow is awaiting the repository's first-time-contributor approval before it can build the signed installer.

## Screenshots

Not applicable.
