### PR TITLE
fix(ci): build the preload bundle for installers + packaging gate — v1.3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,21 @@ jobs:
       - name: Build main bundle
         run: pnpm run build:main
 
+      # [20260816_Fix_PackagedPreload] The build jobs never ran build:preload,
+      # so every installer this workflow ever produced (v1.0.0 → v1.3.1) shipped
+      # without dist-preload/preload.js — the packaged app boots, then the
+      # renderer shows "Electron API 不可用 / preload 脚本加载失败" and no feature
+      # works. main.ts loads the preload from app.getAppPath()/dist-preload.
+      - name: Build preload bundle
+        run: pnpm run build:preload
+
+      # [20260816_Fix_PackagedPreload] Gate: refuse to package unless the
+      # preload bundle exists (electron-builder's files glob silently skips
+      # missing entries, which is how this shipped broken for so long).
+      - name: Verify preload bundle exists (packaging gate)
+        run: test -f dist-preload/preload.js
+      # [20260816_Fix_PackagedPreload] END
+
       - name: Build renderer
         run: pnpm run build:renderer
 
@@ -177,6 +192,17 @@ jobs:
 
       - name: Build main bundle
         run: pnpm run build:main
+
+      # [20260816_Fix_PackagedPreload] Same as build-mac: the preload bundle
+      # must be built and present before packaging, or the installed app
+      # shows "Electron API 不可用" and nothing works.
+      - name: Build preload bundle
+        run: pnpm run build:preload
+
+      - name: Verify preload bundle exists (packaging gate)
+        shell: bash
+        run: test -f dist-preload/preload.js
+      # [20260816_Fix_PackagedPreload] END
 
       - name: Build renderer
         run: pnpm run build:renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-08-16
+
+### Fixed
+
+- **所有历史安装包缺少 preload 脚本**（v1.0.0 → v1.3.1 均受影响）：Build Installers 流水线的 build-mac/build-win 两个 job 从未执行 `build:preload`，打出的 app.asar 里没有 `dist-preload/preload.js`。安装后主进程能启动、窗口能创建，但渲染进程拿不到 Electron API，界面弹出「Electron API 不可用 / preload 脚本加载失败，主功能均无法工作」，全部功能不可用。此前无人报告的原因：v1.2.0 的 Windows 包在更早的启动阶段就崩溃（#157），mac 用户基数小。修复：两个构建 job 补上 `build:preload`，并新增打包门禁 —— `dist-preload/preload.js` 不存在则拒绝打包（electron-builder 的 files 通配会静默跳过缺失文件，这正是问题长期潜伏的机制）。**请所有用户升级到 v1.3.2；v1.3.1 及更早版本均不可用。**
+
 ## [1.3.1] - 2026-08-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Murmur - 基于FunASR和可配置AI模型的中文优化语音转文字应用",
   "main": "dist-main/main.js",
   "private": true,


### PR DESCRIPTION
## Summary

**Every installer this workflow has ever produced (v1.0.0 → v1.3.1) is missing .** Discovered by installing the released v1.3.1 dmg on a real Mac: the app boots, the window opens, then the renderer shows 「Electron API 不可用 / preload 脚本加载失败，主功能均无法工作」 and nothing works.

## Root cause

The build-mac and build-win jobs run `build:main` + `build:renderer` but **never `build:preload`** (commit d9ef684 added it to the test job only). electron-builder's `files` glob silently skips missing paths, so the asar shipped without the preload and nothing ever failed.

Evidence:
- Released v1.2.0 mac zip: `asar list` shows **0** `dist-preload` entries
- v1.3.1 dmg: same, and the dialog reproduces on a real Mac
- Nobody reported it before because v1.2.0's Windows package crashed even earlier (#157), and the mac user base is small

## Fix

- build-mac + build-win: `pnpm run build:preload` before packaging
- New packaging gate on both jobs: `test -f dist-preload/preload.js` — refuse to package a preload-less app ever again
- Version 1.3.2 + CHANGELOG entry stating all releases ≤ v1.3.1 are unusable

## Verification

- ci:check 10/10 green; YAML validated
- Post-merge I will install the v1.3.2 dmg on this Mac and verify: no preload dialog, renderer processes healthy, and dist-preload present in the shipped asar