### PR TITLE
feat: unload/reload protocol actions with worker-thread reload (T11, #189)

### DIFF
--- a/funasr_server.py
+++ b/funasr_server.py
@@ -79,6 +79,9 @@ THREAD_CAP = 8
 # catches corrupted-DB / renderer-bug payloads that reach the protocol).
 HOTWORD_MAX_CHARS = 4096
 
+# [T11 review NIT] Shared error message for failed (re)initialization.
+INIT_FAILED_MESSAGE = "模型初始化失败"
+
 
 def sanitize_hotword(value):
     """Coerce a protocol hotword to a safe string ('' on non-string).
@@ -139,7 +142,7 @@ class FunASRServer:
         # [20260821_T11_UnloadReload] Serializes initialize() across the
         # main read loop (mic lazy-init) and the inference worker
         # (reload_models) — concurrent double model load = memory blowup.
-        self._init_lock = threading.Lock()
+        self._init_lock = threading.RLock()
         self._inference_thread = None
         self._output_thread = None
 
@@ -471,126 +474,132 @@ class FunASRServer:
         # non-finite input rejection) must not hit an unbound name in the
         # finally cleanup.
         infer_path = audio_path
-        # [20260821_T11_UnloadReload] Lock-guarded lazy init (worker
-        # reload can race this main-loop path).
-        if not self._ensure_initialized():
-            return {"success": False, "error": "模型初始化失败", "type": "init_error"}
+        # [T11 review MAJOR] Hold the models lock across the whole
+        # inference section: a worker unload/reload defers instead of
+        # freeing models mid-generate (busy = deferred, never
+        # concurrent — now true in BOTH directions). RLock because
+        # _ensure_initialized re-acquires inside.
+        with self._init_lock:
+            # [20260821_T11_UnloadReload] Lock-guarded lazy init (worker
+            # reload can race this main-loop path).
+            if not self._ensure_initialized():
+                return {"success": False, "error": INIT_FAILED_MESSAGE, "type": "init_error"}
 
-        try:
-            # 检查音频文件是否存在
-            if not os.path.exists(audio_path):
-                return {"success": False, "error": f"音频文件不存在: {audio_path}"}
+            try:
+                # 检查音频文件是否存在
+                if not os.path.exists(audio_path):
+                    return {"success": False, "error": f"音频文件不存在: {audio_path}"}
 
-            logger.info(f"开始转录音频文件: {audio_path}")
+                logger.info(f"开始转录音频文件: {audio_path}")
 
-            # 设置默认选项
-            default_options = {
-                "batch_size_s": 60,
-                "hotword": "",
-                "use_vad": True,
-                "use_punc": True,  # 使用FunASR自带的标点恢复
-                "language": "zh",
-            }
+                # 设置默认选项
+                default_options = {
+                    "batch_size_s": 60,
+                    "hotword": "",
+                    "use_vad": True,
+                    "use_punc": True,  # 使用FunASR自带的标点恢复
+                    "language": "zh",
+                }
 
-            if options:
-                default_options.update(options)
+                if options:
+                    default_options.update(options)
 
-            # [20260820_T14_Hotwords] Defense-in-depth: coerce the hotword
-            # option to a safe string before it reaches generate().
-            default_options["hotword"] = sanitize_hotword(
-                default_options.get("hotword", "")
-            )
-
-            # [20260819_T7_MicPreprocess] Ticket #186 (spec #177 T7): run the
-            # DSP module on the push-to-talk path too. The renderer delivers
-            # a 16k mono WAV temp (created/cleaned by the TS side); the DSP
-            # output below is OUR temp and is unlinked in the finally block.
-            # Fallback policy mirrors the file path (see _apply_preprocessing).
-            infer_path = self._apply_preprocessing(audio_path)
-
-            # 执行语音识别
-            if default_options["use_vad"]:
-                vad_result = self.vad_model.generate(
-                    input=infer_path, batch_size_s=default_options["batch_size_s"]
+                # [20260820_T14_Hotwords] Defense-in-depth: coerce the hotword
+                # option to a safe string before it reaches generate().
+                default_options["hotword"] = sanitize_hotword(
+                    default_options.get("hotword", "")
                 )
-                logger.info("VAD处理完成")
 
-            # 执行ASR识别
-            asr_result = self.asr_model.generate(
-                input=infer_path,
-                batch_size_s=default_options["batch_size_s"],
-                hotword=default_options["hotword"],
-                cache={},
-            )
+                # [20260819_T7_MicPreprocess] Ticket #186 (spec #177 T7): run the
+                # DSP module on the push-to-talk path too. The renderer delivers
+                # a 16k mono WAV temp (created/cleaned by the TS side); the DSP
+                # output below is OUR temp and is unlinked in the finally block.
+                # Fallback policy mirrors the file path (see _apply_preprocessing).
+                infer_path = self._apply_preprocessing(audio_path)
 
-            # 提取识别文本
-            if isinstance(asr_result, list) and len(asr_result) > 0:
-                if isinstance(asr_result[0], dict) and "text" in asr_result[0]:
-                    raw_text = asr_result[0]["text"]
+                # 执行语音识别
+                if default_options["use_vad"]:
+                    vad_result = self.vad_model.generate(
+                        input=infer_path, batch_size_s=default_options["batch_size_s"]
+                    )
+                    logger.info("VAD处理完成")
+
+                # 执行ASR识别
+                asr_result = self.asr_model.generate(
+                    input=infer_path,
+                    batch_size_s=default_options["batch_size_s"],
+                    hotword=default_options["hotword"],
+                    cache={},
+                )
+
+                # 提取识别文本
+                if isinstance(asr_result, list) and len(asr_result) > 0:
+                    if isinstance(asr_result[0], dict) and "text" in asr_result[0]:
+                        raw_text = asr_result[0]["text"]
+                    else:
+                        raw_text = str(asr_result[0])
                 else:
-                    raw_text = str(asr_result[0])
-            else:
-                raw_text = str(asr_result)
+                    raw_text = str(asr_result)
 
-            logger.info(f"ASR识别完成，原始文本: {raw_text[:100]}...")
+                logger.info(f"ASR识别完成，原始文本: {raw_text[:100]}...")
 
-            # 使用FunASR进行标点恢复
-            final_text = raw_text
-            if default_options["use_punc"] and self.punc_model and raw_text.strip():
-                try:
-                    punc_result = self.punc_model.generate(input=raw_text)
-                    if isinstance(punc_result, list) and len(punc_result) > 0:
-                        if (
-                            isinstance(punc_result[0], dict)
-                            and "text" in punc_result[0]
-                        ):
-                            final_text = punc_result[0]["text"]
-                        else:
-                            final_text = str(punc_result[0])
-                    logger.info("FunASR标点恢复完成")
-                except Exception as e:
-                    logger.warning(f"FunASR标点恢复失败，使用原始文本: {str(e)}")
+                # 使用FunASR进行标点恢复
+                final_text = raw_text
+                if default_options["use_punc"] and self.punc_model and raw_text.strip():
+                    try:
+                        punc_result = self.punc_model.generate(input=raw_text)
+                        if isinstance(punc_result, list) and len(punc_result) > 0:
+                            if (
+                                isinstance(punc_result[0], dict)
+                                and "text" in punc_result[0]
+                            ):
+                                final_text = punc_result[0]["text"]
+                            else:
+                                final_text = str(punc_result[0])
+                        logger.info("FunASR标点恢复完成")
+                    except Exception as e:
+                        logger.warning(f"FunASR标点恢复失败，使用原始文本: {str(e)}")
 
-            duration = self._get_audio_duration(infer_path)
-            self.transcription_count += 1
+                duration = self._get_audio_duration(infer_path)
+                self.transcription_count += 1
 
-            result = {
-                "success": True,
-                "text": final_text,
-                "raw_text": raw_text,
-                "confidence": (
-                    getattr(asr_result[0], "confidence", 0.0)
-                    if isinstance(asr_result, list)
-                    else 0.0
-                ),
-                "duration": duration,
-                "language": "zh-CN",
-                "model_type": "pytorch",  # 标识使用的是pytorch版本
-            }
+                result = {
+                    "success": True,
+                    "text": final_text,
+                    "raw_text": raw_text,
+                    "confidence": (
+                        getattr(asr_result[0], "confidence", 0.0)
+                        if isinstance(asr_result, list)
+                        else 0.0
+                    ),
+                    "duration": duration,
+                    "language": "zh-CN",
+                    "model_type": "pytorch",  # 标识使用的是pytorch版本
+                }
 
-            # 生产环境：每10次转录后进行内存清理
-            if self.transcription_count % 10 == 0:
-                self._cleanup_memory()
-                logger.info(f"已完成 {self.transcription_count} 次转录，执行内存清理")
+                # 生产环境：每10次转录后进行内存清理
+                if self.transcription_count % 10 == 0:
+                    self._cleanup_memory()
+                    logger.info(f"已完成 {self.transcription_count} 次转录，执行内存清理")
 
-            logger.info(f"转录完成，最终文本: {final_text[:100]}...")
-            return result
+                logger.info(f"转录完成，最终文本: {final_text[:100]}...")
+                return result
 
-        except Exception as e:
-            error_msg = f"音频转录失败: {str(e)}"
-            logger.error(error_msg)
-            logger.error(traceback.format_exc())
-            return {"success": False, "error": error_msg, "type": "transcription_error"}
-        finally:
-            # [20260819_T7_MicPreprocess] Clean OUR temp only — the original
-            # mic temp belongs to the TS side (close-then-unlink discipline
-            # lives in audioFileHelpers); fallback returns the original path,
-            # which the != audio_path guard leaves untouched.
-            if infer_path != audio_path:
-                try:
-                    os.unlink(infer_path)
-                except Exception:
-                    pass
+            except Exception as e:
+                error_msg = f"音频转录失败: {str(e)}"
+                logger.error(error_msg)
+                logger.error(traceback.format_exc())
+                return {"success": False, "error": error_msg, "type": "transcription_error"}
+            finally:
+                # [20260819_T7_MicPreprocess] Clean OUR temp only — the original
+                # mic temp belongs to the TS side (close-then-unlink discipline
+                # lives in audioFileHelpers); fallback returns the original path,
+                # which the != audio_path guard leaves untouched.
+                if infer_path != audio_path:
+                    try:
+                        os.unlink(infer_path)
+                    except Exception:
+                        pass
 
     def transcribe_file_audio(self, audio_path, options=None):
         """带时间戳的文件转录，用于 transcribe_file 命令"""
@@ -607,7 +616,7 @@ class FunASRServer:
         if not self._ensure_initialized():
             return {
                 "success": False,
-                "error": "模型初始化失败",
+                "error": INIT_FAILED_MESSAGE,
                 "type": "init_error",
                 "request_id": request_id,
             }
@@ -1126,13 +1135,17 @@ class FunASRServer:
     # transcribe_file is structural; the main loop just enqueues, so ping
     # stays answerable throughout.
     def _do_unload(self, request_id):
-        """释放全部模型（含懒加载的说话人模型），重置初始化状态"""
-        self.asr_model = None
-        self.vad_model = None
-        self.punc_model = None
-        # Lazy speaker model unloads too and stays lazy on reload.
-        self.cam_model = None
-        self.initialized = False
+        """Free all models (incl. the lazy speaker model), reset state."""
+        # [T11 review MAJOR] Under the models lock: if a mic transcribe /
+        # diarize holds it on the read loop, unload WAITS (busy = deferred)
+        # instead of freeing models mid-generate.
+        with self._init_lock:
+            self.asr_model = None
+            self.vad_model = None
+            self.punc_model = None
+            # Lazy speaker model unloads too and stays lazy on reload.
+            self.cam_model = None
+            self.initialized = False
         logger.info(f"模型已卸载 request_id={request_id}")
         self.response_queue.put({
             "request_id": request_id,
@@ -1142,7 +1155,7 @@ class FunASRServer:
         })
 
     def _do_reload(self, request_id):
-        """在推理线程重载模型；progress 事件续期 TS 侧请求超时"""
+        """Reload models on the worker thread; progress renews TS timeouts."""
         self.response_queue.put({
             "request_id": request_id,
             "type": "progress",
@@ -1157,7 +1170,7 @@ class FunASRServer:
             "request_id": request_id,
             "type": "result",
             "success": ok,
-            "error": None if ok else "模型初始化失败",
+            "error": None if ok else INIT_FAILED_MESSAGE,
             "asr_model": self.asr_model_name,
         })
 
@@ -1252,88 +1265,93 @@ class FunASRServer:
         返回:
             segments列表，每个元素增加speaker字段
         """
-        import librosa
-        import numpy as np
+        # [T11 review MAJOR] Same models lock as transcribe_audio —
+        # diarize runs on the read loop too, unload must defer.
+        with self._init_lock:
 
-        if not segments or len(segments) == 0:
-            return {"success": False, "error": "无分段数据"}
+            import librosa
+            import numpy as np
 
-        try:
-            self._load_cam_model()
-        except RuntimeError as e:
-            return {"success": False, "error": str(e)}
+            if not segments or len(segments) == 0:
+                return {"success": False, "error": "无分段数据"}
 
-        # 加载整个音频文件到内存
-        audio, sr = librosa.load(audio_path, sr=16000, mono=True)
+            try:
+                self._load_cam_model()
+            except RuntimeError as e:
+                return {"success": False, "error": str(e)}
 
-        embeddings = []
-        valid_indices = []
-        for i, seg in enumerate(segments):
-            start_sample = int(seg["start_ms"] / 1000.0 * sr)
-            end_sample = int(seg["end_ms"] / 1000.0 * sr)
-            start_sample = max(0, start_sample)
-            end_sample = min(len(audio), end_sample)
+            # 加载整个音频文件到内存
+            audio, sr = librosa.load(audio_path, sr=16000, mono=True)
 
-            if end_sample - start_sample < sr * 0.1:
-                continue  # 跳过大短的片段（<100ms）
+            embeddings = []
+            valid_indices = []
+            for i, seg in enumerate(segments):
+                start_sample = int(seg["start_ms"] / 1000.0 * sr)
+                end_sample = int(seg["end_ms"] / 1000.0 * sr)
+                start_sample = max(0, start_sample)
+                end_sample = min(len(audio), end_sample)
 
-            chunk = audio[start_sample:end_sample]
-            # 使用CAM++提取声纹嵌入
-            result = self.cam_model(chunk, output_dir=None)
-            if result and len(result) > 0:
-                emb = result[0].get("spk_embedding") or result[0].get("embedding")
-                if emb is not None:
-                    embeddings.append(np.array(emb).flatten())
-                    valid_indices.append(i)
+                if end_sample - start_sample < sr * 0.1:
+                    continue  # 跳过大短的片段（<100ms）
 
-        if len(embeddings) == 0:
-            for seg in segments:
-                seg["speaker"] = "Speaker"
+                chunk = audio[start_sample:end_sample]
+                # 使用CAM++提取声纹嵌入
+                result = self.cam_model(chunk, output_dir=None)
+                if result and len(result) > 0:
+                    emb = result[0].get("spk_embedding") or result[0].get("embedding")
+                    if emb is not None:
+                        embeddings.append(np.array(emb).flatten())
+                        valid_indices.append(i)
+
+            if len(embeddings) == 0:
+                for seg in segments:
+                    seg["speaker"] = "Speaker"
+                return {"success": True, "segments": segments}
+
+            # 余弦相似度聚类
+            embeddings = np.stack(embeddings)  # (N, D)
+            N = len(embeddings)
+            threshold = 0.7
+            labels = list(range(N))  # 初始每个embedding一个cluster
+
+            for i in range(N):
+                for j in range(i + 1, N):
+                    sim = np.dot(embeddings[i], embeddings[j]) / (
+                        np.linalg.norm(embeddings[i]) * np.linalg.norm(embeddings[j]) + 1e-8
+                    )
+                    if sim > threshold:
+                        # 合并cluster
+                        root_i = labels[i]
+                        root_j = labels[j]
+                        new_label = min(root_i, root_j)
+                        for k in range(N):
+                            if labels[k] == root_i or labels[k] == root_j:
+                                labels[k] = new_label
+
+            # 重映射label到连续编号
+            unique_labels = sorted(set(labels))
+            label_map = {old: f"Speaker {chr(65 + idx)}" for idx, old in enumerate(unique_labels)}
+            if len(unique_labels) == 1:
+                label_map[unique_labels[0]] = "Speaker"
+
+            speaker_for_index = {}
+            for vi, label_id in zip(valid_indices, labels):
+                speaker_for_index[vi] = label_map[label_id]
+
+            for i, seg in enumerate(segments):
+                seg["speaker"] = speaker_for_index.get(i, "Speaker")
+
             return {"success": True, "segments": segments}
 
-        # 余弦相似度聚类
-        embeddings = np.stack(embeddings)  # (N, D)
-        N = len(embeddings)
-        threshold = 0.7
-        labels = list(range(N))  # 初始每个embedding一个cluster
+        # [20260817_T5_HandleCommand] Ticket #181 (spec #177 T5): the stdin
+        # command dispatch, extracted verbatim from run()'s read loop so it is
+        # unit-testable without spawning the process (protocol extensions for
+        # idle-unload/hotwords must extend tests/python accordingly).
+        # Returns (result, keep_running):
+        #   result is None     -> action was queued (transcribe_file); the read
+        #                         loop must NOT print anything for it
+        #   keep_running False -> stop the read loop after printing (exit)
 
-        for i in range(N):
-            for j in range(i + 1, N):
-                sim = np.dot(embeddings[i], embeddings[j]) / (
-                    np.linalg.norm(embeddings[i]) * np.linalg.norm(embeddings[j]) + 1e-8
-                )
-                if sim > threshold:
-                    # 合并cluster
-                    root_i = labels[i]
-                    root_j = labels[j]
-                    new_label = min(root_i, root_j)
-                    for k in range(N):
-                        if labels[k] == root_i or labels[k] == root_j:
-                            labels[k] = new_label
-
-        # 重映射label到连续编号
-        unique_labels = sorted(set(labels))
-        label_map = {old: f"Speaker {chr(65 + idx)}" for idx, old in enumerate(unique_labels)}
-        if len(unique_labels) == 1:
-            label_map[unique_labels[0]] = "Speaker"
-
-        speaker_for_index = {}
-        for vi, label_id in zip(valid_indices, labels):
-            speaker_for_index[vi] = label_map[label_id]
-
-        for i, seg in enumerate(segments):
-            seg["speaker"] = speaker_for_index.get(i, "Speaker")
-
-        return {"success": True, "segments": segments}
-
-    # [20260817_T5_HandleCommand] Ticket #181 (spec #177 T5): the stdin
-    # command dispatch, extracted verbatim from run()'s read loop so it is
-    # unit-testable without spawning the process (protocol extensions for
-    # idle-unload/hotwords must extend tests/python accordingly).
-    # Returns (result, keep_running):
-    #   result is None     -> action was queued (transcribe_file); the read
-    #                         loop must NOT print anything for it
-    #   keep_running False -> stop the read loop after printing (exit)
     def handle_command(self, command):
         if command.get("action") == "transcribe":
             audio_path = command.get("audio_path")

--- a/funasr_server.py
+++ b/funasr_server.py
@@ -136,6 +136,10 @@ class FunASRServer:
         self.request_queue = queue.Queue()
         self.response_queue = queue.Queue()
         self.cancel_event = threading.Event()
+        # [20260821_T11_UnloadReload] Serializes initialize() across the
+        # main read loop (mic lazy-init) and the inference worker
+        # (reload_models) — concurrent double model load = memory blowup.
+        self._init_lock = threading.Lock()
         self._inference_thread = None
         self._output_thread = None
 
@@ -467,10 +471,10 @@ class FunASRServer:
         # non-finite input rejection) must not hit an unbound name in the
         # finally cleanup.
         infer_path = audio_path
-        if not self.initialized:
-            init_result = self.initialize()
-            if not init_result["success"]:
-                return init_result
+        # [20260821_T11_UnloadReload] Lock-guarded lazy init (worker
+        # reload can race this main-loop path).
+        if not self._ensure_initialized():
+            return {"success": False, "error": "模型初始化失败", "type": "init_error"}
 
         try:
             # 检查音频文件是否存在
@@ -596,6 +600,17 @@ class FunASRServer:
         request_id = options.get("request_id", "")
         # [20260820_T14_Hotwords] Defense-in-depth (file path).
         hotword = sanitize_hotword(options.get("hotword", ""))
+        # [20260821_T11_UnloadReload] File path ran WITHOUT an init guard
+        # (review finding): after an unload it crashed on None models.
+        # Runs on the inference worker thread — reload stays off the read
+        # loop naturally.
+        if not self._ensure_initialized():
+            return {
+                "success": False,
+                "error": "模型初始化失败",
+                "type": "init_error",
+                "request_id": request_id,
+            }
         self.cancel_event.clear()
         import time
         _t0 = time.time()
@@ -1093,6 +1108,59 @@ class FunASRServer:
                 "error": "FunASR未安装",
             }
 
