### PR TITLE
fix: AI polish fails with generic error — surface real cause + raise max_tokens default

### DIFF
--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -122,11 +122,14 @@ export default function TranscriptionResult({
               120000,
             ),
           ),
-        ])) as { success?: boolean; text?: string };
+        ])) as { success?: boolean; text?: string; error?: string };
         if (result?.success && result?.text) {
           setOptimizedText(result.text);
         } else {
-          setOptimizeError("AI处理失败，请重试");
+          // [20260815_Fix_AiEmptyContent] Surface the main-process error
+          // (e.g. max_tokens exhausted by model reasoning) instead of a
+          // generic message that hides the actionable cause.
+          setOptimizeError(result?.error || "AI处理失败，请重试");
         }
       } else if (onAIOptimize) {
         const result = await onAIOptimize(text);

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -194,11 +194,14 @@ export async function processTextWithAI(
       parseFloat(
         (await databaseManager.getSetting("ai_temperature")) as string,
       ) || 0.3;
+    // [20260815_Fix_AiMaxTokensDefault] 8192 fallback matches the renderer
+    // DEFAULT_SETTINGS — reasoning models count thinking tokens against
+    // max_tokens; the old 2000 could be exhausted by reasoning alone.
     const maxTokens =
       parseInt(
         (await databaseManager.getSetting("ai_max_tokens")) as string,
         10,
-      ) || 2000;
+      ) || 8192;
 
     if (!validateAIBaseUrl(baseUrl, { allowLocalhost: isLocal })) {
       return {
@@ -292,7 +295,10 @@ export async function processTextWithAI(
     }
 
     const data = (await response.json()) as {
-      choices?: Array<{ message?: { content?: string } }>;
+      choices?: Array<{
+        message?: { content?: string };
+        finish_reason?: string;
+      }>;
       usage?: unknown;
     };
 
@@ -303,9 +309,32 @@ export async function processTextWithAI(
     });
 
     if (data.choices && data.choices.length > 0) {
+      // [20260815_Fix_AiEmptyContent] Reasoning models (e.g. deepseek-v4-flash)
+      // can spend the entire max_tokens budget on reasoning before emitting
+      // any content: HTTP 200, choices present, message.content empty,
+      // finish_reason "length" (production logs 2026-08-15: reasoning_tokens
+      // 2000 == completion_tokens == max_tokens). Returning success with empty
+      // text made the UI show a generic "AI处理失败，请重试" with no cause.
+      const content = data.choices[0]?.message?.content?.trim() || "";
+      if (!content) {
+        const usage = data.usage as { completion_tokens?: number } | undefined;
+        const tokenCapHit =
+          data.choices[0]?.finish_reason === "length" ||
+          (usage?.completion_tokens !== undefined &&
+            usage.completion_tokens >= maxTokens);
+        const error = tokenCapHit
+          ? `AI输出为空：模型推理占满了 max_tokens（${maxTokens}）预算，请在设置中调大「AI 配置 → 最大输出长度」或换用非推理模型`
+          : "AI返回了空内容，请重试或更换模型";
+        logger.error?.("AI返回空内容:", {
+          finish_reason: data.choices[0]?.finish_reason,
+          usage: data.usage,
+          maxTokens,
+        });
+        return { success: false, error };
+      }
       const result: AIResult = {
         success: true,
-        text: data.choices[0]?.message?.content?.trim() || "",
+        text: content,
         usage: data.usage,
         model: model,
       };

--- a/src/settings/sections/AIConfigSection.tsx
+++ b/src/settings/sections/AIConfigSection.tsx
@@ -406,10 +406,15 @@ export const AIConfigSection: React.FC<AIConfigSectionProps> = ({
               {settings.ai_max_tokens}
             </span>
           </div>
+          {/* [20260815_Fix_AiMaxTokensDefault] Range 1024–16384 (was 500–4096):
+              reasoning models count thinking tokens against max_tokens, so
+              the old ceiling starved them; 16384 matches what the 150s
+              request timeout can realistically deliver. Min 1024 keeps every
+              value (incl. default 8192) on the 256-step notch grid. */}
           <input
             type="range"
-            min="500"
-            max="4096"
+            min="1024"
+            max="16384"
             step="256"
             value={settings.ai_max_tokens}
             onChange={(e) =>
@@ -418,8 +423,8 @@ export const AIConfigSection: React.FC<AIConfigSectionProps> = ({
             className="w-full h-1.5 bg-[#d2d2d7] dark:bg-[#3a3a3c] rounded-full appearance-none cursor-pointer accent-[#0071e3]"
           />
           <div className="flex justify-between text-[10px] text-[#86868b]">
-            <span>500</span>
-            <span>4096</span>
+            <span>1024</span>
+            <span>16384</span>
           </div>
         </div>
       </div>

--- a/src/settings/useSettings.ts
+++ b/src/settings/useSettings.ts
@@ -59,7 +59,10 @@ const DEFAULT_SETTINGS: SettingsState = {
   ai_base_url: "https://api.openai.com/v1",
   ai_model: "gpt-3.5-turbo",
   ai_temperature: 0.3,
-  ai_max_tokens: 2000,
+  // [20260815_Fix_AiMaxTokensDefault] 8192 (was 2000): reasoning models count
+  // thinking tokens against max_tokens; 2000 let reasoning alone exhaust the
+  // budget and return empty content (see 20260815_Fix_AiEmptyContent).
+  ai_max_tokens: 8192,
   enable_ai_optimization: true,
   window_always_on_top: true,
   auto_paste: "paste",
@@ -123,7 +126,7 @@ export function useSettings() {
           ai_temperature:
             parseFloat(allSettings.ai_temperature as string) || 0.3,
           ai_max_tokens:
-            parseInt(allSettings.ai_max_tokens as string, 10) || 2000,
+            parseInt(allSettings.ai_max_tokens as string, 10) || 8192,
           enable_ai_optimization: allSettings.enable_ai_optimization !== false,
           window_always_on_top: allSettings.window_always_on_top !== false,
           auto_paste: (allSettings.auto_paste || "paste") as string,

--- a/tests/unit/ai-config-expanded.test.tsx
+++ b/tests/unit/ai-config-expanded.test.tsx
@@ -280,12 +280,13 @@ describe("[20260729_Test_AIConfigExpanded] AIConfigSection uncovered branches", 
     });
     render(<AIConfigSection {...props} />);
 
-    // The max-tokens slider has min="500", max="4096", step="256".
+    // [20260815_Fix_AiMaxTokensDefault] The max-tokens slider has
+    // min="1024", max="16384", step="256".
     const sliders = screen.getAllByRole("slider");
     const maxTokensSlider = sliders.find(
       (s) =>
-        (s as HTMLInputElement).getAttribute("min") === "500" &&
-        (s as HTMLInputElement).getAttribute("max") === "4096",
+        (s as HTMLInputElement).getAttribute("min") === "1024" &&
+        (s as HTMLInputElement).getAttribute("max") === "16384",
     ) as HTMLInputElement;
     expect(maxTokensSlider).toBeDefined();
 

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -212,6 +212,10 @@ describe("aiHandlers", () => {
       expect(body.max_tokens).toBe(4000);
     });
 
+    // [20260815_Fix_AiMaxTokensDefault] Default raised 2000 → 8192: reasoning
+    // models (deepseek-v4-flash etc.) count thinking tokens against
+    // max_tokens; 2000 let reasoning alone exhaust the budget and return
+    // empty content (see 20260815_Fix_AiEmptyContent).
     it("uses default temperature and max_tokens when not configured", async () => {
       const db = {
         getSetting: vi.fn(async (key: string) => {
@@ -235,7 +239,7 @@ describe("aiHandlers", () => {
         (fetchMock.mock.calls[0]![1] as { body: string }).body,
       );
       expect(body.temperature).toBe(0.3);
-      expect(body.max_tokens).toBe(2000);
+      expect(body.max_tokens).toBe(8192);
     });
 
     it("returns error on HTTP 401 response", async () => {
@@ -271,6 +275,50 @@ describe("aiHandlers", () => {
       const result = await processTextWithAI("test", "optimize", db, logger);
       expect(result.success).toBe(false);
       expect(result.error).toContain("格式错误");
+    });
+
+    // [20260815_Fix_AiEmptyContent] Regression: reasoning models (e.g.
+    // deepseek-v4-flash) can spend the entire max_tokens budget on reasoning
+    // (finish_reason "length"), returning HTTP 200 with an EMPTY message.content.
+    // Production logs 2026-08-15: outputLength 0, reasoning_tokens 2000 ==
+    // completion_tokens 2000 == max_tokens. This must NOT be reported as
+    // success — the UI would then show a generic failure with no cause.
+    it("returns actionable error when reasoning exhausts max_tokens and content is empty", async () => {
+      const db = setupDb();
+      const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+
+      mockFetch({
+        choices: [
+          {
+            message: { content: "" },
+            finish_reason: "length",
+          },
+        ],
+        usage: {
+          completion_tokens: 2000,
+          completion_tokens_details: { reasoning_tokens: 2000 },
+        },
+      });
+
+      const result = await processTextWithAI("test", "optimize", db, logger);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("max_tokens");
+    });
+
+    // [20260815_Fix_AiEmptyContent] Same guard applies when content is
+    // undefined or whitespace, or finish_reason is absent but output is empty.
+    it("returns error when content is whitespace only", async () => {
+      const db = setupDb();
+      const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+
+      mockFetch({
+        choices: [{ message: { content: "   \n  " } }],
+        usage: { completion_tokens: 10 },
+      });
+
+      const result = await processTextWithAI("test", "optimize", db, logger);
+      expect(result.success).toBe(false);
+      expect(result.error).toBeTruthy();
     });
   });
 

--- a/tests/unit/components/AIConfigSection.test.tsx
+++ b/tests/unit/components/AIConfigSection.test.tsx
@@ -1,0 +1,86 @@
+// [20260815_Fix_AiMaxTokensDefault] Component contract test for the AI
+// settings section's 最大输出长度 slider. The old ceiling (4096) was too low
+// for reasoning models, whose thinking tokens count against max_tokens and
+// could exhaust the budget before any content was emitted (see
+// 20260815_Fix_AiEmptyContent). This locks the slider to the new bounds
+// (1024–16384) and pins the default 8192 onto the slider's notch grid.
+// @vitest-environment happy-dom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AIConfigSection } from "../../../src/settings/sections/AIConfigSection";
+import type { SettingsState } from "../../../src/settings/useSettings";
+
+// t() echoes its fallback arg — deterministic, no i18n backend required.
+vi.mock("react-i18next", () => {
+  const t = (key: string, fallback?: string) => fallback ?? key;
+  return { useTranslation: () => ({ t }) };
+});
+
+const BASE_SETTINGS: SettingsState = {
+  ai_api_key: "sk-test",
+  ai_base_url: "https://api.deepseek.com",
+  ai_model: "deepseek-v4-flash",
+  ai_temperature: 0.3,
+  ai_max_tokens: 8192,
+  enable_ai_optimization: true,
+  window_always_on_top: true,
+  auto_paste: "paste",
+  close_behavior: "hide",
+  theme: "system",
+  effects_enabled: false,
+};
+
+function renderSection(settings: SettingsState = BASE_SETTINGS) {
+  return render(
+    <AIConfigSection
+      settings={settings}
+      onInputChange={vi.fn()}
+      customModel={false}
+      setCustomModel={vi.fn()}
+      resolvedProviderPresets={[]}
+      providerPresets={[]}
+      applyProviderPreset={vi.fn()}
+      showApiKey={false}
+      setShowApiKey={vi.fn()}
+      apiKeyInputRef={{ current: null }}
+      testing={false}
+      testResult={null}
+      testAIConfiguration={vi.fn()}
+      saveSettings={vi.fn().mockResolvedValue(true)}
+      saving={false}
+      showQuickStart={false}
+    />,
+  );
+}
+
+function findMaxTokensSlider(): HTMLInputElement {
+  const label = screen.getByText("最大输出长度");
+  // The label and its slider share the wrapping <div> block.
+  const block = label.closest("div")!.parentElement!;
+  const slider = block.querySelector(
+    'input[type="range"]',
+  ) as HTMLInputElement | null;
+  expect(slider).not.toBeNull();
+  return slider!;
+}
+
+describe("AIConfigSection max output tokens slider", () => {
+  it("allows up to 16384 tokens (reasoning models need headroom)", () => {
+    renderSection();
+    const slider = findMaxTokensSlider();
+    expect(slider.max).toBe("16384");
+    expect(slider.min).toBe("1024");
+  });
+
+  it("keeps the 8192 default on the slider's notch grid", () => {
+    renderSection();
+    const slider = findMaxTokensSlider();
+    const min = parseInt(slider.min, 10);
+    const step = parseInt(slider.step, 10);
+    // Independent truth: 8192 = 1024 + 30×256, so the default value must sit
+    // exactly on a notch — otherwise the thumb renders off the saved value.
+    expect((8192 - min) % step).toBe(0);
+    expect(slider.value).toBe("8192");
+  });
+});

--- a/tests/unit/components/TranscriptionResult.test.tsx
+++ b/tests/unit/components/TranscriptionResult.test.tsx
@@ -209,4 +209,29 @@ describe("TranscriptionResult", () => {
     });
     clearElectronAPI();
   });
+
+  // [20260815_Fix_AiEmptyContent] Regression: when processText resolves with
+  // { success: false, error: "..." } the UI must surface the main-process
+  // error, not the generic "AI处理失败，请重试". Previously result.error was
+  // discarded, hiding the real cause (e.g. max_tokens exhausted by reasoning).
+  it("shows main-process error message when processText resolves with failure", async () => {
+    stubElectronAPI({
+      processText: vi
+        .fn()
+        .mockResolvedValue({
+          success: false,
+          error: "AI输出为空，请调大 max_tokens",
+        }),
+    });
+    render(<TranscriptionResult text="hello" />);
+    await waitFor(() => {
+      expect(screen.getByText("应用")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("应用"));
+    await waitFor(() => {
+      expect(screen.getByText("AI输出为空，请调大 max_tokens")).toBeTruthy();
+      expect(screen.queryByText("AI处理失败，请重试")).toBeNull();
+    });
+    clearElectronAPI();
+  });
 });

--- a/tests/unit/settings-sections.test.tsx
+++ b/tests/unit/settings-sections.test.tsx
@@ -495,8 +495,10 @@ describe("[20260729_Test_SettingsSections] AIConfigSection", () => {
       (s) => (s as HTMLInputElement).value === "1500",
     ) as HTMLInputElement;
     expect(maxTokensSlider).toBeDefined();
-    expect(maxTokensSlider).toHaveAttribute("min", "500");
-    expect(maxTokensSlider).toHaveAttribute("max", "4096");
+    // [20260815_Fix_AiMaxTokensDefault] Bounds raised 500–4096 → 1024–16384
+    // (reasoning models need headroom for thinking tokens).
+    expect(maxTokensSlider).toHaveAttribute("min", "1024");
+    expect(maxTokensSlider).toHaveAttribute("max", "16384");
     expect(maxTokensSlider).toHaveAttribute("step", "256");
   });
 

--- a/tests/unit/useSettings-hook.test.tsx
+++ b/tests/unit/useSettings-hook.test.tsx
@@ -152,4 +152,20 @@ describe("useSettings hook", () => {
     const api = (globalThis.window as TestWindow).electronAPI!;
     expect(api.setSetting).toHaveBeenCalledWith("effects_enabled", false);
   });
+
+  // [20260815_Fix_AiMaxTokensDefault] When no ai_max_tokens is persisted,
+  // loadSettings must fall back to 8192 (not the old 2000): reasoning models
+  // count thinking tokens against max_tokens and 2000 let reasoning alone
+  // exhaust the budget (empty-content failures, see 20260815_Fix_AiEmptyContent).
+  it("falls back to ai_max_tokens 8192 when no value is persisted", async () => {
+    const api = (globalThis.window as TestWindow).electronAPI!;
+    (api.getAllSettings as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.settings.ai_max_tokens).toBe(8192);
+  });
 });


### PR DESCRIPTION
## Root cause (confirmed via production app.log, 2026-08-15)

The user's reasoning model `deepseek-v4-flash` spent its ENTIRE max_tokens budget (2000) on reasoning tokens — HTTP 200, choices present, `message.content` **empty**, `reasoning_tokens 2000 == completion_tokens 2000 == max_tokens`. Two defects stacked:

1. `processTextWithAI` returned `success: true` with empty text when choices existed (content never checked), and
2. `TranscriptionResult` discarded `result.error`, showing a generic "AI处理失败，请重试" for every failure — the real cause never reached the user.

Failures were **stochastic** (same input worked 2026-08-09 when reasoning used only 794 tokens): longer/harder inputs make reasoning hit the cap more often.

## Changes

- **aiHandlers**: empty content after trim → `success: false`. Detects the token-cap case via `finish_reason "length"` or `completion_tokens >= max_tokens` and tells the user to raise AI 配置 → 最大输出长度 or switch to a non-reasoning model; logs finish_reason/usage/maxTokens.
- **TranscriptionResult**: show `result.error` (generic copy only as fallback).
- **Defaults raised for reasoning models**: `ai_max_tokens` 2000 → 8192 in `useSettings` (DEFAULT_SETTINGS + loadSettings fallback) and the `aiHandlers` fallback; slider range 500–4096 → **1024–16384** (min moved to 1024 so the 8192 default sits on the 256-step notch grid). 16384 caps what the 150s request timeout can realistically deliver — deliberately NOT the model max (128K+), which would 400 on providers with lower limits (gpt-3.5-turbo: 4096).
- **Tests**: regression tests at 3 seams (main-process default 8192, hook fallback 8192, slider bounds + notch-grid alignment) + empty-content guard (reasoning-exhaustion and whitespace cases) + UI error passthrough (asserts the generic copy does NOT appear). Updated 2 existing tests that encoded the old 500–4096 slider contract.

> Note: existing users keep their saved `ai_max_tokens`; the new default applies only when nothing is persisted.

## Verification

`pnpm ci:check` 10/10 (format, lint 0/0, license, typecheck ×2, test+coverage, build:main/preload/renderer, effects chunk isolation) after `pnpm rebuild better-sqlite3` (system-node ABI). Security audit: non-blocking warnings only.