### PR TITLE
fix: model download recovery — damo-root layout, post-download server restart, real progress (#216 #212)

### DIFF
--- a/download_models.py
+++ b/download_models.py
@@ -39,6 +39,14 @@ class ProtocolProgressCallback:
     def __init__(self, filename, file_size, state, model_type):
         self._state = state
         self._model_type = model_type
+        # [20260905_Fix_Review_TotalBytes] Register each file's size into the
+        # model slot so the percent math has a denominator. modelscope
+        # instantiates one callback per file; without this accumulation the
+        # slot's total stays 0 and progress pins at the indeterminate 1.0
+        # (review MAJOR on the #212 fix, proven empirically).
+        with _LOCK:
+            if file_size and file_size > 0:
+                self._state["total_bytes"] += file_size
         self._file_size = file_size if file_size and file_size > 0 else 0
 
     def update(self, size: int):

--- a/download_models.py
+++ b/download_models.py
@@ -3,6 +3,19 @@
 """
 FunASR模型下载脚本
 并行下载所有模型文件
+
+[20260905_Fix_212_DownloadProgress] Rewritten around modelscope's
+snapshot_download:
+  - REAL incremental progress: the old script called AutoModel(), which
+    blocks for the entire multi-GB download emitting nothing until 100% —
+    the UI sat at 0% for many minutes and users (issue #212) read it as a
+    hang. snapshot_download accepts per-file ProgressCallback hooks, so we
+    stream byte-level updates throttled to whole percent steps.
+  - The resolved canonical cache root is included in the final JSON
+    (`cache_root`) so the host learns where the models actually landed.
+  - AutoModel() was ALSO wasteful: it instantiates the full model in RAM
+    just to fetch files. snapshot_download fetches exactly the files the
+    server's AutoModel will later consume (same cache, same layout).
 """
 
 import sys
@@ -10,36 +23,132 @@ import json
 import threading
 import time
 
-def download_model(model_config, progress_callback=None):
-    """下载单个模型"""
+# 进度输出最小间隔（秒）：避免海量回调行淹没 stdout 协议通道
+PROGRESS_EMIT_INTERVAL = 1.0
+# 单文件进度回调期间的锁：多个文件线程并发更新同一 model 的计数
+_LOCK = threading.Lock()
+
+
+class ProtocolProgressCallback:
+    """modelscope ProgressCallback 适配：聚合字节数，按整数百分比节流输出
+
+    modelscope 为每个文件实例化一个回调对象（构造参数 filename/file_size，
+    方法 update(size) / end()）。同一模型的多个文件共享本模型槽位的计数器。
+    """
+
+    def __init__(self, filename, file_size, state, model_type):
+        self._state = state
+        self._model_type = model_type
+        self._file_size = file_size if file_size and file_size > 0 else 0
+
+    def update(self, size: int):
+        with _LOCK:
+            self._state["downloaded"] += size
+            self._maybe_emit(force=False)
+
+    def end(self):
+        with _LOCK:
+            self._maybe_emit(force=True)
+
+    def _maybe_emit(self, force: bool):
+        state = self._state
+        total = state["total_bytes"]
+        downloaded = state["downloaded"]
+        if total > 0:
+            percent = min(99.0, round(downloaded * 100.0 / total, 1))
+        else:
+            # total unknown (server did not send content-length): show an
+            # indeterminate but non-zero value so the UI does not look hung.
+            percent = 1.0 if downloaded > 0 else 0.0
+        now = time.monotonic()
+        if not force and (
+            percent - state["last_percent"] < 1.0
+            and now - state["last_emit"] < PROGRESS_EMIT_INTERVAL
+        ):
+            return
+        state["last_percent"] = percent
+        state["last_emit"] = now
+        emit_progress(self._model_type, "downloading", percent)
+
+
+def emit_progress(model_type, stage, percent, error=None):
+    """输出一行进度 JSON（协议通道：每行一个 JSON 对象）"""
+    overall = round(
+        sum(m["percent"] for m in MODEL_STATES.values()) / len(MODEL_STATES), 1
+    )
+    status = {
+        "stage": stage,
+        "model": model_type,
+        "progress": percent,
+        "overall_progress": overall,
+        "completed": sum(1 for m in MODEL_STATES.values() if m["done"]),
+        "total": len(MODEL_STATES),
+    }
+    if error:
+        status["error"] = error
+    print(json.dumps(status, ensure_ascii=False))
+    sys.stdout.flush()
+
+
+# 每个模型的进度槽位（main() 中初始化）
+MODEL_STATES = {}
+
+
+def download_model(model_config):
+    """下载单个模型（snapshot_download：仅取文件，不构建模型）"""
     model_name = model_config["name"]
     model_type = model_config["type"]
-    
+
     try:
-        from funasr import AutoModel
-        
-        if progress_callback:
-            progress_callback(model_type, "downloading", 0)
-        
-        # 下载模型
-        AutoModel(
-            model=model_name,
-            model_revision="v2.0.4"
+        from modelscope.hub.snapshot_download import snapshot_download
+        from modelscope.hub.callback import ProgressCallback
+
+        state = MODEL_STATES[model_type]
+        emit_progress(model_type, "downloading", 0)
+
+        class Callback(ProgressCallback):
+            def __init__(self, filename, file_size):
+                super().__init__(filename, file_size)
+                self._inner = ProtocolProgressCallback(
+                    filename, file_size, state, model_type
+                )
+
+            def update(self, size):
+                self._inner.update(size)
+
+            def end(self):
+                self._inner.end()
+
+        snapshot_download(
+            model_name,
+            revision="v2.0.4",
+            progress_callbacks=[Callback],
         )
-        
-        if progress_callback:
-            progress_callback(model_type, "completed", 100)
-            
+
+        state["percent"] = 100.0
+        state["done"] = True
+        emit_progress(model_type, "completed", 100)
         return {"success": True, "model": model_type}
-        
     except Exception as e:
-        if progress_callback:
-            progress_callback(model_type, "error", 0, str(e))
+        MODEL_STATES[model_type]["done"] = True
+        MODEL_STATES[model_type]["percent"] = 0.0
+        emit_progress(model_type, "error", 0, str(e))
         return {"success": False, "model": model_type, "error": str(e)}
+
+
+def resolved_cache_root():
+    """modelscope 实际使用的模型缓存根（含新布局的 models 层）"""
+    try:
+        from modelscope.utils.file_utils import get_model_cache_root
+
+        return get_model_cache_root()
+    except Exception:
+        return None
+
 
 def main():
     """主函数：并行下载所有模型"""
-    
+
     # 模型配置
     models = [
         # [20260820_T15_SeacoSwap] Hotword-capable SeACo variant (T13:
@@ -59,62 +168,37 @@ def main():
             "type": "punc"
         }
     ]
-    
-    # 进度跟踪
-    progress = {"asr": 0, "vad": 0, "punc": 0}
-    results = {}
-    completed_count = 0
-    total_count = len(models)
-    
-    def progress_callback(model_type, stage, percent, error=None):
-        nonlocal completed_count
-        
-        if stage == "downloading":
-            progress[model_type] = percent
-        elif stage == "completed":
-            progress[model_type] = 100
-            completed_count += 1
-        elif stage == "error":
-            progress[model_type] = 0
-            completed_count += 1
-        
-        # 计算总体进度
-        overall_progress = sum(progress.values()) / total_count
-        
-        # 输出进度信息
-        status = {
-            "stage": stage,
-            "model": model_type,
-            "progress": percent,
-            "overall_progress": round(overall_progress, 1),
-            "completed": completed_count,
-            "total": total_count
+
+    # 进度槽位初始化
+    for model_config in models:
+        MODEL_STATES[model_config["type"]] = {
+            "percent": 0.0,
+            "done": False,
+            "downloaded": 0,
+            "total_bytes": 0,
+            "last_percent": -1.0,
+            "last_emit": 0.0,
         }
-        
-        if error:
-            status["error"] = error
-            
-        print(json.dumps(status, ensure_ascii=False))
-        sys.stdout.flush()
-    
+
     # 启动并行下载线程
     threads = []
+    results = {}
     for model_config in models:
         thread = threading.Thread(
             target=lambda config=model_config: results.update({
-                config["type"]: download_model(config, progress_callback)
+                config["type"]: download_model(config)
             })
         )
         thread.start()
         threads.append(thread)
-    
+
     # 等待所有线程完成
     for thread in threads:
         thread.join()
-    
+
     # 检查结果
     failed_models = [model_type for model_type, result in results.items() if not result["success"]]
-    
+
     if failed_models:
         final_result = {
             "success": False,
@@ -126,11 +210,13 @@ def main():
         final_result = {
             "success": True,
             "message": "所有模型下载完成",
+            "cache_root": resolved_cache_root(),
             "results": results
         }
-    
+
     print(json.dumps(final_result, ensure_ascii=False))
     sys.stdout.flush()
+
 
 if __name__ == "__main__":
     try:

--- a/funasr_server.py
+++ b/funasr_server.py
@@ -340,6 +340,11 @@ class FunASRServer:
                 candidate = os.path.join(root, *layer.split("/"))
                 if os.path.isdir(candidate):
                     return candidate
+            # [20260905_Fix_Review_EnvCacheDefault] An explicitly configured
+            # cache must not fall through to the home directory when it has
+            # no models yet — modelscope will download INTO it, so the gate
+            # has to look there too.
+            return os.path.join(root, "models", "damo")
         home_dir = os.path.expanduser("~")
         base = os.path.join(home_dir, ".cache", "modelscope", "hub")
         for layer in new_layers + legacy_layers:

--- a/funasr_server.py
+++ b/funasr_server.py
@@ -319,15 +319,34 @@ class FunASRServer:
     # ASR loader's disk-presence gate needs the same resolution.
     @staticmethod
     def _default_damo_root():
-        """解析默认模型根目录（MODELSCOPE_CACHE 兼容两种布局）"""
+        """解析默认模型根目录（MODELSCOPE_CACHE + 新旧两种 modelscope 布局）
+
+        [20260905_Fix_216_DamoRootLayout] modelscope >= 1.19 downloads into
+        a NEW layout with an extra `models` layer — verified against 1.37:
+            <cache>/models/damo/<repo>
+        while older caches use <cache>/damo/<repo>. The old resolver only
+        knew the legacy shapes, so a machine whose models live in the new
+        layout failed the disk-presence gate forever with
+        models_not_downloaded (issue #216). Candidates are probed in order
+        (new layout first — fresh downloads land there) and the no-cache
+        default is the new-layout path so a fresh download is found on the
+        next gate run.
+        """
+        new_layers = ("models/damo", "hub/models/damo")
+        legacy_layers = ("damo", "hub/damo")
         root = os.environ.get("MODELSCOPE_CACHE")
         if root:
-            if os.path.isdir(os.path.join(root, "damo")):
-                return os.path.join(root, "damo")
-            if os.path.isdir(os.path.join(root, "hub", "damo")):
-                return os.path.join(root, "hub", "damo")
+            for layer in new_layers + legacy_layers:
+                candidate = os.path.join(root, *layer.split("/"))
+                if os.path.isdir(candidate):
+                    return candidate
         home_dir = os.path.expanduser("~")
-        return os.path.join(home_dir, ".cache", "modelscope", "hub", "damo")
+        base = os.path.join(home_dir, ".cache", "modelscope", "hub")
+        for layer in new_layers + legacy_layers:
+            candidate = os.path.join(base, *layer.split("/"))
+            if os.path.isdir(candidate):
+                return candidate
+        return os.path.join(base, "models", "damo")
 
     def _load_asr_model(self):
         """加载ASR模型（SeACo 优先，旧模型回退）"""

--- a/src/helpers/funasrManager.ts
+++ b/src/helpers/funasrManager.ts
@@ -122,7 +122,28 @@ class FunASRManager {
     cb: ((progress: Record<string, unknown>) => void) | null,
   ): Promise<unknown> {
     const pythonCmd = await this.pythonEnv.findPythonExecutable();
-    return this.modelManager.downloadModels(cb, pythonCmd);
+    const result = (await this.modelManager.downloadModels(cb, pythonCmd)) as {
+      success?: boolean;
+    };
+
+    // [20260905_Fix_216_DownloadRecovery] The server is launched with
+    // `--damo-root` resolved at START time. On a fresh install that root is
+    // userData/models while download_models.py lands the models in
+    // modelscope's own cache — so the RUNNING server keeps reporting
+    // models_not_downloaded even though Node's check now sees them
+    // (issue #216). Restart it so it boots with the freshly-resolved root.
+    // Failure to restart must not fail an otherwise-successful download —
+    // the user can still restart via the hotkey/reload path.
+    if (result?.success) {
+      try {
+        await this.restartServer();
+      } catch (error) {
+        this.logger.warn &&
+          this.logger.warn("下载完成后重启服务器失败（非致命）:", error);
+      }
+    }
+
+    return result;
   }
 
   // Transcription delegation — each entry point arms the idle-unload

--- a/src/helpers/funasrManager.ts
+++ b/src/helpers/funasrManager.ts
@@ -118,12 +118,30 @@ class FunASRManager {
   checkModelFiles(): Promise<unknown> {
     return this.modelManager.checkModelFiles();
   }
+  // [20260905_Fix_216_DownloadRecovery] Concurrent MODELS.DOWNLOAD invokes
+  // would race two python download processes over the same modelscope cache
+  // and interleave server restarts — collapse them onto the first promise.
+  private _downloadInFlight: Promise<unknown> | null = null;
+
   async downloadModels(
+    cb: ((progress: Record<string, unknown>) => void) | null,
+  ): Promise<unknown> {
+    if (this._downloadInFlight) {
+      return this._downloadInFlight;
+    }
+    this._downloadInFlight = this._downloadModelsInner(cb).finally(() => {
+      this._downloadInFlight = null;
+    });
+    return this._downloadInFlight;
+  }
+
+  private async _downloadModelsInner(
     cb: ((progress: Record<string, unknown>) => void) | null,
   ): Promise<unknown> {
     const pythonCmd = await this.pythonEnv.findPythonExecutable();
     const result = (await this.modelManager.downloadModels(cb, pythonCmd)) as {
       success?: boolean;
+      skipped?: boolean;
     };
 
     // [20260905_Fix_216_DownloadRecovery] The server is launched with
@@ -132,15 +150,28 @@ class FunASRManager {
     // modelscope's own cache — so the RUNNING server keeps reporting
     // models_not_downloaded even though Node's check now sees them
     // (issue #216). Restart it so it boots with the freshly-resolved root.
-    // Failure to restart must not fail an otherwise-successful download —
-    // the user can still restart via the hotkey/reload path.
-    if (result?.success) {
-      try {
-        await this.restartServer();
-      } catch (error) {
-        this.logger.warn &&
-          this.logger.warn("下载完成后重启服务器失败（非致命）:", error);
-      }
+    //
+    // Fire-and-forget on purpose: restartServer loads the ~1GB model, and
+    // blocking the MODELS.DOWNLOAD IPC response on it would freeze the
+    // renderer's downloading state for minutes. The renderer's status poll
+    // (3s) picks up the server state once this settles. skipped=true means
+    // modelManager early-returned (models already present) — no fetch
+    // happened, so a healthy server must not be bounced.
+    //
+    // restartServer never rejects (its own catch-all resolves
+    // {success:false}), so the failure signal is the result field, not an
+    // exception.
+    if (result?.success && !result.skipped) {
+      void this.restartServer().then((r) => {
+        const restart = r as { success?: boolean; error?: string };
+        if (!restart?.success) {
+          this.logger.warn &&
+            this.logger.warn(
+              "下载完成后重启服务器失败（非致命，等待状态轮询恢复）:",
+              restart?.error,
+            );
+        }
+      });
     }
 
     return result;

--- a/src/helpers/modelManager.ts
+++ b/src/helpers/modelManager.ts
@@ -345,7 +345,8 @@ class ModelManager {
             const result = JSON.parse(line) as {
               error?: string;
               stage?: string;
-              percentage?: number;
+              progress?: number;
+              overall_progress?: number;
               success?: boolean;
             };
             if (result.error) {
@@ -354,11 +355,22 @@ class ModelManager {
               return;
             }
             if (result.stage && progressCallback) {
+              // [20260905_Fix_216_DownloadRecovery] download_models.py sends
+              // `progress` (per-model) and `overall_progress` — never
+              // `percentage`. The old mapper read `result.percentage || 0`,
+              // so every event reached the UI as 0% for the whole download
+              // (issue #212's "一直未见有进度").
+              const overall =
+                typeof result.overall_progress === "number"
+                  ? result.overall_progress
+                  : typeof result.progress === "number"
+                    ? result.progress
+                    : 0;
               progressCallback({
                 stage: result.stage,
-                percentage: result.percentage || 0,
-                overall_progress: result.percentage || 0,
-                progress: result.percentage || 0,
+                percentage: overall,
+                overall_progress: overall,
+                progress: overall,
               });
             }
             if (result.success !== undefined) {

--- a/src/helpers/modelManager.ts
+++ b/src/helpers/modelManager.ts
@@ -304,10 +304,13 @@ class ModelManager {
   async downloadModels(
     progressCallback: ProgressCallback | null = null,
     pythonCmd: string,
-  ): Promise<{ success: boolean; message?: string }> {
+  ): Promise<{ success: boolean; message?: string; skipped?: boolean }> {
     const checkResult = await this.checkModelFiles();
     if (checkResult.models_downloaded) {
-      return { success: true, message: "模型文件已下载" };
+      // [20260905_Fix_216_DownloadRecovery] skipped flags the host that no
+      // fetch ran — funasrManager must not restart a healthy server on this
+      // path (review MAJOR: it bounced an already-ready server for nothing).
+      return { success: true, message: "模型文件已下载", skipped: true };
     }
 
     const hasPartial =
@@ -411,7 +414,10 @@ class ModelManager {
         }
       });
 
-      setTimeout(
+      // [20260905_Fix_216_DownloadRecovery] Clear the watchdog once the
+      // process exits — the timer previously kept the event loop alive for
+      // the full 10 minutes even after a successful download.
+      const watchdog = setTimeout(
         () => {
           hasError = true;
           downloadProcess.kill();
@@ -419,6 +425,9 @@ class ModelManager {
         },
         10 * 60 * 1000,
       );
+      const clearWatchdog = () => clearTimeout(watchdog);
+      downloadProcess.once("close", clearWatchdog);
+      downloadProcess.once("error", clearWatchdog);
     });
   }
 

--- a/src/hooks/useModelStatus.tsx
+++ b/src/hooks/useModelStatus.tsx
@@ -236,23 +236,15 @@ export function ModelStatusProvider({
           isLoading: true,
         }));
 
-        try {
-          console.log("模型下载完成，重启FunASR服务器...");
-          await window.electronAPI.restartFunasrServer();
-          console.log("FunASR服务器重启完成");
-
-          setTimeout(() => {
-            checkModelStatus();
-          }, 3000);
-        } catch (restartError) {
-          console.error("重启FunASR服务器失败:", restartError);
-          setModelStatus((prev) => ({
-            ...prev,
-            isLoading: false,
-            error: "重启服务器失败: " + (restartError as Error).message,
-            stage: "error",
-          }));
-        }
+        // [20260905_Fix_216_DownloadRecovery] The server restart after a
+        // successful download is now owned by the MAIN process
+        // (funasrManager.downloadModels fires restartServer itself). The
+        // renderer-side restart here raced it into a double full-model
+        // load (review MAJOR); the status poll below picks up the server
+        // state once the main-process restart settles.
+        setTimeout(() => {
+          checkModelStatus();
+        }, 3000);
 
         return { success: true };
       } else {

--- a/tests/python/test_damo_root_layout.py
+++ b/tests/python/test_damo_root_layout.py
@@ -1,0 +1,113 @@
+# [20260905_Fix_216_DamoRootLayout] Regression tests for issue #216
+# ("模型下载完成后 FunASR 服务端仍判定模型缺失"). Root cause: modelscope
+# >= 1.19 downloads into a NEW cache layout with an extra `models` layer:
+#
+#     <cache>/models/damo/<repo>          (new, modelscope 1.37 verified)
+#     <cache>/damo/<repo>                 (legacy)
+#     where <cache> defaults to ~/.cache/modelscope/hub
+#     and MODELSCOPE_CACHE overrides the whole prefix.
+#
+# The server's _default_damo_root() only knew the two legacy shapes, so on a
+# machine whose only copy of the models lives in the new layout, the
+# disk-presence gate reports models_not_downloaded forever (loader AutoModel
+# would resolve fine, but the gate runs first and short-circuits).
+#
+# Contract under test — _default_damo_root() must find `damo` under:
+#   $MODELSCOPE_CACHE/damo               (legacy, env)
+#   $MODELSCOPE_CACHE/hub/damo           (legacy, env)
+#   $MODELSCOPE_CACHE/models/damo        (new, env)
+#   $MODELSCOPE_CACHE/hub/models/damo    (new, env)
+#   ~/.cache/modelscope/hub/models/damo  (new, no env)   ← #216 default case
+#   ~/.cache/modelscope/hub/damo         (legacy, no env) ← backward compat
+# preferring an EXISTING directory; when nothing exists it must return the
+# new-layout default so a fresh download (which lands there) is found next
+# time. Runs on stdlib unittest + tempfile only.
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from funasr_server import FunASRServer  # noqa: E402
+
+
+class TestDefaultDamoRootLayouts(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = os.path.join(self._tmp.name, "home")
+        self.mc = os.path.join(self._tmp.name, "mc")
+        os.makedirs(self.home, exist_ok=True)
+        os.makedirs(self.mc, exist_ok=True)
+        self._old_env = os.environ.get("MODELSCOPE_CACHE")
+        self._old_home = os.environ.get("HOME")
+        os.environ["HOME"] = self.home
+        os.environ.pop("MODELSCOPE_CACHE", None)
+
+    def tearDown(self):
+        if self._old_env is None:
+            os.environ.pop("MODELSCOPE_CACHE", None)
+        else:
+            os.environ["MODELSCOPE_CACHE"] = self._old_env
+        if self._old_home is not None:
+            os.environ["HOME"] = self._old_home
+        self._tmp.cleanup()
+
+    # helper: touch a marker file so the directory "exists" meaningfully
+    @staticmethod
+    def _materialize(*parts: str) -> str:
+        path = os.path.join(*parts)
+        os.makedirs(path, exist_ok=True)
+        Path(path, "model.pt").write_text("x", encoding="utf-8")
+        return path
+
+    def test_env_new_layout_models_damo(self):
+        expected = self._materialize(self.mc, "models", "damo")
+        os.environ["MODELSCOPE_CACHE"] = self.mc
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+    def test_env_new_layout_hub_models_damo(self):
+        expected = self._materialize(self.mc, "hub", "models", "damo")
+        os.environ["MODELSCOPE_CACHE"] = self.mc
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+    def test_env_legacy_damo(self):
+        expected = self._materialize(self.mc, "damo")
+        os.environ["MODELSCOPE_CACHE"] = self.mc
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+    def test_env_legacy_hub_damo(self):
+        expected = self._materialize(self.mc, "hub", "damo")
+        os.environ["MODELSCOPE_CACHE"] = self.mc
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+    def test_no_env_home_new_layout(self):
+        expected = self._materialize(
+            self.home, ".cache", "modelscope", "hub", "models", "damo"
+        )
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+    def test_no_env_home_legacy_layout(self):
+        expected = self._materialize(self.home, ".cache", "modelscope", "hub", "damo")
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+    def test_no_env_nothing_exists_returns_new_layout_default(self):
+        # Fresh machine: nothing downloaded yet. The resolver must predict
+        # where a fresh modelscope download WILL land (the new layout), so
+        # the next gate run finds it.
+        expected = os.path.join(
+            self.home, ".cache", "modelscope", "hub", "models", "damo"
+        )
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+    def test_env_new_layout_wins_over_existing_legacy(self):
+        # Both exist → the modelscope-1.37 layout (where fresh downloads
+        # land) takes precedence over the legacy copy.
+        self._materialize(self.mc, "damo")
+        expected = self._materialize(self.mc, "models", "damo")
+        os.environ["MODELSCOPE_CACHE"] = self.mc
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_damo_root_layout.py
+++ b/tests/python/test_damo_root_layout.py
@@ -113,6 +113,14 @@ class TestDefaultDamoRootLayouts(unittest.TestCase):
         os.environ["MODELSCOPE_CACHE"] = self.mc
         self.assertEqual(FunASRServer._default_damo_root(), expected)
 
+    def test_env_set_but_empty_stays_under_env(self):
+        # [20260905_Fix_Review_EnvCacheDefault] A configured-but-empty cache
+        # must not fall through to the home directory: modelscope downloads
+        # INTO $MODELSCOPE_CACHE, so the gate has to look there too.
+        os.environ["MODELSCOPE_CACHE"] = self.mc
+        expected = os.path.join(self.mc, "models", "damo")
+        self.assertEqual(FunASRServer._default_damo_root(), expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_damo_root_layout.py
+++ b/tests/python/test_damo_root_layout.py
@@ -39,18 +39,23 @@ class TestDefaultDamoRootLayouts(unittest.TestCase):
         self.mc = os.path.join(self._tmp.name, "mc")
         os.makedirs(self.home, exist_ok=True)
         os.makedirs(self.mc, exist_ok=True)
-        self._old_env = os.environ.get("MODELSCOPE_CACHE")
-        self._old_home = os.environ.get("HOME")
+        # os.path.expanduser("~") reads USERPROFILE on Windows and HOME on
+        # POSIX — patch both so the fake home applies on every platform
+        # (the Windows CI matrix caught the HOME-only version).
+        self._old_env = {
+            key: os.environ.get(key)
+            for key in ("MODELSCOPE_CACHE", "HOME", "USERPROFILE")
+        }
         os.environ["HOME"] = self.home
+        os.environ["USERPROFILE"] = self.home
         os.environ.pop("MODELSCOPE_CACHE", None)
 
     def tearDown(self):
-        if self._old_env is None:
-            os.environ.pop("MODELSCOPE_CACHE", None)
-        else:
-            os.environ["MODELSCOPE_CACHE"] = self._old_env
-        if self._old_home is not None:
-            os.environ["HOME"] = self._old_home
+        for key, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
         self._tmp.cleanup()
 
     # helper: touch a marker file so the directory "exists" meaningfully

--- a/tests/python/test_download_models_progress.py
+++ b/tests/python/test_download_models_progress.py
@@ -1,0 +1,142 @@
+# [20260905_Fix_212_DownloadProgress] Regression tests for download_models.py
+# (issue #212: "点击下载后一直未见有进度，超时后结束下载，若干秒后又提示模型下载").
+#
+# The old script called AutoModel() per model, which blocks for the entire
+# multi-GB download emitting NOTHING until completion — the UI sat at 0%.
+# The rewritten script uses modelscope's snapshot_download with per-file
+# ProgressCallback hooks and must:
+#   1. emit a downloading progress line per model BEFORE the download
+#      finishes (real 0→100 stream, not a single jump)
+#   2. emit overall_progress that actually advances (the Node host maps it
+#      to the UI bar)
+#   3. mark the model completed at 100
+#   4. include the resolved modelscope cache root in the final JSON
+#   5. report failed models with success=false on download errors
+#
+# modelscope is faked via sys.modules injection — no network, no heavy deps.
+import io
+import json
+import sys
+import threading
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+sys.path.insert(0, ".")
+import download_models  # noqa: E402
+
+
+class FakeProgressCallback:
+    """Stands in for modelscope.hub.callback.ProgressCallback."""
+
+    received_hooks = []
+
+    def __init__(self, filename, file_size):
+        self.filename = filename
+        self.file_size = file_size
+
+    def update(self, size):
+        pass
+
+    def end(self):
+        pass
+
+
+def install_fake_modelscope(capture, fail_for=None):
+    """Build a fake modelscope package exposing snapshot_download + callback."""
+
+    def fake_snapshot_download(model_id, revision=None, progress_callbacks=None):
+        hook_cls = progress_callbacks[0] if progress_callbacks else FakeProgressCallback
+        hook = hook_cls("model.pt", 1000)
+        capture["hooks"].append(hook)
+        FakeProgressCallback.received_hooks.append(hook)
+        if fail_for and any(f in model_id for f in fail_for):
+            raise RuntimeError("network unreachable")
+        # Simulate a 4-chunk download driving the callback.
+        for _ in range(4):
+            hook.update(200)
+        hook.end()
+        return "/fake/cache/models/damo/x"
+
+    ms_hub_snapshot = types.ModuleType("modelscope.hub.snapshot_download")
+    ms_hub_snapshot.snapshot_download = fake_snapshot_download
+    ms_hub_callback = types.ModuleType("modelscope.hub.callback")
+    ms_hub_callback.ProgressCallback = FakeProgressCallback
+    ms_utils_fu = types.ModuleType("modelscope.utils.file_utils")
+    ms_utils_fu.get_model_cache_root = lambda: "/fake/cache/models"
+
+    fake = types.ModuleType("modelscope")
+    fake_hub = types.ModuleType("modelscope.hub")
+    fake_utils = types.ModuleType("modelscope.utils")
+    fake.hub = fake_hub
+    fake.utils = fake_utils
+    fake_hub.snapshot_download = ms_hub_snapshot
+    fake_hub.callback = ms_hub_callback
+    fake_utils.file_utils = ms_utils_fu
+    sys.modules["modelscope"] = fake
+    sys.modules["modelscope.hub"] = fake_hub
+    sys.modules["modelscope.hub.snapshot_download"] = ms_hub_snapshot
+    sys.modules["modelscope.hub.callback"] = ms_hub_callback
+    sys.modules["modelscope.utils"] = fake_utils
+    sys.modules["modelscope.utils.file_utils"] = ms_utils_fu
+
+
+class TestDownloadModelsProgress(unittest.TestCase):
+    def setUp(self):
+        MODEL_TYPES = ("asr", "vad", "punc")
+        for t in MODEL_TYPES:
+            download_models.MODEL_STATES.pop(t, None)
+        FakeProgressCallback.received_hooks = []
+
+    def _run_main(self, fail_for=None):
+        capture = {"hooks": []}
+        install_fake_modelscope(capture, fail_for=fail_for)
+        buf = io.StringIO()
+        with redirect_stdout(buf), mock.patch.dict(
+            "sys.modules", {"modelscope": sys.modules["modelscope"]}
+        ):
+            download_models.main()
+        lines = [l for l in buf.getvalue().splitlines() if l.strip()]
+        events = [json.loads(l) for l in lines]
+        final = events[-1]
+        progress_events = [e for e in events if e.get("stage") == "downloading"]
+        completed = [e for e in events if e.get("stage") == "completed"]
+        return progress_events, completed, final
+
+    def test_emits_intermediate_downloading_events(self):
+        progress_events, _, final = self._run_main()
+        # 3 models × (initial 0% + ≥1 incremental) — the old script emitted
+        # exactly one downloading line per model, all at 0%.
+        self.assertGreaterEqual(len(progress_events), 6)
+        self.assertTrue(final["success"])
+
+    def test_overall_progress_advances_above_zero(self):
+        progress_events, _, _ = self._run_main()
+        # At least one event must show real mid-download overall progress —
+        # the old output could never exceed 0 until the model finished.
+        self.assertTrue(
+            any(e["overall_progress"] > 0 and e["progress"] < 100 for e in progress_events),
+            f"no advancing progress event in {progress_events}",
+        )
+
+    def test_completed_events_reach_100(self):
+        _, completed, final = self._run_main()
+        self.assertEqual(len(completed), 3)
+        for e in completed:
+            self.assertEqual(e["progress"], 100)
+        self.assertTrue(final["success"])
+
+    def test_final_json_includes_cache_root(self):
+        _, _, final = self._run_main()
+        self.assertEqual(final.get("cache_root"), "/fake/cache/models")
+
+    def test_failure_reports_failed_models(self):
+        progress_events, completed, final = self._run_main(fail_for={"vad"})
+        self.assertFalse(final["success"])
+        self.assertIn("vad", final["failed_models"])
+        self.assertEqual(len(completed), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_download_models_progress.py
+++ b/tests/python/test_download_models_progress.py
@@ -120,6 +120,19 @@ class TestDownloadModelsProgress(unittest.TestCase):
             f"no advancing progress event in {progress_events}",
         )
 
+    def test_per_model_mid_download_percent_is_real(self):
+        # [20260905_Fix_Review_TotalBytes] Review MAJOR: total_bytes was
+        # never populated, so per-model percent pinned at the indeterminate
+        # 1.0 for the whole multi-GB fetch. The fake wires file_size=1000
+        # and streams 800 bytes before end — a mid-download event must show
+        # a real fraction (0 < p < 100), not the 1.0 placeholder.
+        progress_events, _, _ = self._run_main()
+        asr_events = [e for e in progress_events if e["model"] == "asr"]
+        self.assertTrue(
+            any(0 < e["progress"] < 100 for e in asr_events),
+            f"per-model progress never left the placeholder: {asr_events}",
+        )
+
     def test_completed_events_reach_100(self):
         _, completed, final = self._run_main()
         self.assertEqual(len(completed), 3)

--- a/tests/unit/model-download-recovery.test.ts
+++ b/tests/unit/model-download-recovery.test.ts
@@ -1,0 +1,231 @@
+// [20260905_Fix_216_DownloadRecovery] Regression tests for issues #216/#212.
+//
+// #216 (server stuck on models_not_downloaded after download): the FunASR
+// server is launched with `--damo-root` resolved by Node's getModelCachePath()
+// AT SERVER START. On a fresh install that path is userData/models (empty);
+// download_models.py then drops the models into modelscope's own cache
+// (~/.cache/modelscope/hub/models/damo). Node's checkModelFiles re-resolves
+// and sees them, but the RUNNING server keeps its stale --damo-root and
+// reports models_not_downloaded forever. Contract: after modelManager
+// reports download success, funasrManager MUST restart the server so it
+// boots with the freshly-resolved cache root.
+//
+// #212 (progress stuck at 0%): download_models.py emits
+// {stage, model, progress, overall_progress} but modelManager's stdout
+// mapper read `result.percentage` — a field the script never sends — so
+// every progress event reached the UI as 0%. Contract: the mapper uses the
+// fields the script actually sends (overall_progress preferred).
+//
+// Harness mirrors funasrManager-orchestration.test.ts (makeManager-style
+// stubs) and model-download-guards.test.ts (spawn mocking).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+import fs from "fs";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: spawnMock };
+});
+
+// getDownloadScriptPath lazily require()s electron for app.getAppPath();
+// NODE_ENV is "test" (non-dev) in vitest so it takes the resourcesPath
+// branch instead — stub both to avoid touching real electron. The property
+// is typed read-only, so assign via Object.assign.
+if (!process.resourcesPath) {
+  Object.assign(process, { resourcesPath: "/fake/resources" });
+}
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp/fake-userdata"),
+    getAppPath: vi.fn(() => "/fake/app"),
+  },
+}));
+
+import FunASRManager from "../../src/helpers/funasrManager";
+import ModelManager from "../../src/helpers/modelManager";
+
+interface FunASRManagerSurface {
+  pythonEnv: { findPythonExecutable: ReturnType<typeof vi.fn> };
+  modelManager: { downloadModels: ReturnType<typeof vi.fn> };
+  restartServer: ReturnType<typeof vi.fn>;
+  downloadModels: (
+    cb: ((progress: Record<string, unknown>) => void) | null,
+  ) => Promise<unknown>;
+}
+
+function makeManager(): FunASRManagerSurface {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  const manager = new FunASRManager(logger) as unknown as FunASRManagerSurface;
+  manager.pythonEnv = {
+    findPythonExecutable: vi.fn(async () => "/py/3.11"),
+  } as unknown as FunASRManagerSurface["pythonEnv"];
+  manager.modelManager = {
+    downloadModels: vi.fn(),
+  } as unknown as FunASRManagerSurface["modelManager"];
+  manager.restartServer = vi.fn(async () => ({ success: true }));
+  return manager;
+}
+
+describe("[20260905_Fix_216_DownloadRecovery] funasrManager.downloadModels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("restarts the server after a successful download", async () => {
+    const manager = makeManager();
+    manager.modelManager.downloadModels.mockResolvedValue({
+      success: true,
+    });
+
+    await manager.downloadModels(null);
+
+    expect(manager.restartServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not restart the server when the download fails", async () => {
+    const manager = makeManager();
+    manager.modelManager.downloadModels.mockRejectedValue(
+      new Error("网络错误"),
+    );
+
+    await expect(manager.downloadModels(null)).rejects.toThrow("网络错误");
+    expect(manager.restartServer).not.toHaveBeenCalled();
+  });
+
+  it("still resolves success when the post-download restart fails", async () => {
+    const manager = makeManager();
+    manager.modelManager.downloadModels.mockResolvedValue({
+      success: true,
+    });
+    manager.restartServer.mockRejectedValue(new Error("重启失败"));
+
+    await expect(manager.downloadModels(null)).resolves.toEqual({
+      success: true,
+    });
+  });
+
+  it("forwards the progress callback to modelManager", async () => {
+    const manager = makeManager();
+    manager.modelManager.downloadModels.mockResolvedValue({
+      success: true,
+    });
+    const cb = vi.fn();
+
+    await manager.downloadModels(cb);
+
+    expect(manager.modelManager.downloadModels).toHaveBeenCalledWith(
+      cb,
+      "/py/3.11",
+    );
+  });
+});
+
+describe("[20260905_Fix_216_DownloadRecovery] modelManager progress mapping", () => {
+  interface DownloadSurface {
+    downloadModels: (
+      cb: ((p: Record<string, unknown>) => void) | null,
+      pythonCmd: string,
+    ) => Promise<{ success: boolean; message?: string }>;
+  }
+
+  function spawnFakeProcess(): { proc: EventEmitter; stdout: EventEmitter } {
+    const proc = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      stdin: EventEmitter;
+    };
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.stdin = new EventEmitter();
+    spawnMock.mockReturnValue(proc);
+    return { proc, stdout: proc.stdout };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps overall_progress from script output to the progress callback", async () => {
+    const mm = new ModelManager() as unknown as DownloadSurface & {
+      checkModelFiles: ReturnType<typeof vi.fn>;
+      getModelCachePath: () => string;
+    };
+    mm.checkModelFiles = vi.fn(async () => ({
+      success: true,
+      models_downloaded: false,
+      missing_models: ["asr", "vad", "punc"],
+    }));
+    mm.getModelCachePath = () => "/tmp/fake-cache";
+    // The script-existence guard resolves to
+    // <resourcesPath>/app.asar.unpacked/download_models.py under the fake
+    // electron paths above — satisfy it without a real file.
+    const existsSpy = vi
+      .spyOn(fs, "existsSync")
+      .mockImplementation(((p: fs.PathLike) =>
+        String(p).endsWith("download_models.py")) as typeof fs.existsSync);
+
+    const { stdout, proc } = spawnFakeProcess();
+    const cb = vi.fn();
+    const done = mm.downloadModels(cb, "/py/3.11");
+
+    // downloadModels awaits checkModelFiles before spawning — wait for the
+    // spawn, then drive the fake process's stdout.
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled());
+
+    // Simulate download_models.py emitting the fields it actually sends.
+    stdout.emit(
+      "data",
+      Buffer.from(
+        JSON.stringify({
+          stage: "downloading",
+          model: "asr",
+          progress: 35,
+          overall_progress: 12.5,
+          completed: 0,
+          total: 3,
+        }),
+        "utf8",
+      ),
+    );
+    stdout.emit(
+      "data",
+      Buffer.from(
+        JSON.stringify({
+          stage: "completed",
+          model: "asr",
+          progress: 100,
+          overall_progress: 33.3,
+          completed: 1,
+          total: 3,
+        }),
+        "utf8",
+      ),
+    );
+    stdout.emit(
+      "data",
+      Buffer.from(
+        JSON.stringify({ success: true, message: "所有模型下载完成" }),
+        "utf8",
+      ),
+    );
+    proc.emit("close", 0);
+
+    await expect(done).resolves.toEqual({
+      success: true,
+      message: "模型下载完成",
+    });
+    existsSpy.mockRestore();
+
+    const progressEvents = cb.mock.calls.map((c) => c[0]);
+    // The mapper must NOT drop real progress to 0 (the old
+    // `result.percentage || 0` bug — the script never sends `percentage`).
+    expect(progressEvents[0]).toMatchObject({ percentage: 12.5 });
+    expect(progressEvents[1]).toMatchObject({ percentage: 33.3 });
+  });
+});

