### PR TITLE
chore: add treehouse worktree pool config

### DIFF
--- a/treehouse.toml
+++ b/treehouse.toml
@@ -1,0 +1,6 @@
+max_trees = 16
+root = ""
+
+# Worktree root directory (relative to repo root or absolute path).
+# Worktrees are placed under {root}/.treehouse/. Default: $HOME
+# Example: root = "./"


### PR DESCRIPTION
## Summary

Add repo-level `treehouse.toml` (max_trees=16) enabling the treehouse worktree pool for parallel agent sessions - worktrees pre-warmed with dependencies via the user-level post_create hook, reused across checkouts.

Config-only change; no code or CI impact.