### PR TITLE
fix: ship bindings runtime helper in packaged app + release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-16
+
+### Fixed
+
+- **Windows 安装包启动崩溃**（Issue #157）：打包后的 Windows 应用启动即报 `Cannot find module 'file-uri-to-path'`、GUI 无法打开 —— pnpm 依赖布局下 electron-builder 把 `bindings` 打进了 app.asar 却漏掉其运行时依赖。已将 `file-uri-to-path@1.0.0` 声明为直接生产依赖并加回归测试锁定（修复方案来自 @LauraGPT 的 PR #158，因 lockfile 冲突在 main 上重放）。v1.2.0 的 Windows 用户请升级本版本。
+- **AI 润色失败只显示通用错误**（PR #164）：真实失败原因（如推理模型把全部 `max_tokens` 预算耗在 reasoning tokens 上导致正文为空）在上报前被丢弃，用户只能看到"AI处理失败"。现在真实错误会透传到界面，`max_tokens` 默认值同时调大。
+- **窗口生命周期 UX 整改**（PR #136）：隐藏窗口不再卡死 AI 定时器（关闭 backgroundThrottling）、任务栏重新显示应用图标、子窗口关闭后焦点回到主窗口、文本输入中按 Escape 不再隐藏窗口；设置项改为即时自动保存，Toast 移到底部居中不再遮挡表单。
+
 ### Removed
 
 - Visual-effects feature (History-window animated background, its settings toggle, and the `motion`/`ogl` dependencies) — a default-off decorative layer.

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -208,7 +208,7 @@ Repository: https://github.com/eslint/eslint
 Publisher: Nicholas C. Zakas
 
 ---
-file-uri-to-path@2.0.0
+file-uri-to-path@1.0.0
 License: MIT
 Repository: https://github.com/TooTallNate/file-uri-to-path
 Publisher: Nathan Rajlich

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Murmur - 基于FunASR和可配置AI模型的中文优化语音转文字应用",
   "main": "dist-main/main.js",
   "private": true,
@@ -119,6 +119,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "docx": "^9.6.1",
+    "file-uri-to-path": "1.0.0",
     "i18next": "^26.2.0",
     "lucide-react": "^0.518.0",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       docx:
         specifier: ^9.6.1
         version: 9.6.1
+      file-uri-to-path:
+        specifier: 1.0.0
+        version: 1.0.0
       i18next:
         specifier: ^26.2.0
         version: 26.2.0(typescript@6.0.3)

--- a/tests/unit/package-runtime-dependencies.test.ts
+++ b/tests/unit/package-runtime-dependencies.test.ts
@@ -1,0 +1,29 @@
+// [20260816_Fix_WinBindingsHelper] Regression test for issue #157: the
+// packaged Windows app crashed at startup with MODULE_NOT_FOUND because
+// electron-builder copied `bindings` into app.asar but omitted its runtime
+// helper `file-uri-to-path` (a pnpm-layout transitive dependency). Declaring
+// it as a direct production dependency (package.json) makes electron-builder
+// include it; this test locks that contract so it cannot silently regress.
+// Credit: fix authored by LauraGPT in PR #158, re-applied on post-#165 main.
+// [20260816_Fix_WinBindingsHelper] END
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+
+// [20260816_Fix_WinBindingsHelper] electron-builder packages the top-level
+// node_modules tree, so the helper must exist there — not only in .pnpm.
+describe("packaged runtime dependencies", () => {
+  it("includes the bindings helper in the top-level app dependency tree", () => {
+    const helperEntry = path.join(
+      PROJECT_ROOT,
+      "node_modules",
+      "file-uri-to-path",
+      "index.js",
+    );
+
+    expect(fs.existsSync(helperEntry)).toBe(true);
+  });
+});
+// [20260816_Fix_WinBindingsHelper] END

--- a/tests/unit/phase0-security.test.ts
+++ b/tests/unit/phase0-security.test.ts
@@ -135,7 +135,9 @@ describe("Phase 0: Ghost dependencies removed from package.json", () => {
     "es-errors",
     "es-object-atoms",
     "es-set-tostringtag",
-    "file-uri-to-path",
+    // [20260816_Fix_WinBindingsHelper] removed from ghost deps: it is now a
+    // deliberate direct production dependency (issue #157 Windows packaging
+    // fix) so electron-builder ships bindings' runtime helper in app.asar.
     "get-intrinsic",
     "math-intrinsics",
     "mime-db",
@@ -151,6 +153,13 @@ describe("Phase 0: Ghost dependencies removed from package.json", () => {
 describe("Phase 0: Native sqlite runtime dependencies", () => {
   it("should keep bindings as a direct production dependency", () => {
     expect(pkg.dependencies).toHaveProperty("bindings");
+  });
+
+  // [20260816_Fix_WinBindingsHelper] bindings' top-level require of this
+  // helper crashed packaged Windows installs (issue #157); pin it as a
+  // direct dependency so electron-builder always packages it.
+  it("should keep the bindings helper as a direct production dependency", () => {
+    expect(pkg.dependencies).toHaveProperty("file-uri-to-path", "1.0.0");
   });
 });
 // [20260612_Fix_BindingsPackaging] END


### PR DESCRIPTION
## Summary

- **Fixes the v1.2.0 Windows startup crash** (issue #157): packaged installs died on launch with `Cannot find module 'file-uri-to-path'` because electron-builder shipped `bindings` into app.asar but dropped its pnpm transitive runtime helper. `file-uri-to-path@1.0.0` is now a direct production dependency with regression tests locking the contract.
- Releases **v1.3.0**: CHANGELOG rolled with the three user-facing fixes (Windows startup crash, AI polish error surfacing #164, window lifecycle UX + settings auto-save #136), version bumped, stale THIRD-PARTY-LICENSES entry corrected.

This re-applies @LauraGPT's PR #158, whose branch had lockfile conflicts with post-#165 main (dependency tree shrank in the lean pass). All credit for the root-cause analysis and the fix design goes to them.

## Root cause

`better-sqlite3/lib/database.js` does `require('bindings')('better_sqlite3.node')`; `bindings@1.5.0` top-level-requires `file-uri-to-path`. Under the pnpm dependency layout, electron-builder's collector packaged the direct dep `bindings` but omitted the non-top-level helper. Exact pin `1.0.0` matches bindings' own resolution (it declares `1.0.0` exactly); a looser specifier risks shipping a diverging copy.

## Verification

- Regression tests red/green: manifest pin + top-level `node_modules/file-uri-to-path/index.js` presence
- Focused suites: 43/43 pass
- **Packaged-app proof**: built `pnpm run pack`, confirmed the fresh `app.asar` contains `file-uri-to-path@1.0.0` (1.0.0 layout, top-level `index.js`), then extracted `bindings.js` + helper from the asar and loaded the exact require chain that crashed on Windows — passes
- `pnpm ci:check`: **10/10 gates green** (format, lint, license, typecheck ×2, builds ×3, coverage 96.6/92.8/94.5/97.1 with 1408 tests, dev smoke boot)

Fixes #157
Closes #158