+    # [20260821_T11_UnloadReload] Ticket #189 (spec #177 T11): init guard
+    # shared by both transcribe paths; double-checked under the init lock
+    # so a worker-thread reload and a main-loop mic transcribe collapse
+    # into a single initialize().
+    def _ensure_initialized(self):
+        if self.initialized:
+            return True
+        with self._init_lock:
+            if self.initialized:
+                return True
+            result = self.initialize()
+            return bool(result and result.get("success"))
+
+    # [20260821_T11_UnloadReload] Worker-thread handlers. Called ONLY from
+    # _inference_worker (queued via request_queue) — serialization with
+    # transcribe_file is structural; the main loop just enqueues, so ping
+    # stays answerable throughout.
+    def _do_unload(self, request_id):
+        """释放全部模型（含懒加载的说话人模型），重置初始化状态"""
+        self.asr_model = None
+        self.vad_model = None
+        self.punc_model = None
+        # Lazy speaker model unloads too and stays lazy on reload.
+        self.cam_model = None
+        self.initialized = False
+        logger.info(f"模型已卸载 request_id={request_id}")
+        self.response_queue.put({
+            "request_id": request_id,
+            "type": "result",
+            "success": True,
+            "message": "模型已卸载",
+        })
+
+    def _do_reload(self, request_id):
+        """在推理线程重载模型；progress 事件续期 TS 侧请求超时"""
+        self.response_queue.put({
+            "request_id": request_id,
+            "type": "progress",
+            "phase": "reload",
+            "message": "模型重载中...",
+            "progress_pct": 0,
+        })
+        # [T11] Under the init lock (via _ensure_initialized): a mic
+        # transcribe on the main loop can lazy-init concurrently.
+        ok = self._ensure_initialized()
+        self.response_queue.put({
+            "request_id": request_id,
+            "type": "result",
+            "success": ok,
+            "error": None if ok else "模型初始化失败",
+            "asr_model": self.asr_model_name,
+        })
+
     def _inference_worker(self):
         """推理线程：从 request_queue 取任务，执行推理"""
         while self.running:
