### PR TITLE
fix(ci): declare @electron/rebuild as devDep — Windows build shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@electron/notarize": "^3.0.1",
+    "@electron/rebuild": "^4.2.0",
     "@eslint/js": "^9.25.0",
     "@playwright/test": "1.60.0",
     "@tailwindcss/postcss": "^4.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@electron/notarize':
         specifier: ^3.0.1
         version: 3.1.0
+      '@electron/rebuild':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@eslint/js':
         specifier: ^9.25.0
         version: 9.39.4

--- a/tests/unit/deps-lean.test.ts
+++ b/tests/unit/deps-lean.test.ts
@@ -58,6 +58,17 @@ describe("[20260815_Refactor_DepsLean] runtime dependencies", () => {
     expect(pkg.dependencies).toHaveProperty("bindings");
   });
 
+  // [20260816_Fix_WinCiElectronRebuild] Windows CI (build.yml) runs
+  // `npx @electron/rebuild` after `pnpm install --ignore-scripts` with a
+  // hoisted node_modules. electron-builder 26 pulled it in transitively, but
+  // pnpm only links .bin shims for DIRECT dependencies, so npx found the
+  // package locally without an `electron-rebuild` shim and failed with
+  // "'electron-rebuild' is not recognized". Declaring it directly keeps the
+  // shim present and the Windows native-ABI rebuild deterministic.
+  it("declares @electron/rebuild as a devDependency (Windows CI rebuild shim)", () => {
+    expect(pkg.devDependencies).toHaveProperty("@electron/rebuild");
+  });
+
   it.each(REMOVED_RUNTIME_DEPS)("%s is not a production dependency", (name) => {
     expect(pkg.dependencies).not.toHaveProperty(name);
   });


### PR DESCRIPTION
## Summary

Fixes the v1.3.0 tag build failure: the Windows `build-win` job failed at `npx @electron/rebuild` with `'electron-rebuild' is not recognized`, so the release job was skipped (no v1.3.0 artifacts were published).

## Root cause

electron-builder 26 (#165 lean pass) pulled `@electron/rebuild@4.2.0` into the tree **transitively** via `app-builder-lib`. On Windows CI (`pnpm install --ignore-scripts` + `node-linker=hoisted`), npx now resolves the package from the local hoisted tree, but pnpm only creates `node_modules/.bin` shims for **direct** dependencies — so the `electron-rebuild` bin doesn't exist. v1.2.0 only worked because the package wasn't in the dependency tree at all and npx fell back to a registry fetch.

## Fix

- `@electron/rebuild@^4.2.0` added to devDependencies (identical to the version already resolved — lockfile delta is just the importer entry)
- contract test in `deps-lean.test.ts` locks the devDependency so a future cleanup can't silently break Windows CI again

## Verification

- `node_modules/.bin/electron-rebuild` shim present after install
- focused suites 44/44 pass
- `pnpm ci:check`: 10/10 gates green

Needed to complete the v1.3.0 release (#157 fix) — the tag will be re-pointed after this merges.