### PR TITLE
docs: sync arch map, gate lists, CHANGELOG, and README to post-#166 state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ Murmur targets **Windows** and **macOS**. See `CLAUDE.md` → _Cross-Platform Su
 
 ### Delivery Gates
 
-- **All commits MUST pass `pnpm ci:check` before push.** This runs: format check, lint, license check, typecheck, typecheck:tests, test with coverage, build:main, build:preload, build:renderer.
+- **All commits MUST pass `pnpm ci:check` before push.** This runs: format check, lint, license check, typecheck, typecheck:tests, test with coverage, build:main, build:preload, build:renderer, dev smoke (`pnpm run dev` boots and the vite dev server answers).
 - **Quick check:** `pnpm lint` + `pnpm test` for rapid iteration during development.
 - **Bug fix:** reproduce the bug, add a failing test **first**, then fix and verify.
 - **High-risk** (session flow, IPC, security, privacy, release packaging): include a risk statement and fresh verification evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lean pass: ~4,500 net lines of dead code, unused dependencies, and duplicate logic removed; `pnpm audit` now reports against the official registry (99 → 2 advisories, both without upstream fixes).
 - Toolchain: Electron 36 → 39.8.10, electron-builder 24 → 26, better-sqlite3 11 → 12 (Electron 39 ABI).
+- Minimalism pass (2026-08-16): the dead F2 double-click IPC chain, the web-modal SettingsPanel fallback, and seven unused environment config getters were removed; the settings window now loads `settings.html` in dev and production alike.
+- Test coverage pushed to **96.6% statements / 92.8% branches / 94.5% functions / 97.1% lines** (1,406 unit tests) with vitest thresholds raised to 96/92/94/96.
+- `pnpm ci:check` now runs a **dev smoke gate** (10 checks): it boots `pnpm run dev` and verifies the vite dev server answers, catching native-ABI and startup regressions the static gates miss. The gate leaves better-sqlite3 in the electron-ABI state `pnpm run dev` expects.
 
 ## [1.2.0] - 2026-08-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ When adding platform-specific code, use `process.platform === "win32"` checks. A
 
 ### Delivery Gates
 
-- **All commits MUST pass `pnpm ci:check` before push.** This mirrors CI and runs: format check, lint, license check, typecheck, typecheck:tests, test with coverage, build:main, build:preload, build:renderer.
+- **All commits MUST pass `pnpm ci:check` before push.** This mirrors CI and runs: format check, lint, license check, typecheck, typecheck:tests, test with coverage, build:main, build:preload, build:renderer, dev smoke (pnpm run dev boots and the vite dev server answers).
 - **Quick check:** `pnpm lint` + `pnpm test` for rapid iteration during development.
 - **Bug fix:** reproduce the bug, add a failing test **first**, then fix and verify; no implementation-only fixes, no fix-then-backfill tests.
 - **High-risk** (session flow, IPC, security, privacy, release packaging): include a risk statement and fresh verification evidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ chore: 升级 Electron 到 v36
 提交前在本地运行完整检查（和 CI 一致）：
 
 ```bash
-pnpm ci:check          # 完整门禁（format + lint + typecheck + test + coverage + build）
+pnpm ci:check          # 完整门禁（format + lint + typecheck + test + coverage + build + dev smoke）
 pnpm ci:check --e2e    # 含 e2e（慢）
 pnpm lint && pnpm test # 快速迭代
 ```

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ pnpm dev
 
 ```bash
 pnpm dev          # 启动开发模式
-pnpm test         # 运行测试（1000+ tests）
+pnpm test         # 运行测试（1400+ tests，覆盖率 ~97%）
 pnpm lint         # 代码检查（0 warnings）
 pnpm typecheck    # TypeScript 类型检查
 pnpm ci:check     # 本地运行所有 CI 门禁

--- a/docs/research/murmur-architecture-map.md
+++ b/docs/research/murmur-architecture-map.md
@@ -406,11 +406,11 @@ Path: `/Users/guanxueliang/Desktop/oh-my-ai/Murmur/src/helpers/logManager.ts`
 
 Path: `/Users/guanxueliang/Desktop/oh-my-ai/Murmur/src/helpers/environment.ts`
 
-**What it does:** Loads `.env` from `process.cwd()` via a minimal built-in parser (dotenv dependency removed in the 2026-08 lean pass; shell env wins over file values). Provides typed config getters reading `process.env` with defaults: `getAIConfig` (placeholder — real config via settings), `getAudioConfig` (16000/1/wav), `getFunASRConfig`, `getAppConfig` (hotkey default `CommandOrControl+Shift+Space`), `getDatabaseConfig`, `getProxyConfig`, `getPerformanceConfig`. Platform `getDataDirectory()` (macOS `~/Library/Application Support/Murmur`, Windows `%APPDATA%\Murmur`, Linux `~/.config/Murmur`). `ensureDataDirectory`/`getLogDirectory`/`getCacheDirectory`/`getModelsDirectory` create dirs. `validateEnvironment()` (Node 18+ check). `exportConfig()` aggregates all. `getSystemInfo()` (os module).
+**What it does:** Loads `.env` from `process.cwd()` via a minimal built-in parser (dotenv dependency removed in the 2026-08 lean pass; shell env wins over file values). Platform `getDataDirectory()` (macOS `~/Library/Application Support/Murmur`, Windows `%APPDATA%\Murmur`, Linux `~/.config/Murmur`) + `ensureDataDirectory()` creates it. (The seven typed config getters, `getSystemInfo`, `validateEnvironment`, `exportConfig`, and the per-purpose directory helpers were removed in the 2026-08-16 minimalism pass — zero callers; logManager has its own getSystemInfo/getLogDirectory.)
 
 **Dependencies:** `path`, `fs`, `os`. **No direct electron dependency** (uses `process.env`/`os`).
 
-**Public interface:** all getters above + `loadEnvironmentVariables()`, `isDevelopment()`, `isProduction()`, `validateEnvironment()`, `exportConfig()`.
+**Public interface:** `loadEnvironmentVariables()`, `getDataDirectory()`, `ensureDataDirectory()`.
 
 **Testing seam:** Coverage-excluded but **fully unit-testable** — no Electron, only `os`/`fs`/`process.env`. Set env vars + temp dirs. Platform branching testable by stubbing `process.platform`.
 
@@ -824,10 +824,10 @@ Path: `/Users/guanxueliang/Desktop/oh-my-ai/Murmur/src/helpers/detectLocalModels
 ### 6.1 Structure
 
 - `src/main.tsx` — React 19 entry. `ErrorBoundary` class component, `initializeApp()` (theme apply from setting + system listener, drag/drop prevention, contextmenu prevention in prod, global error handlers → `electronAPI.log`), `assertElectronAPI()` guard (renders fallback if preload missing), mounts `ModelStatusProvider > App + Toaster`.