@@ -1105,7 +1173,13 @@ class FunASRServer:
                 action = task.get("action")
 
                 try:
-                    if action == "transcribe_file":
+                    if action == "unload_models":
+                        self._do_unload(request_id)
+                        continue
+                    elif action == "reload_models":
+                        self._do_reload(request_id)
+                        continue
+                    elif action == "transcribe_file":
                         opts = task.get("options", {})
                         opts["request_id"] = request_id
                         result = self.transcribe_file_audio(
@@ -1272,6 +1346,15 @@ class FunASRServer:
         elif command.get("action") == "cleanup":
             self._cleanup_memory()
             return {"success": True, "message": "内存清理完成"}, True
+        elif command.get("action") in ("unload_models", "reload_models"):
+            # [20260821_T11_UnloadReload] Queued like transcribe_file:
+            # serialization with in-flight file work is structural (busy =
+            # deferred, never concurrent); the read loop only enqueues.
+            self.request_queue.put({
+                "request_id": command.get("request_id", ""),
+                "action": command.get("action"),
+            })
+            return None, True
         elif command.get("action") == "transcribe_file":
             # 放入推理队列，不立即返回确认
             # 推理结果和进度通过 response_queue → output_worker → stdout 发送

--- a/tests/python/test_unload_reload.py
+++ b/tests/python/test_unload_reload.py
@@ -1,0 +1,187 @@
+# [20260821_T11_UnloadReload] Ticket #189 (spec #177 T11): unload/reload
+# protocol actions + worker-thread reload + init guards. RED first.
+# Design (spec v2 F3 + T7-transferred review constraints):
+#   - unload_models/reload_models are QUEUED actions (request_queue) —
+#     serialized with transcribe_file for free (busy = deferred, never
+#     concurrent); the main read loop only enqueues, so ping stays
+#     answerable while the worker reloads
+#   - reload emits progress events (renew TS-side request timeouts)
+#   - _ensure_initialized guards both transcribe paths, guarded by an
+#     init lock (reload-in-worker can race a mic transcribe on the main
+#     loop — double model load = memory blowup)
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ),
+)
+
+os.environ.setdefault("MURMUR_DEVICE", "cpu")
+
+from funasr_server import FunASRServer  # noqa: E402
+
+
+def make_server():
+    return FunASRServer(damo_root="/tmp/test-damo")
+
+
+class FakeModel:
+    def generate(self, *args, **kwargs):
+        return [{"text": "x", "value": []}]
+
+
+class ProtocolRoutingTest(unittest.TestCase):
+    """unload/reload must be QUEUED (deferred behind in-flight file work),
+    never handled inline on the read loop."""
+
+    def _server(self):
+        srv = make_server()
+        srv.request_queue = __import__("queue").Queue()
+        return srv
+
+    def test_unload_models_routes_to_request_queue(self):
+        srv = self._server()
+        result, keep = srv.handle_command(
+            {"action": "unload_models", "request_id": "r1"}
+        )
+        self.assertIsNone(result)  # queued → read loop prints nothing
+        self.assertTrue(keep)
+        task = srv.request_queue.get_nowait()
+        self.assertEqual(task["action"], "unload_models")
+        self.assertEqual(task["request_id"], "r1")
+
+    def test_reload_models_routes_to_request_queue(self):
+        srv = self._server()
+        result, keep = srv.handle_command(
+            {"action": "reload_models", "request_id": "r2"}
+        )
+        self.assertIsNone(result)
+        self.assertTrue(keep)
+        task = srv.request_queue.get_nowait()
+        self.assertEqual(task["action"], "reload_models")
+
+
+class DoUnloadTest(unittest.TestCase):
+    def test_unloads_all_models_and_resets_initialized(self):
+        srv = make_server()
+        srv.asr_model = FakeModel()
+        srv.vad_model = FakeModel()
+        srv.punc_model = FakeModel()
+        srv.cam_model = FakeModel()
+        srv.initialized = True
+        srv.response_queue = __import__("queue").Queue()
+
+        srv._do_unload("r1")
+
+        self.assertIsNone(srv.asr_model)
+        self.assertIsNone(srv.vad_model)
+        self.assertIsNone(srv.punc_model)
+        # Lazy speaker model unloads too, keeping its lazy-load semantics.
+        self.assertIsNone(srv.cam_model)
+        self.assertFalse(srv.initialized)
+        resp = srv.response_queue.get_nowait()
+        self.assertTrue(resp["success"])
+        self.assertEqual(resp["request_id"], "r1")
+
+
+class DoReloadTest(unittest.TestCase):
+    def test_reload_runs_initialize_and_reports_generation(self):
+        srv = make_server()
+        srv.initialized = False
+        srv.response_queue = __import__("queue").Queue()
+        srv.asr_model_name = None
+
+        calls = []
+
+        def fake_initialize():
+            calls.append(1)
+            srv.initialized = True
+            srv.asr_model_name = FunASRServer.ASR_MODEL_SEACO
+            return {"success": True}
+
+        srv.initialize = fake_initialize
+        srv._do_reload("r2")
+
+        self.assertEqual(calls, [1])
+        # Progress events precede the result (AC: renew TS timeouts).
+        events = []
+        while not srv.response_queue.empty():
+            events.append(srv.response_queue.get_nowait())
+        progress = [e for e in events if e.get("type") == "progress"]
+        self.assertGreaterEqual(len(progress), 1)
+        result = [e for e in events if e.get("type") == "result"][0]
+        self.assertTrue(result["success"])
+        self.assertEqual(result["asr_model"], FunASRServer.ASR_MODEL_SEACO)
+
+    def test_reload_failure_reports_error(self):
+        srv = make_server()
+        srv.initialized = False
+        srv.response_queue = __import__("queue").Queue()
+
+        def boom():
+            return {"success": False, "error": "加载失败"}
+
+        srv.initialize = boom
+        srv._do_reload("r3")
+        result = [
+            srv.response_queue.get_nowait() for _ in range(1)
+        ]
+        # drain everything
+        while not srv.response_queue.empty():
+            result.append(srv.response_queue.get_nowait())
+        final = [e for e in result if e.get("type") == "result"][0]
+        self.assertFalse(final["success"])
+
+
+class EnsureInitializedTest(unittest.TestCase):
+    def test_guard_initializes_once_when_uninitialized(self):
+        srv = make_server()
+        srv.initialized = False
+        calls = []
+
+        def fake_init():
+            calls.append(1)
+            srv.initialized = True
+            return {"success": True}
+
+        srv.initialize = fake_init
+        ok = srv._ensure_initialized()
+        self.assertTrue(ok)
+        self.assertEqual(calls, [1])
+        # Second call after success does not re-initialize.
+        self.assertTrue(srv._ensure_initialized())
+        self.assertEqual(calls, [1])
+
+    def test_concurrent_ensure_serializes_to_single_init(self):
+        # reload-in-worker can race a mic transcribe on the main loop —
+        # the init lock must collapse them into ONE initialize() call.
+        srv = make_server()
+        srv.initialized = False
+        calls = []
+
+        def slow_init():
+            calls.append(threading.current_thread().name)
+            time.sleep(0.2)
+            srv.initialized = True
+            return {"success": True}
+
+        srv.initialize = slow_init
+        threads = [
+            threading.Thread(target=srv._ensure_initialized) for _ in range(5)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(srv.initialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_unload_reload.py
+++ b/tests/python/test_unload_reload.py
@@ -10,6 +10,7 @@
 #     init lock (reload-in-worker can race a mic transcribe on the main
 #     loop — double model load = memory blowup)
 import os
+import queue
 import sys
 import threading
 import time
@@ -42,7 +43,7 @@ class ProtocolRoutingTest(unittest.TestCase):
 
     def _server(self):
         srv = make_server()
-        srv.request_queue = __import__("queue").Queue()
+        srv.request_queue = queue.Queue()
         return srv
 
     def test_unload_models_routes_to_request_queue(self):
@@ -75,7 +76,7 @@ class DoUnloadTest(unittest.TestCase):
         srv.punc_model = FakeModel()
         srv.cam_model = FakeModel()
         srv.initialized = True
-        srv.response_queue = __import__("queue").Queue()
+        srv.response_queue = queue.Queue()
 
         srv._do_unload("r1")
 
@@ -94,7 +95,7 @@ class DoReloadTest(unittest.TestCase):
     def test_reload_runs_initialize_and_reports_generation(self):
         srv = make_server()
         srv.initialized = False
-        srv.response_queue = __import__("queue").Queue()
+        srv.response_queue = queue.Queue()
         srv.asr_model_name = None
 
         calls = []
@@ -122,7 +123,7 @@ class DoReloadTest(unittest.TestCase):
     def test_reload_failure_reports_error(self):
         srv = make_server()
         srv.initialized = False
-        srv.response_queue = __import__("queue").Queue()
+        srv.response_queue = queue.Queue()
 
         def boom():
             return {"success": False, "error": "加载失败"}
@@ -181,6 +182,42 @@ class EnsureInitializedTest(unittest.TestCase):
             t.join()
         self.assertEqual(len(calls), 1)
         self.assertTrue(srv.initialized)
+
+
+class UnloadDefersDuringInferenceTest(unittest.TestCase):
+    """[T11 review MAJOR] The worker's unload must NOT free models while a
+    mic transcribe/diarize holds the models lock on the main loop — the
+    reviewer reproduced a mid-inference NoneType failure without it."""
+
+    def test_unload_waits_for_the_models_lock(self):
+        srv = make_server()
+        srv.asr_model = FakeModel()
+        srv.vad_model = FakeModel()
+        srv.punc_model = FakeModel()
+        srv.cam_model = FakeModel()
+        srv.initialized = True
+        srv.response_queue = queue.Queue()
+
+        with srv._init_lock:  # simulated in-flight mic inference
+            t = threading.Thread(target=srv._do_unload, args=("r9",))
+            t.start()
+            time.sleep(0.15)
+            # Models untouched, no premature response — busy = deferred.
+            self.assertIsNotNone(srv.asr_model)
+            self.assertTrue(srv.initialized)
+            self.assertTrue(srv.response_queue.empty())
+        t.join(timeout=2)
+        self.assertFalse(t.is_alive())
+        self.assertIsNone(srv.asr_model)
+        self.assertFalse(srv.initialized)
+
+    def test_lock_is_reentrant(self):
+        # transcribe_audio holds the lock across its body AND calls
+        # _ensure_initialized inside — a non-reentrant lock self-deadlocks.
+        srv = make_server()
+        srv.initialized = True
+        with srv._init_lock:
+            self.assertTrue(srv._ensure_initialized())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
T11 of spec #177 (F3 idle-unload, Python half). Queued `unload_models`/`reload_models` protocol actions — structural serialization with file transcription, worker-thread reload (read loop stays free to answer ping), init-lock guard shared by both transcribe paths, and the missing file-path init guard (platform-scan finding).

T12 (#190) wires the TS side: idle timer → unload, hotkey-down → reload_models pre-trigger, health-check suppression during loading.

## Verification
9 red-first Python tests (routing, unload semantics incl. lazy speaker model, reload progress/result ordering, guard idempotence, 5-thread concurrent-collapse to a single initialize). Suite 61/61, full `pnpm ci:check` 11/11.

Closes #189