### PR TITLE
ci: boot the packaged app before release (mac DMG + win EXE smoke)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,41 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # [20260816_Gate_PackagedBootSmoke] Install the DMG we just built and
+      # boot the real app. Asserts on the boot log: window created, startup
+      # complete, and the renderer→preload→IPC bridge alive (hotkey
+      # registration is sent BY the renderer, so it can only appear when the
+      # preload works). This is the gate that would have caught both the
+      # node-ABI sqlite binary (v1.3.0 mac) and the missing preload script
+      # (all releases ≤ v1.3.1) — "build green" is not "artifact works".
+      - name: Smoke test packaged app (boot + preload bridge)
+        run: |
+          set -euo pipefail
+          DMG=$(ls dist/*.dmg | head -1)
+          hdiutil attach "$DMG" -nobrowse -quiet
+          VOL=$(ls /Volumes | grep -i murmur | head -1)
+          rm -rf /tmp/murmur-smoke && mkdir -p /tmp/murmur-smoke
+          cp -R "/Volumes/$VOL/Murmur.app" /tmp/murmur-smoke/
+          hdiutil detach "/Volumes/$VOL" -quiet || true
+          rm -f "$HOME/Library/Application Support/Murmur/logs/app.log"
+          /tmp/murmur-smoke/Murmur.app/Contents/MacOS/Murmur > /tmp/murmur-smoke/stdout.log 2>&1 &
+          APP_PID=$!
+          sleep 60
+          LOG="$HOME/Library/Application Support/Murmur/logs/app.log"
+          test -f "$LOG" || { echo "::error::app.log never appeared"; cat /tmp/murmur-smoke/stdout.log | tail -20; exit 1; }
+          for milestone in "主窗口创建成功" "应用启动完成" "注册成功"; do
+            grep -q "$milestone" "$LOG" || { echo "::error::boot milestone missing: $milestone"; tail -20 "$LOG"; exit 1; }
+          done
+          if grep -qE "NODE_MODULE_VERSION|Uncaught Exception|preload 脚本加载失败" "$LOG"; then
+            echo "::error::fatal errors in packaged app boot log"
+            grep -E "NODE_MODULE_VERSION|Uncaught Exception|preload" "$LOG" | head -5
+            exit 1
+          fi
+          kill "$APP_PID" 2>/dev/null || true
+          sleep 3
+          pkill -f "murmur-smoke/Murmur.app" 2>/dev/null || true
+          echo "packaged app smoke passed: boot milestones + preload bridge verified"
+      # [20260816_Gate_PackagedBootSmoke] END
       - name: Generate SHA256 checksums
         run: |
           cd dist
@@ -213,6 +248,39 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # [20260816_Gate_PackagedBootSmoke] Windows counterpart of the mac
+      # smoke: silently install the EXE we just built (/S, per-user install
+      # to %LOCALAPPDATA%\Programs\murmur), launch it, and assert the same
+      # boot-log milestones (window created, startup complete, renderer IPC
+      # via hotkey registration) plus absence of fatal boot errors. Would
+      # have caught the v1.2.0 file-uri-to-path crash (#157) before release.
+      - name: Smoke test packaged installer (boot + preload bridge)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $installer = (Get-ChildItem dist -Filter "Murmur.Setup*.exe" | Select-Object -First 1).FullName
+          if (-not $installer) { throw "installer exe not found in dist/" }
+          Write-Host "Installing $installer silently"
+          Start-Process -FilePath $installer -ArgumentList '/S' -Wait
+          $appExe = Join-Path $env:LOCALAPPDATA 'Programs\murmur\Murmur.exe'
+          if (-not (Test-Path $appExe)) { throw "installed app not found at $appExe" }
+          $logDir = Join-Path $env:APPDATA 'Murmur\logs'
+          Remove-Item (Join-Path $logDir 'app.log') -ErrorAction SilentlyContinue
+          Start-Process -FilePath $appExe
+          Start-Sleep -Seconds 90
+          $log = Join-Path $logDir 'app.log'
+          if (-not (Test-Path $log)) { throw "app.log not found at $log" }
+          $content = Get-Content $log -Raw -Encoding UTF8
+          foreach ($milestone in @('主窗口创建成功','应用启动完成','注册成功')) {
+            if ($content -notlike "*$milestone*") { throw "boot milestone missing: $milestone" }
+          }
+          foreach ($fatal in @('NODE_MODULE_VERSION','Uncaught Exception','preload 脚本加载失败')) {
+            if ($content -like "*$fatal*") { throw "fatal error in packaged boot log: $fatal" }
+          }
+          if (-not (Get-Process -Name 'Murmur' -ErrorAction SilentlyContinue)) { throw 'Murmur process is not running' }
+          Stop-Process -Name 'Murmur' -Force -ErrorAction SilentlyContinue
+          Write-Host 'packaged installer smoke passed: boot milestones + preload bridge verified'
+      # [20260816_Gate_PackagedBootSmoke] END
       - name: Generate SHA256 checksums
         shell: pwsh
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,17 @@ chore: 升级 Electron 到 v36
 11. <!-- [20260816_Refactor_RemoveEffects] gate removed with the effects feature -->
 12. **E2E tests** — `pnpm test:e2e`（非阻塞，验证中）
 
+### Release Gates（Build Installers 流水线，tag `v*` 触发）
+
+打包产物在发布前必须通过以下门禁（2026-08-16 v1.3.2 前后陆续引入，此前流水线产出的安装包全部不可用）：
+
+1. **Native ABI gate** — 打包前必须在 Electron 运行时（`ELECTRON_RUN_AS_NODE`）下用 better-sqlite3 真实打开内存库（拦截系统 Node ABI 的 sqlite 二进制，v1.3.0 macOS 事故）
+2. **Preload presence gate** — `dist-preload/preload.js` 不存在则拒绝打包（electron-builder files 通配会静默跳过缺失文件，v1.3.1 及更早全部缺 preload）
+3. **Packaged boot smoke（mac）** — 挂载刚构建的 DMG、真实启动 app，断言启动日志含"主窗口创建成功/应用启动完成/热键注册成功"（热键注册来自渲染进程 IPC，可证明 preload 桥端到端工作）且无致命错误
+4. **Packaged boot smoke（win）** — 静默安装（`/S`）刚构建的 EXE 后同样断言
+
+经验教训：**构建全绿 ≠ 产物可用**。发布流水线的验收对象是"安装后的 app"，不是"dist/ 里有文件"。
+
 ### 本地门禁
 
 提交前在本地运行完整检查（和 CI 一致）：


### PR DESCRIPTION
## Summary

**Every installer this pipeline ever produced was broken in some way while all jobs stayed green** — because nothing ever launched the packaged app. This PR makes the release pipeline boot the real artifact before it can be published:

- **build-mac**: mount the just-built DMG, launch the app, assert boot-log milestones — 主窗口创建成功 / 应用启动完成 / **热键注册成功** (sent BY the renderer → proves the preload bridge end-to-end) — and no fatal errors (NODE_MODULE_VERSION / Uncaught Exception / preload 脚本加载失败)
- **build-win**: silently install the just-built EXE (NSIS /S), launch, same assertions
- CONTRIBUTING.md documents the four release gates

These smoke steps are exact reproductions of the manual verification that caught both the v1.3.0 macOS ABI crash and the missing-preload defect during today's v1.3.x cycle.

## Verification plan

- ci:check 10/10 locally; YAML validated
- After merge: trigger a **workflow_dispatch** run on main (no tag → release job skipped) to prove both smokes pass on real runners before the next tagged release