### PR TITLE
fix(ci): force Electron-ABI sqlite rebuild + packaging ABI gate — v1.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # [20260816_Fix_MacCiNodeAbi] The old `npx electron-builder
+      # install-app-deps` step silently no-opped on CI (~0.2s "finished"):
+      # pnpm's onlyBuiltDependencies allowlist let better-sqlite3's own
+      # install script download a system-Node prebuild (ABI 137), and the
+      # unforced rebuild never replaced it — the shipped v1.3.0 macOS dmg
+      # crashed at launch under Electron 39 (ABI 140). -f forces a real
+      # Electron-ABI rebuild every time.
       - name: Rebuild native modules for Electron
-        run: npx electron-builder install-app-deps
+        run: npx @electron/rebuild -f -w better-sqlite3
 
+      # [20260816_Fix_MacCiNodeAbi] Gate: the native module must actually
+      # open a database under the bundled Electron runtime before we are
+      # allowed to package. ELECTRON_RUN_AS_NODE runs Electron's own Node
+      # (ABI 140); a node-ABI binary exits non-zero here.
+      - name: Verify native sqlite ABI under Electron (packaging gate)
+        run: |
+          ELECTRON_RUN_AS_NODE=1 npx electron -e "const D=require('better-sqlite3'); new D(':memory:').prepare('select 1 as ok').get(); console.log('native ABI gate passed')"
+      # [20260816_Fix_MacCiNodeAbi] END
       - name: Prepare embedded Python
         run: pnpm run prepare:python:embedded
 
@@ -137,9 +152,17 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Rebuild native modules for Electron
-        run: npx @electron/rebuild
+        run: npx @electron/rebuild -f -w better-sqlite3
       # [20260802_Fix_WinCiPnpmPostinstall] END
 
+      # [20260816_Fix_MacCiNodeAbi] Same ABI gate as build-mac: prove the
+      # native sqlite module opens a database under the bundled Electron
+      # before packaging, so a wrong-ABI binary can never reach an installer.
+      - name: Verify native sqlite ABI under Electron (packaging gate)
+        shell: bash
+        run: |
+          ELECTRON_RUN_AS_NODE=1 npx electron -e "const D=require('better-sqlite3'); new D(':memory:').prepare('select 1 as ok').get(); console.log('native ABI gate passed')"
+      # [20260816_Fix_MacCiNodeAbi] END
       # [20260802_Fix_WinEmbeddedPython] prepare-embedded-python.js now
       # supports Windows (-pc-windows-msvc-shared). Keep continue-on-error
       # because torch/funasr pip install may exceed CI time/disk limits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-08-16
+
+### Fixed
+
+- **v1.3.0 的 macOS 安装包启动崩溃**：v1.3.0 的 dmg 内 `better_sqlite3.node` 是按系统 Node ABI 137 编译的（Electron 39 需要 ABI 140），首次 `new Database()` 即抛 `NODE_MODULE_VERSION` 不匹配，主窗口无法打开。根因：CI 上 pnpm 的 `onlyBuiltDependencies` 白名单允许 better-sqlite3 在安装时下载系统 Node 的预编译产物，而随后的 `electron-builder install-app-deps` 重建是约 0.2 秒的静默 no-op，从未替换成 Electron ABI 版本。修复：mac 构建 job 改为 `npx @electron/rebuild -f -w better-sqlite3` 强制真实重建；mac/win 两个 job 在打包前新增 ABI 门禁 —— 必须在 Electron 运行时下真实打开一次 SQLite 内存库才能继续打包。**v1.3.0 的 macOS dmg 不可用，请 macOS 用户改装 v1.3.1**（v1.3.0 的 Windows 安装包经核实 ABI 正确，不受影响）。
+
 ## [1.3.0] - 2026-08-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Murmur - 基于FunASR和可配置AI模型的中文优化语音转文字应用",
   "main": "dist-main/main.js",
   "private": true,


### PR DESCRIPTION
## Summary

**The v1.3.0 macOS dmg crashes at launch** (discovered by installing the released artifact on a real Mac): the bundled `better_sqlite3.node` is a system-Node ABI 137 build while Electron 39 needs ABI 140 — the first `new Database()` throws `NODE_MODULE_VERSION` mismatch and the main window never opens. This PR fixes the CI pipeline and ships **v1.3.1**.

## Root cause (from the v1.3.0 build-mac job log)

1. pnpm's `onlyBuiltDependencies` allowlist lets better-sqlite3's own install script run → `prebuild-install` downloads a **system-Node (ABI 137)** prebuild on the fresh CI runner (`.nvmrc` = node 24).
2. The subsequent `electron-builder install-app-deps` "rebuilds" all no-opped — **~0.2s "preparing → finished"** — never replacing the binary.
3. Local builds survived by luck: a warm pnpm store already held an Electron-ABI build, which is why local `pnpm run pack` verification passed while CI shipped 137.

The v1.3.0 **Windows exe is ABI-correct**: its `--ignore-scripts` install produced no binary at all, forcing `@electron/rebuild` to do a real 7-second rebuild.

## Fix

- **build-mac**: `npx @electron/rebuild -f -w better-sqlite3` — forced real rebuild (same command the local dev-smoke gate uses), replacing the no-op `install-app-deps` step.
- **build-mac + build-win**: new **packaging ABI gate** — before packaging, the native module must open an in-memory SQLite database under the bundled Electron (`ELECTRON_RUN_AS_NODE=1 npx electron -e ...`). A wrong-ABI binary fails the job and the release can never ship broken again.
- Version 1.3.1 + CHANGELOG entry; v1.3.0 release notes will warn macOS users.

## Verification

- Gate verified bidirectionally on a real tree: **passes** after `electron-rebuild -f`, **fails** with the `NODE_MODULE_VERSION 137/140` error after `pnpm rebuild better-sqlite3` (node ABI)
- Reproduced the v1.3.0 dmg crash on a real Mac (boot log: ABI mismatch at `DatabaseManager.initialize`), and proved the unpacked binary opens a DB under Electron only after a forced rebuild
- `pnpm ci:check`: 10/10 gates green; workflow YAML validated

After merge: tag v1.3.1 → CI build → I will install the released dmg on this Mac and re-run the same boot smoke that caught this.