### PR TITLE
docs: sync knowledge base to post-v1.3.2 release reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Murmur targets **Windows** and **macOS**. See `CLAUDE.md` → _Cross-Platform Su
 
 - Use `process.platform === "win32"` for platform checks, not `os.platform()` or feature detection.
 - Windows paths use backslashes; UNC paths (`\\server\share`) are rejected by `audioPathValidator`.
-- Native modules (`better-sqlite3`) need Electron ABI — on Windows CI, use `--ignore-scripts` + `@electron/rebuild`.
+- Native modules (`better-sqlite3`) need Electron ABI. Hazard: `electron-builder install-app-deps` can silently no-op while pnpm's build allowlist fetches a system-Node-ABI prebuild — release CI forces `@electron/rebuild -f` and gates packaging on a real DB open under Electron (details in `CLAUDE.md` → Cross-Platform Support).
 - Embedded Python (`prepare-embedded-python.js`) supports both macOS (`-apple-darwin`) and Windows (`-pc-windows-msvc-shared`) downloads.
 - Add `it.skipIf(process.platform === "win32")` for Unix-only test behavior.
 
@@ -153,6 +153,7 @@ Murmur targets **Windows** and **macOS**. See `CLAUDE.md` → _Cross-Platform Su
 - **Bug fix:** reproduce the bug, add a failing test **first**, then fix and verify.
 - **High-risk** (session flow, IPC, security, privacy, release packaging): include a risk statement and fresh verification evidence.
 - **Gate failure:** run `node scripts/ci-check.js --json` to diagnose; use `--fix` for auto-fixable issues.
+- **Releases:** push a `v*` tag → `build.yml` builds installers behind four release gates (native ABI, preload presence, mac/win packaged boot smoke). Never bypass or downgrade these gates — every release before v1.3.2 shipped broken while CI stayed green. See `CONTRIBUTING.md` → Release Gates.
 
 ### Commit Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,8 @@ Murmur targets **Windows** and **macOS** (Apple Silicon). Code must work on both
 - **Python paths**: macOS uses `python/bin/python3.11` (embedded); Windows uses `python/python.exe` (embedded). The `prepare-embedded-python.js` script supports both platforms via platform-aware getters (`pythonBin`, `sitePackagesPath`, `downloadPlatform`).
 - **Process management**: `gracefulShutdown()` uses `taskkill /T /F /PID` on Windows, `proc.kill("SIGKILL")` on Unix — see `src/helpers/funasrServer.ts`.
 - **Path validation**: `audioPathValidator.ts` allows all `C:\` drive paths on Windows; UNC paths (`\\server\share`) are rejected early to avoid network timeouts. macOS uses realpath + `/Volumes/` prefix checks.
-- **Native modules**: `better-sqlite3` needs Electron ABI. On Windows CI, `electron-builder install-app-deps` can't fork `pnpm.mjs` — use `--ignore-scripts` + `npx @electron/rebuild` instead.
-- **CI build**: `.github/workflows/build.yml` runs `build-win` on `windows-latest` and `build-mac` on `macos-latest`. The embedded Python step is `continue-on-error` on Windows.
+- **Native modules**: `better-sqlite3` needs the Electron ABI. Beware: `electron-builder install-app-deps` can silently no-op (~0.2s "finished") while pnpm's `onlyBuiltDependencies` allowlist lets better-sqlite3's own install fetch a system-Node-ABI prebuild — the release pipeline therefore forces `npx @electron/rebuild -f -w better-sqlite3` and gates packaging on a real DB open under Electron. Locally: `pnpm rebuild better-sqlite3` before tests, `npx electron-rebuild` before dev.
+- **CI build**: `.github/workflows/build.yml` runs `build-win` on `windows-latest` and `build-mac` on `macos-latest` (embedded Python is `continue-on-error` on Windows). Releases are tag-triggered (`v*`) and must pass the four release gates — native ABI, preload presence, mac/win packaged boot smoke — documented in `CONTRIBUTING.md` → Release Gates. The NSIS installer is named `Murmur Setup <version>.exe` (spaces, not dots).
 
 When adding platform-specific code, use `process.platform === "win32"` checks. Add tests with `it.skipIf(process.platform === "win32")` for Unix-only behavior.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ chore: 升级 Electron 到 v36
 4. **Security audit** — `pnpm audit --audit-level moderate`（非阻塞）
 5. **License compliance** — `pnpm license:check`（拦截 GPL/AGPL）
 6. **Dependency review** — PR 中自动审查新增依赖（high 级别阻断）
-7. **Test + coverage** — `pnpm test -- --coverage`（覆盖率阈值：全 src/ 统计，statements 44% / branches 37% / functions 42% / lines 44%；后端 helpers 层独立 95%+）
+7. **Test + coverage** — `pnpm test -- --coverage`（覆盖率阈值：全 src/ 统计，statements 96% / branches 92% / functions 94% / lines 96%，2026-08-16 起以 1406+ 用例维持）
 8. **Build main** — `pnpm run build:main`
 9. **Build preload** — `pnpm run build:preload`
 10. **Build renderer** — `pnpm run build:renderer`
@@ -148,11 +148,7 @@ pnpm ci:check --e2e    # 含 e2e（慢）
 pnpm lint && pnpm test # 快速迭代
 ```
 
