### PR TITLE
docs: agent tooling rules — gh-axi preference, tasks-axi ledger, chrome-devtools-axi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ When adding platform-specific code, use `process.platform === "win32"` checks. A
 
 ### Issue tracker
 
-Issues and PRDs live as GitHub issues. Use the `gh` CLI for all operations. See `docs/agents/issue-tracker.md`.
+Issues and PRDs live as GitHub issues. Use the `gh-axi` CLI for all operations (agent-ergonomic `gh` wrapper, same auth, lower token cost). See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
@@ -155,6 +155,11 @@ Five canonical triage roles: `needs-triage`, `needs-info`, `ready-for-agent`, `r
 ### Domain docs
 
 Domain context: see `docs/agents/domain.md`.
+
+### Agent tooling
+
+- `backlog.md` is the shared task ledger for all agent sessions and worktrees. Use `tasks-axi` (`add` / `start` / `done` / `block` / `ready`) for all task state — never hand-edit task lines in the ledger.
+- Browser automation: use `chrome-devtools-axi` (`open`, `snapshot`, `click @uid`, `eval`) instead of screenshot-and-guess.
 
 ## GBrain Configuration (configured by /setup-gbrain)
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+Issues and PRDs for this repo live as GitHub issues. Prefer `gh-axi` (agent-ergonomic `gh` wrapper, same auth, lower token cost); the plain `gh` commands below work identically.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Tells every agent (any harness reading CLAUDE.md) to use the installed AXI toolchain:

- **gh-axi** for GitHub operations (same auth as `gh`, compact TOON output, lower token cost — verified against this repo)
- **tasks-axi** as the only way to mutate `backlog.md` (the shared task ledger merged in #203)
- **chrome-devtools-axi** for browser automation (open/snapshot/click @uid/eval — verified)

Updates CLAUDE.md (one line swap + new Agent tooling section) and docs/agents/issue-tracker.md opening. Docs-only.