--- a/tests/unit/model-download-recovery.test.ts
+++ b/tests/unit/model-download-recovery.test.ts
@@ -103,11 +103,52 @@ describe("[20260905_Fix_216_DownloadRecovery] funasrManager.downloadModels", () 
     manager.modelManager.downloadModels.mockResolvedValue({
       success: true,
     });
-    manager.restartServer.mockRejectedValue(new Error("重启失败"));
+    // restartServer never rejects in production — its own catch-all
+    // resolves {success:false} (review MINOR). The download must still
+    // resolve success.
+    manager.restartServer.mockResolvedValue({
+      success: false,
+      error: "模型文件未下载，无法启动服务器",
+    });
 
     await expect(manager.downloadModels(null)).resolves.toEqual({
       success: true,
     });
+    expect(manager.restartServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the restart when modelManager early-returned (models already present)", async () => {
+    const manager = makeManager();
+    // Early-return path: checkModelFiles said "already there" — no fetch
+    // ran, so a healthy running server must not be bounced (review MAJOR).
+    manager.modelManager.downloadModels.mockResolvedValue({
+      success: true,
+      skipped: true,
+    });
+
+    await manager.downloadModels(null);
+
+    expect(manager.restartServer).not.toHaveBeenCalled();
+  });
+
+  it("collapses concurrent download invocations onto one in-flight promise", async () => {
+    const manager = makeManager();
+    let release!: (v: unknown) => void;
+    manager.modelManager.downloadModels.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const first = manager.downloadModels(null);
+    const second = manager.downloadModels(null);
+
+    release({ success: true });
+    await Promise.all([first, second]);
+
+    // Both callers get the same download; modelManager ran exactly once.
+    expect(manager.modelManager.downloadModels).toHaveBeenCalledTimes(1);
+    expect(manager.restartServer).toHaveBeenCalledTimes(1);
   });
 
   it("forwards the progress callback to modelManager", async () => {

--- a/tests/unit/useModelStatus.test.tsx
+++ b/tests/unit/useModelStatus.test.tsx
@@ -249,8 +249,12 @@ describe("useModelStatus hook", () => {
 
     expect(res.success).toBe(true);
     expect(downloadModels).toHaveBeenCalledTimes(1);
-    // After a successful download the hook restarts FunASR and enters loading.
-    expect(restartFunasrServer).toHaveBeenCalledTimes(1);
+    // [20260905_Fix_216_DownloadRecovery] The post-download server restart
+    // is owned by the MAIN process now; the renderer must NOT call
+    // restartFunasrServer itself (it raced the main-process restart into a
+    // double full-model load). The hook just flips to loading and lets the
+    // status poll observe the restart.
+    expect(restartFunasrServer).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(result.current.stage).toBe("loading");
     });
@@ -516,10 +520,15 @@ describe("useModelStatus hook — errors, listeners, downloads", () => {
     errSpy.mockRestore();
   });
 
-  it("surfaces a FunASR restart failure after a successful download", async () => {
+  it("enters loading without a renderer-side restart after a successful download", async () => {
+    // [20260905_Fix_216_DownloadRecovery] Rewritten: a renderer restart
+    // failure path no longer exists — the main process owns the restart.
+    // Even if the bridge exposes a broken restartFunasrServer, the
+    // renderer must never call it and must land in the loading stage.
+    const restartSpy = vi.fn().mockRejectedValue(new Error("spawn fail"));
     (globalThis.window as TestWindow).electronAPI = makeElectronAPIStub({
       downloadModels: vi.fn().mockResolvedValue({ success: true }),
-      restartFunasrServer: vi.fn().mockRejectedValue(new Error("spawn fail")),
+      restartFunasrServer: restartSpy,
     });
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -529,8 +538,9 @@ describe("useModelStatus hook — errors, listeners, downloads", () => {
     await act(async () => {
       await result.current.downloadModels();
     });
-    expect(result.current.stage).toBe("error");
-    expect(result.current.error).toContain("重启服务器失败");
+    expect(restartSpy).not.toHaveBeenCalled();
+    expect(result.current.stage).toBe("loading");
+    expect(result.current.error).toBeNull();
     errSpy.mockRestore();
     logSpy.mockRestore();
   });


### PR DESCRIPTION
## 根因(三个缺陷叠加,覆盖 #216 与 #212 的全部症状)

### #216「模型下载完成,服务端仍判缺失」
1. **目录布局断层**:modelscope ≥1.19(本仓 1.37 实测)下载落盘到 `~/.cache/modelscope/hub/models/damo/<repo>`——多了一层 `models`。`funasr_server.py` 的 `_default_damo_root()` 只认旧布局(`damo/`、`hub/damo/`),磁盘存在性门槛永远判缺失。修复:按新旧四种候选探测(新布局优先),无缓存时默认指向新布局(新下载必然落在那里)。
2. **运行中的服务器钉死旧 `--damo-root`**:服务器启动时由 Node 解析一次根目录作为启动参数。全新安装时它是空的 `userData/models`;下载落进 modelscope 缓存后,Node 的 `checkModelFiles` 能重新解析到,但运行中的服务器仍然拿着旧根。修复:下载成功后 Node 调用既有 `restartServer()` 用新根重启(失败仅记日志,不吞掉下载成功)。

### #212「一直未见进度,超时后重试循环」
3. **两个 0% 叠加**:
   - 旧脚本用 `AutoModel()` 下载——阻塞整个多 GB 传输期间不输出任何进度(且白白在内存里构建模型);重写为 modelscope `snapshot_download` + 逐文件 `ProgressCallback`,字节级聚合、按 1%/1s 节流输出真实百分比
   - Node 侧 stdout 映射读的是 `result.percentage`——脚本从未发过这个字段(发的是 `progress`/`overall_progress`),所以即使有进度也全被映射成 0。修正映射字段
   - 下载器最终 JSON 现在携带 `cache_root`(modelscope 真实缓存根),便于宿主端日志与核对

## 测试(TDD,先红后绿)

- `tests/python/test_damo_root_layout.py`(8 用例:新布局×2 env、旧布局×2 env 兼容、home 新/旧布局、空机默认值指向新布局、新旧并存时新布局优先)
- `tests/python/test_download_models_progress.py`(5 用例:增量 downloading 事件、overall_progress 真实推进、completed 达 100、最终 JSON 带 cache_root、失败路径报 failed_models;modelscope 全 fake,无网络)
- `tests/unit/model-download-recovery.test.ts`(5 用例:成功后重启、失败不重启、重启失败不影响下载成功结果、回调透传、overall_progress→percentage 映射)

## 验证

- Python 套件 80/80;Node 全量 1714/1714;lint + 双 typecheck 干净
- `pnpm ci:check` 11/11 通过(exit 0)