-**覆盖率回归路线图**：全 src/ 覆盖率当前 46%（statements），后端 helpers 层 95%+。缺口在前端 React 组件（需要 jsdom + RTL）。
-
-- v1.1.0 目标：55%（加 App.tsx + settings 测试）
-- v1.2.0 目标：70%（加 history.tsx + hooks 测试）
-- v1.3.0 目标：80%+（全组件覆盖，对齐业界标准）
+**覆盖率现状**：全 src/ 覆盖率 96.6% statements / 92.8% branches / 94.5% functions / 97.1% lines（2026-08-16，PR #166 达成）。此前的追赶路线图（55% → 70% → 80%）已完成并关闭。
 
 ## 架构概览
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -77,3 +77,18 @@ Adding a new setting to Murmur requires touching **5 places**, and missing any o
 Downscaling a 1024px full-color app icon to 16×16 tray size produces an unreadable blob — the kawaii detail collapses. macOS tray also forces `setTemplateImage(true)` which strips color to a monochrome silhouette.
 
 **Rule:** Ship a dedicated `tray-icon-16.png` (manually optimized for tiny sizes) rather than reusing the app icon. For colored brand tray icons (Discord/Slack style), remove `setTemplateImage(true)`. See `tray.ts` `getTrayIconPath()` for the platform-conditional resolution.
+
+---
+
+## L7: Build green ≠ artifact works — gate releases on installing and booting the packaged app
+
+**Date:** 2026-08-16
+**Context:** The v1.3.x release cycle (v1.2.0 → v1.3.2). Every installer the pipeline ever produced was broken in some way while all workflow jobs stayed green.
+
+Three stacked root causes, each invisible to "did the build finish" checks:
+
+1. **electron-builder's `files` glob silently skips missing paths.** The build jobs never ran `build:preload`, so `dist-preload/preload.js` simply wasn't in the asar — for every release ≤ v1.3.1. The app booted, then the renderer showed 「Electron API 不可用」 with zero functionality. Nothing failed because nothing looked.
+2. **`electron-builder install-app-deps` can silently no-op (~0.2s "finished").** With pnpm's `onlyBuiltDependencies` allowlist, better-sqlite3's own install script fetches a system-Node-ABI prebuild (ABI 137); the "rebuild" never replaced it, so the v1.3.0 macOS dmg crashed on first `new Database()`. Local builds survived by luck (warm pnpm store held an Electron-ABI build), which is why local verification passed while CI shipped broken.
+3. **pnpm only links `node_modules/.bin` shims for direct dependencies.** electron-builder 26 pulled `@electron/rebuild` in transitively; `npx` then found the package locally without its bin shim → "'electron-rebuild' is not recognized" on Windows CI.
+
+**Rule:** The release pipeline's acceptance object is "the installed app", not "files in dist/". Four gates now enforce this in `build.yml` (see `CONTRIBUTING.md` → Release Gates): native-ABI gate (open a real in-memory DB under `ELECTRON_RUN_AS_NODE` Electron), preload-presence gate (`test -f dist-preload/preload.js`), mac packaged boot smoke (mount the DMG, launch, assert 主窗口创建成功 / 应用启动完成 / 热键注册成功 — the last is renderer→preload→IPC, proving the bridge), and the Windows NSIS silent-install counterpart. When verifying locally, remember `require('better-sqlite3')` alone proves nothing — the addon loads lazily inside `new Database()`. And never run `asar extract-file` from the repo root: it writes the file's basename into the CWD (this clobbered package.json once).


### PR DESCRIPTION
Neat-freak knowledge-base pass after the v1.3.x release cycle. Fixes stale facts and promotes this session's hard-won lessons into the repo docs:

- **CLAUDE.md / AGENTS.md** — the native-modules/CI bullet predated the release-pipeline hardening; now states the real hazards (install-app-deps silent no-op, pnpm onlyBuiltDependencies system-Node prebuilds) and points at the four release gates.
- **CONTRIBUTING.md** — coverage numbers were still at the v1.1.0-era 44/46%; corrected to 96.6/92.8/94.5/97.1 with thresholds 96/92/94/96, closed the finished 55→70→80 roadmap.
- **tasks/lessons.md** — new L7: build green ≠ artifact works; the three stacked root causes; the four gates; local verification pitfalls.

Docs-only. ci:check 10/10.