### PR TITLE
feat: SeACo model swap with old-model rollback (T15, #192)

### DIFF
--- a/download_models.py
+++ b/download_models.py
@@ -42,8 +42,12 @@ def main():
     
     # 模型配置
     models = [
+        # [20260820_T15_SeacoSwap] Hotword-capable SeACo variant (T13:
+        # zero CER regression, timestamps intact). The old paraformer is
+        # NOT downloaded fresh — it remains on disk as the rollback for
+        # upgrading users.
         {
-            "name": "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+            "name": "damo/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
             "type": "asr"
         },
         {

--- a/funasr_server.py
+++ b/funasr_server.py
@@ -264,24 +264,33 @@ class FunASRServer:
         logger.info(f"收到信号 {signum}，准备退出...")
         self.running = False
 
-    def _load_asr_model(self):
-        """加载ASR模型"""
-        try:
-            logger.info("开始加载ASR模型...")
-            with suppress_stdout():
-                from funasr import AutoModel
+    # [20260820_T15_SeacoSwap] Ticket #192: primary = hotword-capable
+    # SeACo (T13 spike: zero CER regression, timestamps intact); the old
+    # paraformer stays as the ROLLBACK when SeACo fails to load (missing
+    # files mid-upgrade, corrupt download) — the app stays usable.
+    ASR_MODEL_SEACO = "damo/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
+    ASR_MODEL_FALLBACK = "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
 
-                self.asr_model = AutoModel(
-                    model="damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-                    model_revision="v2.0.4",
-                    disable_update=True,
-                    device=self.device,
-                )
-            logger.info("ASR模型加载完成")
-            return True
-        except Exception as e:
-            logger.error(f"ASR模型加载失败: {str(e)}")
-            return False
+    def _load_asr_model(self):
+        """加载ASR模型（SeACo 优先，旧模型回退）"""
+        from funasr import AutoModel
+
+        for model_name in (self.ASR_MODEL_SEACO, self.ASR_MODEL_FALLBACK):
+            try:
+                logger.info(f"开始加载ASR模型: {model_name}")
+                with suppress_stdout():
+                    self.asr_model = AutoModel(
+                        model=model_name,
+                        model_revision="v2.0.4",
+                        disable_update=True,
+                        device=self.device,
+                    )
+                logger.info(f"ASR模型加载完成: {model_name}")
+                self.asr_model_name = model_name
+                return True
+            except Exception as e:
+                logger.error(f"ASR模型加载失败({model_name}): {str(e)}")
+        return False
 
     def _load_vad_model(self):
         """加载VAD模型"""
@@ -1279,12 +1288,19 @@ class FunASRServer:
         cache_path = self.damo_root if self.damo_root else _default_damo_root()
         logger.info(f"使用的模型根目录(damo root): {cache_path}")
 
-        repos = [
+        # [20260820_T15_SeacoSwap] Either ASR generation satisfies the
+        # required-ASR check (SeACo for fresh installs / upgraded users,
+        # old paraformer for mid-upgrade rollback states).
+        vad_repo = "speech_fsmn_vad_zh-cn-16k-common-pytorch"
+        asr_repos = [
+            "speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
             "speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-            "speech_fsmn_vad_zh-cn-16k-common-pytorch",
+        ]
+        repos = asr_repos + [
+            vad_repo,
             "punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
         ]
-        required_repos = repos[:2]  # ASR + VAD are required; punc is optional
+        # ASR (either generation) + VAD are required; punc is optional.
 
         def _repo_ready(repo_dir):
             # 目录存在且包含任意常见权重/配置文件即认为已就绪
@@ -1299,11 +1315,12 @@ class FunASRServer:
                     return True
             return False
 
-        missing_required = []
-        for r in required_repos:
-            rd = os.path.join(cache_path, r)
-            if not _repo_ready(rd):
-                missing_required.append(r)
+        asr_satisfied = any(
+            _repo_ready(os.path.join(cache_path, r)) for r in asr_repos
+        )
+        missing_required = [] if asr_satisfied else asr_repos[:1]
+        if not _repo_ready(os.path.join(cache_path, vad_repo)):
+            missing_required.append(vad_repo)
 
         if not missing_required:
             logger.info("模型文件存在，开始初始化")

--- a/funasr_server.py
+++ b/funasr_server.py
@@ -122,6 +122,9 @@ def compute_inference_threads(cores, override=None):
 class FunASRServer:
     def __init__(self, damo_root=None):
         self.asr_model = None
+        # [20260820_T15_SeacoSwap] Which ASR generation actually loaded
+        # (exposed via check_status so the UI can flag degraded hotwords).
+        self.asr_model_name = None
         self.vad_model = None
         self.punc_model = None
         self.cam_model = None
@@ -271,11 +274,35 @@ class FunASRServer:
     ASR_MODEL_SEACO = "damo/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
     ASR_MODEL_FALLBACK = "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
 
+    # [20260820_T15_SeacoSwap] Promoted from a nested run() helper: the
+    # ASR loader's disk-presence gate needs the same resolution.
+    @staticmethod
+    def _default_damo_root():
+        """解析默认模型根目录（MODELSCOPE_CACHE 兼容两种布局）"""
+        root = os.environ.get("MODELSCOPE_CACHE")
+        if root:
+            if os.path.isdir(os.path.join(root, "damo")):
+                return os.path.join(root, "damo")
+            if os.path.isdir(os.path.join(root, "hub", "damo")):
+                return os.path.join(root, "hub", "damo")
+        home_dir = os.path.expanduser("~")
+        return os.path.join(home_dir, ".cache", "modelscope", "hub", "damo")
+
     def _load_asr_model(self):
         """加载ASR模型（SeACo 优先，旧模型回退）"""
         from funasr import AutoModel
 
-        for model_name in (self.ASR_MODEL_SEACO, self.ASR_MODEL_FALLBACK):
+        # [T15 review BLOCKER] Disk-presence gate: a repo id that is NOT
+        # on local disk must be skipped WITHOUT calling AutoModel — funasr
+        # auto-downloads ~1GB from modelscope on cache miss, silently
+        # defeating the rollback (or blowing the 300s init timeout).
+        cache_path = self.damo_root or self._default_damo_root()
+        candidates = [
+            m
+            for m in (self.ASR_MODEL_SEACO, self.ASR_MODEL_FALLBACK)
+            if os.path.isdir(os.path.join(cache_path, m.split("/", 1)[1]))
+        ]
+        for model_name in candidates:
             try:
                 logger.info(f"开始加载ASR模型: {model_name}")
                 with suppress_stdout():
@@ -1032,6 +1059,9 @@ class FunASRServer:
             "models_loaded": {
                 "asr": self.asr_model is not None,
                 "vad": self.vad_model is not None,
+            # [T15 review MINOR] Surface the loaded generation so the UI
+            # can flag silent hotword degradation on the old model.
+            "asr_model": self.asr_model_name,
                 "punc": self.punc_model is not None,
             },
         }
@@ -1049,6 +1079,9 @@ class FunASRServer:
                 "models": {
                     "asr": self.asr_model is not None,
                     "vad": self.vad_model is not None,
+            # [T15 review MINOR] Surface the loaded generation so the UI
+            # can flag silent hotword degradation on the old model.
+            "asr_model": self.asr_model_name,
                     "punc": self.punc_model is not None,  # FunASR标点恢复模型状态
                 },
             }
@@ -1271,21 +1304,7 @@ class FunASRServer:
         logger.info("FunASR服务器启动")
 
         # 解析 damo 根目录
-        def _default_damo_root():
-            # 允许通过 MODELSCOPE_CACHE 指定根；常见是 ~/.cache/modelscope/hub/damo
-            root = os.environ.get("MODELSCOPE_CACHE")
-            if root:
-                # 兼容两种布局：<cache>/damo 或 <cache>/hub/damo
-                if os.path.isdir(os.path.join(root, "damo")):
-                    return os.path.join(root, "damo")
-                if os.path.isdir(os.path.join(root, "hub", "damo")):
-                    return os.path.join(root, "hub", "damo")
-                # 像 Node 一样自定义到 /Volumes/APFS/AI/models/damo，就直接传入 --damo-root
-            # 默认回到用户主目录的 modelscope/hub/damo
-            home_dir = os.path.expanduser("~")
-            return os.path.join(home_dir, ".cache", "modelscope", "hub", "damo")
-
-        cache_path = self.damo_root if self.damo_root else _default_damo_root()
+        cache_path = self.damo_root if self.damo_root else self._default_damo_root()
         logger.info(f"使用的模型根目录(damo root): {cache_path}")
 
         # [20260820_T15_SeacoSwap] Either ASR generation satisfies the
@@ -1295,10 +1314,6 @@ class FunASRServer:
         asr_repos = [
             "speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
             "speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-        ]
-        repos = asr_repos + [
-            vad_repo,
-            "punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
         ]
         # ASR (either generation) + VAD are required; punc is optional.
 

--- a/src/helpers/modelManager.ts
+++ b/src/helpers/modelManager.ts
@@ -213,20 +213,39 @@ class ModelManager {
     > = {};
 
     for (const [modelType, config] of Object.entries(this.modelConfigs)) {
+      // [20260820_T15_SeacoSwap] Fallback-aware check: a missing/incomplete
+      // PRIMARY counts as "not fully downloaded" (upgrade entry stays
+      // visible), but if the recorded FALLBACK is ready the model still
+      // satisfies minimum_ready — the server runs on the old generation
+      // instead of refusing to start (review MAJOR fix).
+      let isComplete = false;
       const modelFile = path.join(cachePath, config.cache_path);
       if (fs.existsSync(modelFile)) {
-        const isComplete = this._verifyModel(modelFile, config);
-        modelDetails[modelType] = { downloaded: true, complete: isComplete };
-        if (!isComplete) {
-          allDownloaded = false;
-          missingModels.push(modelType);
-          if (config.required) minimumReady = false;
+        isComplete = this._verifyModel(modelFile, config);
+      }
+      let ready = isComplete;
+      if (!ready && config.fallback_name) {
+        const fallbackFile = path.join(
+          cachePath,
+          config.fallback_name.split("/").slice(1).join("/"),
+        );
+        if (fs.existsSync(fallbackFile)) {
+          ready = this._verifyModel(fallbackFile, {
+            ...config,
+            cache_path: config.fallback_name.split("/").slice(1).join("/"),
+          });
         }
-      } else {
+      }
+      modelDetails[modelType] = { downloaded: ready, complete: ready };
+      if (!ready) {
         allDownloaded = false;
         missingModels.push(modelType);
-        modelDetails[modelType] = { downloaded: false };
         if (config.required) minimumReady = false;
+      } else if (!isComplete) {
+        // Fallback carries readiness, but the primary is absent — surface
+        // the upgrade without blocking startup.
+        allDownloaded = false;
+        missingModels.push(modelType);
       }
     }
 

--- a/src/helpers/modelManager.ts
+++ b/src/helpers/modelManager.ts
@@ -21,6 +21,10 @@ interface ModelConfig {
   cache_path: string;
   expected_size: number;
   required: boolean;
+  // [20260820_T15_SeacoSwap] Optional rollback model — accepted by
+  // checkModelFiles when the primary is absent (upgrade-in-progress /
+  // failed download keeps the app usable on the old model).
+  fallback_name?: string;
 }
 
 interface ModelCheckResult {
@@ -52,10 +56,16 @@ class ModelManager {
     this.modelsDownloaded = null;
     this.modelConfigs = {
       asr: {
-        name: "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+        // [20260820_T15_SeacoSwap] SeACo-Paraformer (hotword-capable, T13
+        // spike: zero CER regression, timestamps present, 952.7 MB). The
+        // old paraformer stays recorded as the rollback target — the
+        // server falls back to it when SeACo fails to load.
+        name: "damo/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+        fallback_name:
+          "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
         cache_path:
-          "speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-        expected_size: 840 * 1024 * 1024,
+          "speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+        expected_size: Math.round(952.7 * 1024 * 1024),
         required: true,
       },
       vad: {
@@ -82,7 +92,11 @@ class ModelManager {
           const damoPath = path.join(startDir, entry.name);
           const subdirs = fs.readdirSync(damoPath, { withFileTypes: true });
           const hasExpectedModel = subdirs.some(
-            (m) => m.isDirectory() && m.name.startsWith("speech_paraformer"),
+            // [20260820_T15_SeacoSwap] Either ASR generation marks a valid damo root.
+            (m) =>
+              m.isDirectory() &&
+              (m.name.startsWith("speech_seaco_paraformer") ||
+                m.name.startsWith("speech_paraformer")),
           );
           if (hasExpectedModel) return damoPath;
         }
@@ -144,6 +158,7 @@ class ModelManager {
           .readdirSync(candidate)
           .some(
             (n) =>
+              n.startsWith("speech_seaco_paraformer") ||
               n.startsWith("speech_paraformer") ||
               n.startsWith("speech_fsmn") ||
               n.startsWith("punc_ct"),

--- a/tests/python/test_seaco_fallback.py
+++ b/tests/python/test_seaco_fallback.py
@@ -1,0 +1,123 @@
+# [20260820_T15_SeacoSwap] Ticket #192 review fixups: BEHAVIOR tests for
+# the ASR fallback (the TS source-contract anchors prove sync, not
+# correctness). RED first.
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ),
+)
+
+os.environ.setdefault("MURMUR_DEVICE", "cpu")
+
+import funasr_server  # noqa: E402
+from funasr_server import FunASRServer  # noqa: E402
+
+SEACO_DIR = funasr_server.FunASRServer.ASR_MODEL_SEACO.split("/", 1)[1]
+OLD_DIR = funasr_server.FunASRServer.ASR_MODEL_FALLBACK.split("/", 1)[1]
+
+
+class AsrFallbackTest(unittest.TestCase):
+    def _make_repo(self, root, repo_dir):
+        os.makedirs(os.path.join(root, repo_dir), exist_ok=True)
+        # One config-ish file satisfies _repo_ready's glob patterns.
+        with open(os.path.join(root, repo_dir, "config.json"), "w") as f:
+            f.write("{}")
+
+    def test_disk_presence_gate_skips_absent_seaco(self):
+        # [review BLOCKER] A model whose repo dir is NOT on disk must be
+        # skipped WITHOUT any AutoModel call — funasr auto-downloads ~1GB
+        # from modelscope on cache miss, which is exactly what the
+        # fallback exists to prevent.
+        import types
+
+        calls = []
+        fake_funasr = types.ModuleType("funasr")
+
+        def fake_automodel(model=None, **kwargs):
+            calls.append(model)
+            return object()
+
+        fake_funasr.AutoModel = fake_automodel
+        real = sys.modules.get("funasr")
+        sys.modules["funasr"] = fake_funasr
+        try:
+            with tempfile.TemporaryDirectory() as root:
+                self._make_repo(root, OLD_DIR)  # old model present only
+                srv = FunASRServer(damo_root=root)
+                ok = srv._load_asr_model()
+        finally:
+            if real is not None:
+                sys.modules["funasr"] = real
+            else:
+                sys.modules.pop("funasr", None)
+        self.assertTrue(ok)
+        self.assertEqual(calls, [FunASRServer.ASR_MODEL_FALLBACK])
+        self.assertEqual(srv.asr_model_name, FunASRServer.ASR_MODEL_FALLBACK)
+
+    def test_seaco_load_failure_falls_back_to_old(self):
+        # Both on disk; SeACo LOAD throws (corrupt download) → old loads.
+        import types
+
+        calls = []
+        fake_funasr = types.ModuleType("funasr")
+
+        def fake_automodel(model=None, **kwargs):
+            calls.append(model)
+            if "seaco" in model:
+                raise RuntimeError("corrupt weights")
+            return object()
+
+        fake_funasr.AutoModel = fake_automodel
+        real = sys.modules.get("funasr")
+        sys.modules["funasr"] = fake_funasr
+        try:
+            with tempfile.TemporaryDirectory() as root:
+                self._make_repo(root, SEACO_DIR)
+                self._make_repo(root, OLD_DIR)
+                srv = FunASRServer(damo_root=root)
+                ok = srv._load_asr_model()
+        finally:
+            if real is not None:
+                sys.modules["funasr"] = real
+            else:
+                sys.modules.pop("funasr", None)
+        self.assertTrue(ok)
+        self.assertEqual(
+            calls,
+            [FunASRServer.ASR_MODEL_SEACO, FunASRServer.ASR_MODEL_FALLBACK],
+        )
+
+    def test_neither_on_disk_returns_false(self):
+        import types
+
+        fake_funasr = types.ModuleType("funasr")
+        fake_funasr.AutoModel = lambda **kw: (_ for _ in ()).throw(
+            AssertionError("must not be called when nothing is on disk")
+        )
+        real = sys.modules.get("funasr")
+        sys.modules["funasr"] = fake_funasr
+        try:
+            with tempfile.TemporaryDirectory() as root:
+                srv = FunASRServer(damo_root=root)
+                ok = srv._load_asr_model()
+        finally:
+            if real is not None:
+                sys.modules["funasr"] = real
+            else:
+                sys.modules.pop("funasr", None)
+        self.assertFalse(ok)
+        self.assertIsNone(srv.asr_model_name)
+
+    def test_asr_model_name_defaults_none(self):
+        srv = FunASRServer(damo_root="/tmp/test-damo")
+        self.assertIsNone(srv.asr_model_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/seaco-fallback-check.test.ts
+++ b/tests/unit/seaco-fallback-check.test.ts
@@ -1,0 +1,87 @@
+// [20260820_T15_SeacoSwap] Ticket #192 review MAJOR: checkModelFiles must
+// honor the old-model fallback — an old-only layout (upgrading user whose
+// SeACo download hasn't run/failed) must report minimum_ready=true so the
+// server is allowed to start, while models_downloaded stays false so the
+// upgrade entry point remains visible. RED first.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+vi.mock("electron", () => ({
+  app: { getPath: vi.fn(() => "/tmp") },
+}));
+
+import ModelManager from "../../src/helpers/modelManager";
+
+interface Surface {
+  clearCache(): void;
+  getModelCachePath(): string;
+  modelConfigs: Record<string, { cache_path: string; fallback_name?: string }>;
+  checkModelFiles(): Promise<{
+    models_downloaded: boolean;
+    minimum_ready: boolean;
+    missing_models: string[];
+    model_details: Record<string, { downloaded: boolean }>;
+  }>;
+}
+
+function asSurface(m: ModelManager): Surface {
+  return m as unknown as Surface;
+}
+
+const SEACO_DIR =
+  "speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch";
+const OLD_DIR =
+  "speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch";
+const VAD_DIR = "speech_fsmn_vad_zh-cn-16k-common-pytorch";
+
+function seedRepo(cache: string, dir: string) {
+  fs.mkdirSync(path.join(cache, dir), { recursive: true });
+  fs.writeFileSync(path.join(cache, dir, "model.pt"), "x");
+}
+
+describe("[20260820_T15_SeacoSwap] checkModelFiles fallback", () => {
+  let cache: string;
+
+  beforeEach(() => {
+    cache = fs.mkdtempSync(path.join(os.tmpdir(), "t15-fb-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cache, { recursive: true, force: true });
+  });
+
+  function makeManager(): Surface {
+    const m = asSurface(new ModelManager(null));
+    m.clearCache();
+    m.getModelCachePath = () => cache;
+    return m;
+  }
+
+  it("old-only layout (upgrading user): minimum_ready=true, models_downloaded=false", async () => {
+    seedRepo(cache, OLD_DIR);
+    seedRepo(cache, VAD_DIR);
+    const result = await makeManager().checkModelFiles();
+    expect(result.minimum_ready).toBe(true);
+    expect(result.models_downloaded).toBe(false);
+    expect(result.model_details.asr?.downloaded).toBe(true);
+  });
+
+  it("both generations present: fully downloaded (SeACo counts)", async () => {
+    seedRepo(cache, SEACO_DIR);
+    seedRepo(cache, OLD_DIR);
+    seedRepo(cache, VAD_DIR);
+    seedRepo(cache, "punc_ct-transformer_zh-cn-common-vocab272727-pytorch");
+    const result = await makeManager().checkModelFiles();
+    expect(result.minimum_ready).toBe(true);
+    expect(result.models_downloaded).toBe(true);
+  });
+
+  it("neither ASR on disk: minimum_ready=false, only 'asr' missing", async () => {
+    seedRepo(cache, VAD_DIR);
+    const result = await makeManager().checkModelFiles();
+    expect(result.minimum_ready).toBe(false);
+    expect(result.missing_models).toContain("asr");
+  });
+});

--- a/tests/unit/seaco-model-catalog.test.ts
+++ b/tests/unit/seaco-model-catalog.test.ts
@@ -1,0 +1,78 @@
+// [20260820_T15_SeacoSwap] Ticket #192: catalog sync + fallback contract.
+// RED first — every sync point that T13 flagged must move to SeACo while
+// the OLD paraformer remains a valid fallback (load-failure rollback).
+import { describe, it, expect, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+
+vi.mock("electron", () => ({
+  app: { getPath: vi.fn(() => "/tmp") },
+}));
+
+import ModelManager from "../../src/helpers/modelManager";
+
+const ROOT = path.join(__dirname, "../..");
+
+describe("[20260820_T15_SeacoSwap] model catalog", () => {
+  it("asr config points at SeACo with the T13-measured expected size", () => {
+    const mgr = new ModelManager(null);
+    const cfg = mgr.modelConfigs.asr!;
+    expect(cfg.name).toBe(
+      "damo/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+    );
+    // T13 spike: 952.7 MB on disk.
+    expect(cfg.expected_size).toBe(Math.round(952.7 * 1024 * 1024));
+    expect(cfg.required).toBe(true);
+  });
+
+  it("fallback ASR (old paraformer) is recorded for rollback", () => {
+    const mgr = new ModelManager(null);
+    const cfg = mgr.modelConfigs.asr as { fallback_name?: string };
+    expect(cfg.fallback_name).toBe(
+      "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+    );
+  });
+});
+
+describe("[20260820_T15_SeacoSwap] source-contract sync points", () => {
+  const read = (p: string) => fs.readFileSync(path.join(ROOT, p), "utf-8");
+
+  it("funasr_server loads SeACo with paraformer fallback", () => {
+    const src = read("funasr_server.py");
+    // Class constants + loader loop (constants sit above the method).
+    expect(src).toContain(
+      'ASR_MODEL_SEACO = "damo/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"',
+    );
+    expect(src).toContain(
+      'ASR_MODEL_FALLBACK = "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"',
+    );
+    const loadBody = src.slice(
+      src.indexOf("def _load_asr_model"),
+      src.indexOf("def _load_vad_model"),
+    );
+    expect(loadBody).toContain("for model_name in");
+    expect(loadBody).toContain("self.asr_model_name = model_name");
+  });
+
+  it("startup repo check accepts either ASR generation", () => {
+    const src = read("funasr_server.py");
+    const check = src.slice(
+      src.indexOf("asr_repos = ["),
+      src.indexOf("if not missing_required:"),
+    );
+    expect(check).toContain("speech_seaco_paraformer_large");
+    expect(check).toContain("speech_paraformer-large");
+    expect(check).toContain("asr_satisfied");
+  });
+
+  it("cache discovery prefixes include the SeACo directory", () => {
+    const src = read("src/helpers/modelManager.ts");
+    expect(src).toContain('startsWith("speech_seaco_paraformer")');
+    expect(src).toContain('startsWith("speech_paraformer")');
+  });
+
+  it("download script table carries SeACo", () => {
+    const src = read("download_models.py");
+    expect(src).toContain("speech_seaco_paraformer_large");
+  });
+});


### PR DESCRIPTION
## Summary
T15 of spec #177: the ASR model becomes SeACo-Paraformer (hotword-capable), with the old paraformer retained as a rollback so a mid-upgrade or corrupt download never bricks transcription.

- Loader: SeACo primary → old paraformer fallback (`asr_model_name` records which generation loaded)
- Startup repo check: either ASR generation satisfies the required gate
- Catalog: SeACo + T13-measured 952.7MB + fallback_name; both cache-discovery prefix sites accept the new directory (fixes the prefix-miss bug from the platform scan)
- download_models.py: fresh installs fetch SeACo only; old model stays on disk as rollback for upgraders

## Verification
- 6 red-first catalog/contract tests; full gate 11/11
- **End-to-end on the real pipeline**: SeACo loads in 6.3s from cache; hotword smoke through the loaded model fixes the rare-noun case (张含月 → 张晗玥)

Deferred (recorded on ticket + #197): sha256 integrity, old-cache cleanup prompt, server-path timestamp sweep.

Closes #192