-- `src/App.tsx` — main UI (27KB). URL `?page=settings` routes to lazy `SettingsPage`. Recording mode / file-import mode toggle. Uses hooks: `useHotkey`, `useWindowDrag`, `useRecording` (with `determineProcessingMode`), `useModelStatus`. Caches settings in `settingsRef`. Paste debounce (1s same-text).
+- `src/App.tsx` — main UI (27KB). Recording mode / file-import mode toggle. Uses hooks: `useHotkey`, `useWindowDrag`, `useRecording` (with `determineProcessingMode`), `useModelStatus`. Caches settings in `settingsRef`. Paste debounce (1s same-text). (The `?page=settings` lazy route and the web-modal SettingsPanel fallback were removed in the 2026-08-16 minimalism pass — the settings window is its own entry in dev and production.)
 - `src/history.tsx`, `src/settings.tsx` — separate window entry points (history.html, settings.html). `SettingsSidebar`, `useSettings`, sections: `AIConfigSection`, `AboutSection`, `GeneralSection`, `PermissionsSection`.
 - `src/hooks/` — `useRecording`, `useHotkey`, `useFileTranscription`, `useWindowDrag`, `usePermissions`, `useModelStatus`.
-- `src/components/` — UI components (SettingsPanel, FileImport, TranscriptionResult, VoiceWaveIndicator, ExportPanel, etc.) + `ui/` shadcn primitives (button, card, tabs, input, dialog, etc.).
+- `src/components/` — UI components (FileImport, TranscriptionResult, VoiceWaveIndicator, ExportPanel, etc.) + `ui/` primitives (button, loading-dots, model-status-indicator, permission-card, sonner). (SettingsPanel, the dead shadcn card/input/label/tabs/status-light/history-modal set, and the LoadingIndicator duplicate were removed in the 2026-08 lean passes.)
 - `src/i18n/` — i18next localization.
 - `src/bootstrap/assertElectronAPI.ts` — runtime preload assertion.
 - `src/types/ipc.ts` — shared IPC type definitions.


### PR DESCRIPTION
## Summary

Docs-only change syncing the knowledge base to the post-#166 reality (neat-freak pass):

- **murmur-architecture-map.md**: environment.ts section (7 config getters removed in the minimalism pass — keeps the .env parser + data dirs), App.tsx section (`?page=settings` lazy route and SettingsPanel removed — settings window is its own entry in dev and production), components inventory (dead shadcn set and LoadingIndicator removed)
- **AGENTS.md / CLAUDE.md / CONTRIBUTING.md**: ci:check gate lists now include the **dev smoke gate** (10 checks)
- **CHANGELOG.md** Unreleased: minimalism pass, coverage push (96.6/92.8/94.5/97.1, 1,406 tests, thresholds 96/92/94/96), dev smoke gate + its electron-ABI semantics
- **README.md**: test line updated to 1400+ tests at ~97% coverage

Docs-only; no source change. CI runs the normal gates (format/lint on markdown included).