### PR TITLE
fix: make suppress_stdout thread-safe — parallel model-load race killed the FunASR server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,9 +195,14 @@ jobs:
             done
             tail -20 "$LOG"; exit 1
           fi
-          if grep -qE "NODE_MODULE_VERSION|Uncaught Exception|preload 脚本加载失败|Python链路自检失败" "$LOG"; then
+          # [20260820_Gate_UnhandledRejection] A suppress_stdout race on main
+          # killed the FunASR server after model init while the main process
+          # logged "Unhandled Rejection" — a pattern the fatal list ignored,
+          # so a broken build could still pass this smoke. Unhandled main
+          # rejections are never acceptable in a packaged app.
+          if grep -qE "NODE_MODULE_VERSION|Uncaught Exception|Unhandled Rejection|preload 脚本加载失败|Python链路自检失败" "$LOG"; then
             echo "::error::fatal errors in packaged app boot log"
-            grep -E "NODE_MODULE_VERSION|Uncaught Exception|preload|Python链路自检失败" "$LOG" | head -5
+            grep -E "NODE_MODULE_VERSION|Uncaught Exception|Unhandled Rejection|preload|Python链路自检失败" "$LOG" | head -5
             exit 1
           fi
           kill "$APP_PID" 2>/dev/null || true
@@ -378,7 +383,9 @@ jobs:
           # break-early snapshot are still caught (parity with mac's live
           # grep).
           $content = Get-Content $log -Raw -Encoding UTF8
-          foreach ($fatal in @('NODE_MODULE_VERSION','Uncaught Exception','preload 脚本加载失败','Python链路自检失败')) {
+          # [20260820_Gate_UnhandledRejection] Windows counterpart of the mac
+          # fatal-list hardening: gate on "Unhandled Rejection" too.
+          foreach ($fatal in @('NODE_MODULE_VERSION','Uncaught Exception','Unhandled Rejection','preload 脚本加载失败','Python链路自检失败')) {
             if ($content -like "*$fatal*") { throw "fatal error in packaged boot log: $fatal" }
           }
           if (-not (Get-Process -Name 'Murmur' -ErrorAction SilentlyContinue)) { throw 'Murmur process is not running' }

--- a/docs/agents/no-mistakes-gate.md
+++ b/docs/agents/no-mistakes-gate.md
@@ -1,0 +1,36 @@
+# no-mistakes gate: push through the AI verification pipeline
+
+Murmur's local push gate. It sits between your branch and `origin` on GitHub: pushing through it runs the full AI-driven verification pipeline in a disposable worktree, and only a fully green run gets forwarded as a real push plus a clean PR.
+
+## When to use it
+
+- You want every check (review, tests, docs, lint) green **before** the branch reaches GitHub and burns CI minutes.
+- An agent delivers work in firstmate's `no-mistakes` ship mode.
+- You do not want to remember the full `pnpm ci:check` ritual by hand.
+
+Plain `git push origin <branch>` still works and is unchanged - the gate is opt-in per push.
+
+## How to push through the gate
+
+```bash
+git push no-mistakes <branch>
+```
+
+The gate remote points at a local bare repository (`~/.no-mistakes/repos/...`). On push it:
+
+1. Creates a disposable worktree at the pushed commit.
+2. Runs the pipeline: AI review, tests, docs check, lint.
+3. Applies mechanical fixes automatically; **changes of intent require your approval** in the terminal.
+4. Forwards to `origin` and opens a PR only when everything is green.
+
+Any red step stops the push: the branch never reaches GitHub in a failing state.
+
+## Agent usage
+
+Agents can invoke the same gate via the `/no-mistakes` skill (installed at user level). Prefer pushing through the gate for any non-trivial delivery; see also the delivery gates in `CLAUDE.md`.
+
+| Concern                        | Answer                                                            |
+| ------------------------------ | ----------------------------------------------------------------- |
+| Does it slow me down           | Pipeline runs in an isolated worktree; you can keep working       |
+| Which agent does the AI review | Whichever `claude` resolves to at that moment (relay-transparent) |
+| Where is gate state            | `~/.no-mistakes/` - nothing runs resident                         |

--- a/funasr_server.py
+++ b/funasr_server.py
@@ -54,17 +54,51 @@ logger = logging.getLogger(__name__)
 logger.info(f"FunASR服务器日志文件: {log_file_path}")
 
 
+# [20260820_Fix_SuppressStdoutRace] The model loaders run in parallel
+# threads and each wraps its AutoModel call in suppress_stdout(). The
+# previous per-thread save/restore of the PROCESS-GLOBAL sys.stdout raced:
+# with N threads inside at once, each thread's "old" stdout was the previous
+# thread's devnull, and after interleaved restores sys.stdout could point at
+# a devnull already closed by another thread's exit — the next protocol
+# print then raised "ValueError: I/O operation on closed file" and killed
+# the server AFTER models loaded successfully. Fix: serialize the
+# save/restore with a lock and reference-count concurrent users so the sink
+# is installed once (first entrant) and removed once (last exits). The lock
+# covers only the bookkeeping, never the suppressed body, so model loads
+# still run in parallel.
+_SUPPRESS_STDOUT_LOCK = threading.Lock()
+_SUPPRESS_STDOUT_DEPTH = 0
+_SUPPRESS_STDOUT_SAVED = None
+_SUPPRESS_STDOUT_SINK = None
+
+
 @contextlib.contextmanager
 def suppress_stdout():
-    """上下文管理器：临时重定向stdout到devnull，避免FunASR库的非JSON输出干扰IPC通信"""
-    old_stdout = sys.stdout
-    devnull = open(os.devnull, "w")
+    """上下文管理器：临时重定向stdout到devnull，避免FunASR库的非JSON输出干扰IPC通信
+
+    Thread-safe: multiple threads may be inside at once; only the first
+    entrant saves the original stdout and installs the shared sink, and the
+    last exiter restores it (lock + reference counting).
+    """
+    global _SUPPRESS_STDOUT_DEPTH, _SUPPRESS_STDOUT_SAVED, _SUPPRESS_STDOUT_SINK
+    with _SUPPRESS_STDOUT_LOCK:
+        if _SUPPRESS_STDOUT_DEPTH == 0:
+            _SUPPRESS_STDOUT_SAVED = sys.stdout
+            _SUPPRESS_STDOUT_SINK = open(os.devnull, "w")
+            sys.stdout = _SUPPRESS_STDOUT_SINK
+        _SUPPRESS_STDOUT_DEPTH += 1
     try:
-        sys.stdout = devnull
         yield
     finally:
-        sys.stdout = old_stdout
-        devnull.close()
+        with _SUPPRESS_STDOUT_LOCK:
+            _SUPPRESS_STDOUT_DEPTH -= 1
+            if _SUPPRESS_STDOUT_DEPTH == 0:
+                sys.stdout = _SUPPRESS_STDOUT_SAVED
+                _SUPPRESS_STDOUT_SAVED = None
+                if _SUPPRESS_STDOUT_SINK is not None:
+                    _SUPPRESS_STDOUT_SINK.close()
+                    _SUPPRESS_STDOUT_SINK = None
+# [20260820_Fix_SuppressStdoutRace] END
 
 
 # [20260819_T8_ThreadAdapt] Ticket #187 (spec #177 T8): inference thread

--- a/tests/python/test_suppress_stdout_thread_safety.py
+++ b/tests/python/test_suppress_stdout_thread_safety.py
@@ -1,0 +1,138 @@
+# [20260820_Fix_SuppressStdoutRace] Regression test for a long-latent race
+# found by a local `pnpm run dev` smoke: the three model loaders
+# (_load_asr_model / _load_vad_model / _load_punc_model) run in PARALLEL
+# threads (introduced 2025-09 f21a4c1) and each wraps its AutoModel call in
+# suppress_stdout(). The old implementation saved/restored the PROCESS-GLOBAL
+# sys.stdout per-thread with no synchronization, so with N threads inside at
+# once, each thread's "old" stdout was actually the previous thread's devnull.
+# After the threads interleaved their restores, sys.stdout could end up
+# pointing at a devnull file that its own `with` had already closed — and the
+# very next protocol print (run()'s init_result) died with
+# "ValueError: I/O operation on closed file", killing the server process
+# AFTER all models had loaded successfully.
+#
+# The race only manifests when models exist on disk (parallel loaders run);
+# CI runners have no models, so the boot smoke could never see it. This test
+# makes the interleaving deterministic with a barrier so all threads are
+# inside the context simultaneously, then asserts sys.stdout is restored to
+# the original object and remains writable.
+# [20260820_Fix_SuppressStdoutRace] END
+import io
+import os
+import sys
+import threading
+import unittest
+
+# funasr_server imports heavy deps lazily, so importing the module for the
+# helper is cheap and works with only numpy/soundfile installed. Resolve the
+# repo root from this file's location so the suite also works when invoked
+# from inside tests/python/ (sibling tests use the same preamble).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+import funasr_server  # noqa: E402
+
+
+# Number of concurrent loader threads to simulate (mirrors the 3 real model
+# loaders; 4 adds margin so the race window is essentially always hit).
+CONCURRENT_THREADS = 4
+# Rounds of enter/exit; each round is one barrier-synchronized interleave.
+ROUNDS = 20
+
+
+class TestSuppressStdoutThreadSafety(unittest.TestCase):
+    def setUp(self):
+        # Capture the real stdout object; tests must leave it untouched.
+        self.real_stdout = sys.stdout
+
+    def tearDown(self):
+        # Belt and braces: if a test fails mid-way, restore stdout so the
+        # test runner itself can keep printing.
+        sys.stdout = self.real_stdout
+
+    def test_concurrent_suppress_restores_original_stdout(self):
+        """All threads inside simultaneously must not corrupt sys.stdout."""
+        for _ in range(ROUNDS):
+            # Barrier timeout turns a dead worker into a clean test failure
+            # (BrokenBarrierError) instead of hanging CI until job timeout.
+            barrier = threading.Barrier(CONCURRENT_THREADS, timeout=10)
+
+            def worker():
+                with funasr_server.suppress_stdout():
+                    # Wait until EVERY thread is inside the context at the
+                    # same time — the exact shape of the parallel model
+                    # loading. Without synchronization this window is timing
+                    # dependent; the barrier makes it deterministic.
+                    barrier.wait()
+
+            threads = [threading.Thread(target=worker) for _ in range(CONCURRENT_THREADS)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            self.assertIs(
+                sys.stdout,
+                self.real_stdout,
+                "sys.stdout was not restored to the original object "
+                "after concurrent suppress_stdout() exited",
+            )
+
+    def test_stdout_writable_after_concurrent_suppress(self):
+        """The restored stdout must not be a closed devnull file."""
+        for _ in range(ROUNDS):
+            barrier = threading.Barrier(CONCURRENT_THREADS, timeout=10)
+
+            def worker():
+                with funasr_server.suppress_stdout():
+                    barrier.wait()
+
+            threads = [threading.Thread(target=worker) for _ in range(CONCURRENT_THREADS)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            # The production failure mode: print() raising
+            # "ValueError: I/O operation on closed file" because sys.stdout
+            # was a devnull closed by another thread's context exit.
+            try:
+                sys.stdout.write("")
+                sys.stdout.flush()
+            except ValueError as e:
+                self.fail(f"sys.stdout unusable after concurrent suppress: {e}")
+
+    def test_single_thread_suppress_still_swallows_and_restores(self):
+        """Sequential usage (pre-parallel behavior) keeps working."""
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            with funasr_server.suppress_stdout():
+                # A print inside the context must NOT reach the captured
+                # stdout — it goes to the suppression sink.
+                print("library noise")
+            sys.stdout = self.real_stdout
+            self.assertEqual(
+                captured.getvalue(),
+                "",
+                "output leaked past suppress_stdout()",
+            )
+        finally:
+            sys.stdout = self.real_stdout
+
+    def test_same_thread_nested_suppress_restores(self):
+        """Nested usage on one thread (import wrap + model wrap) restores."""
+        outer_captured = io.StringIO()
+        sys.stdout = outer_captured
+        try:
+            with funasr_server.suppress_stdout():
+                with funasr_server.suppress_stdout():
+                    print("inner noise")
+                # Still suppressed after the inner context exits.
+                print("outer noise")
+            sys.stdout = self.real_stdout
+            self.assertEqual(outer_captured.getvalue(), "")
+        finally:
+            sys.stdout = self.real_stdout
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 根因

本地 `pnpm run dev` 冒烟(磁盘上有模型)抓到一个长期潜伏的竞态,早于 v1.3.2(2025-09 f21a4c1 引入并行加载时就存在):

- 三个模型加载器(`_load_asr_model` / `_load_vad_model` / `_load_punc_model`)在**并行线程**中各自用 `suppress_stdout()` 包裹 AutoModel 构建
- 旧实现对进程全局 `sys.stdout` 做**无锁的按线程保存/恢复**:N 个线程同时在上下文内时,后进线程保存到的"old stdout"是前一线程装的 devnull
- 交错恢复后 `sys.stdout` 可能指向一个已被其他线程 `with` 退出的**已关闭 devnull**
- 模型全部加载成功后,`run()` 里 `print(json.dumps(init_result))` 抛 `ValueError: I/O operation on closed file` → **服务器进程在初始化成功的瞬间崩溃**(退出码 1),主进程出现 Unhandled Rejection

**为什么 CI 从来没抓到**:runner 上没有模型,初始化走"模型未下载"短路分支,并行加载器(以及竞态)根本不执行。只有真实下载过模型的用户会命中——与 #176/#196 用户升级后将会遇到的路径直接相关(那两个 issue 的主因是 T1/#178 修复的布局/asar 问题,本 PR 修的是同一条用户路径上的第二颗雷)。

## 修复

- `funasr_server.py`:`suppress_stdout()` 改为**锁 + 引用计数**的全局抑制——第一个进入者保存原 stdout 并装上共享 sink,最后一个退出者恢复并关闭。锁只覆盖簿记,不覆盖 yield 体,模型加载保持并行。
- `tests/python/test_suppress_stdout_thread_safety.py`:用 `threading.Barrier` 让所有线程**确定性地同时处于上下文内**(复刻生产竞态形态);旧代码上稳定红(复现 `I/O operation on closed file`),新代码绿。另含顺序吞噪、同线程嵌套用例。barrier 带 10s 超时,死线程转干净失败而非挂死 CI。
- `.github/workflows/build.yml`:双平台打包启动 smoke 的致命模式列表加入 `Unhandled Rejection`(本次事故的下游症状,现行门禁会放过)。

## 验证证据

- TDD 红→绿:新测试对旧代码 2 failures(精确复现事故),修复后 4/4 通过;全量 Python 套件 67/67
- 端到端:本地 dev 冒烟修复前服务器进程崩(init 完成即死、3 次重启耗尽);修复后同样路径 `{"success": true}` 协议输出送达、主进程"FunASR服务器启动成功,模型已初始化"、服务器进程存活、零 Traceback/退出/Unhandled Rejection
- 独立 code-review:**APPROVE**(0 BLOCKER / 0 MAJOR);评审者独立复现红-绿,并对新实现做了 200 轮 × 3 类对抗交错探测(重叠进出/体内抛异常/一线程持有一线程抛)全部通过;3 个 MINOR polish(英文注释、测试导入自足、barrier 超时)已并入
- `pnpm ci:check` 11/11 全绿(exit 0)

## 风险与建议

- 行为变化仅限抑制窗口的簿记逻辑;模型加载并行度不变
- 评审发现的既有缺口(非本 PR 引入):抑制窗口期间 `_output_worker` 的协议输出可能被吞(reload 进度消息场景)。建议另立 follow-up ticket