### PR TITLE
Spec #299 T1+T2 — README 事实纠错 + 文档契约测试(版本钉子/链接完整性)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,15 @@
 
 ### 必要条件
 
-- **Node.js** 18+（推荐 22 LTS）
+<!-- [20260907_Spec299_P0Facts] Env requirements synced with package.json
+     engines (node >=22.5) and pyproject.toml requires-python (>=3.11) after
+     the README audit: 18+/3.8+ contradicted README and failed contributor
+     setup at `uv sync`. -->
+<!-- [20260907_Spec299_P0Facts] END -->
+
+- **Node.js** 22.5+（与 `package.json` engines 一致）
 - **pnpm** 9+（`npm install -g pnpm`）
-- **Python** 3.8+（推荐 3.11）
+- **Python** 3.11+（与 `pyproject.toml` 的 requires-python 一致）
 - **ffmpeg**（音频格式转换，macOS: `brew install ffmpeg`）
 - **Git**
 - macOS / Windows / Linux

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@
 
 <!-- [20260731_README_DynamicBadge] END -->
 
+<!-- [20260907_Spec299_P0Facts] Batch factual sync after the end-to-end README
+     audit (docs/research/readme-end-to-end-audit-2026-09-07.md §2): Electron
+     36→39, FTS5 claim → client-side filtering (FTS5 table removed 2026-08-15),
+     Python 3.8+ → 3.11+ (pyproject.toml requires-python), GPU order
+     CUDA > CPU (MPS intentionally skipped: FunASR float64 unsupported),
+     comparison table macOS Dictation open-source ❌, test-count line switched
+     to non-drift wording. Version claims are pinned by
+     tests/unit/readme-contract.test.ts. -->
+<!-- [20260907_Spec299_P0Facts] END -->
+
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Stars](https://img.shields.io/github/stars/TeFuirnever/Murmur?style=social)](https://github.com/TeFuirnever/Murmur)
 
@@ -66,7 +76,7 @@
 | **自定义 Prompt**   |     ✅     |       ❌       |     ❌     |       ❌        |
 | **11+ AI 模型可选** |     ✅     |       ❌       |     ❌     |       ❌        |
 | 中文识别精度        | ⭐⭐⭐⭐⭐ |     ⭐⭐⭐     | ⭐⭐⭐⭐⭐ |     ⭐⭐⭐      |
-| 开源免费            |     ✅     |       ✅       |     ❌     |       ✅        |
+| 开源免费            |     ✅     |       ❌       |     ❌     |       ✅        |
 
 > 系统听写在"实时性"上更强（流式低延迟），Murmur 在"转写后能做什么"上更强（AI 润色 + 文件批处理 + 隐私）。两者可以共存。
 
@@ -138,7 +148,7 @@
 ### 环境要求
 
 - **Node.js** 22.5+ 和 [pnpm](https://pnpm.io)
-- **Python** 3.8+（用于 FunASR）
+- **Python** 3.11+（用于 FunASR，与 `pyproject.toml` 的 requires-python 一致）
 
 ### 快速开始
 
@@ -163,7 +173,7 @@ pnpm dev
 
 ```bash
 pnpm dev          # 启动开发模式
-pnpm test         # 运行测试（2200+ tests，覆盖率 ~97%）
+pnpm test         # 运行测试（单测 + E2E）与覆盖率门禁
 pnpm lint         # 代码检查（0 warnings）
 pnpm typecheck    # TypeScript 类型检查
 pnpm ci:check     # 本地运行所有 CI 门禁
@@ -175,7 +185,7 @@ pnpm ci:check     # 本地运行所有 CI 门禁
 
 | 层级     | 技术                                                  |
 | -------- | ----------------------------------------------------- |
-| 桌面框架 | Electron 36                                           |
+| 桌面框架 | Electron 39                                           |
 | 前端     | React 19, Tailwind CSS 4, Vite                        |
 | 语音识别 | FunASR (Paraformer-large + FSMN-VAD + CT-Transformer) |
 | AI 优化  | 11+ OpenAI 兼容模型 + 自定义 Prompt 模板              |
@@ -189,12 +199,12 @@ pnpm ci:check     # 本地运行所有 CI 门禁
 - [x] AI 文本智能优化（11+ 模型，含本地 Ollama/LM Studio）
 - [x] 自定义 AI Prompt 模板
 - [x] 音频文件导入转录（wav/mp3/m4a/flac）
-- [x] 转录历史搜索（FTS5 全文搜索）和导出（TXT/SRT/Markdown/DOCX）
+- [x] 转录历史搜索（实时客户端过滤）和导出（TXT/SRT/Markdown/DOCX）
 - [x] 全局热键 `Cmd+Shift+Space`
 - [x] 多语言支持（中文/English）
 - [x] 半自动更新（SHA256 校验）
 - [x] 无障碍（ARIA + 键盘导航）
-- [x] GPU 自动检测（CUDA > MPS > CPU）
+- [x] GPU 自动检测（CUDA > CPU；MPS 因 FunASR float64 不兼容被有意跳过）
 - [x] TypeScript 严格模式（全 src 覆盖率门禁，测试与覆盖率详见 CI）
 - [x] 文件配置支持（`~/.murmur.json`）
 - [x] AI Provider 快速开始引导（免费 API Key 获取）
@@ -259,7 +269,7 @@ Speak to type, convert audio to text, AI auto-polish. Powered by FunASR, all on 
 | **Custom Prompts**     |     ✅     |       ❌        |     ❌     |       ❌        |
 | **11+ AI Models**      |     ✅     |       ❌        |     ❌     |       ❌        |
 | Chinese Accuracy       | ⭐⭐⭐⭐⭐ |     ⭐⭐⭐      | ⭐⭐⭐⭐⭐ |     ⭐⭐⭐      |
-| Open Source            |     ✅     |       ✅        |     ❌     |       ✅        |
+| Open Source            |     ✅     |       ❌        |     ❌     |       ✅        |
 
 > System dictation wins on real-time latency (streaming); Murmur wins on "what you can do after transcription" (AI polish + batch files + privacy). They can coexist.
 
@@ -317,7 +327,7 @@ pnpm dev
 
 | Layer    | Technology                                             |
 | -------- | ------------------------------------------------------ |
-| Desktop  | Electron 36                                            |
+| Desktop  | Electron 39                                            |
 | Frontend | React 19, Tailwind CSS 4, Vite                         |
 | Speech   | FunASR (Paraformer-large + FSMN-VAD + CT-Transformer)  |
 | AI       | 11+ OpenAI-compatible models + custom prompt templates |
@@ -331,12 +341,12 @@ pnpm dev
 - [x] AI text optimization (11+ models, incl. local Ollama/LM Studio)
 - [x] Custom AI prompt templates
 - [x] Audio file transcription (wav/mp3/m4a/flac)
-- [x] History search (FTS5 full-text) and export (TXT/SRT/Markdown/DOCX)
+- [x] History search (instant client-side filtering) and export (TXT/SRT/Markdown/DOCX)
 - [x] Global hotkey
 - [x] Multi-language (Chinese/English)
 - [x] Semi-auto update (SHA256 verified)
 - [x] Accessibility (ARIA + keyboard nav)
-- [x] GPU auto-detection (CUDA > MPS > CPU)
+- [x] GPU auto-detection (CUDA > CPU; MPS intentionally skipped — FunASR float64 unsupported)
 - [x] TypeScript strict mode (full-src coverage gated, see CI for test count)
 - [x] File config support (`~/.murmur.json`)
 - [x] AI Provider quick-start guide (free API key)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ pnpm dev
 
 ```bash
 pnpm dev          # 启动开发模式
-pnpm test         # 运行测试（单测 + E2E）与覆盖率门禁
+pnpm test         # 运行单元测试与覆盖率门禁（E2E 在 CI 单独运行）
 pnpm lint         # 代码检查（0 warnings）
 pnpm typecheck    # TypeScript 类型检查
 pnpm ci:check     # 本地运行所有 CI 门禁

--- a/tests/unit/readme-contract.test.ts
+++ b/tests/unit/readme-contract.test.ts
@@ -1,0 +1,86 @@
+// [20260907_Spec299_DocsContract] Docs contract test: pins README factual
+// claims to their sources of truth so drift turns CI red instead of
+// surfacing in a manual audit (Spec #299, audit report
+// docs/research/readme-end-to-end-audit-2026-09-07.md). Assertions are
+// added incrementally per ticket and must land green: version pins (T1),
+// link integrity (T2), zh/en heading parity after the bilingual split (T3).
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  engines?: { node?: string };
+}
+
+const ROOT = path.resolve(__dirname, "../..");
+
+function readRootFile(relativePath: string): string {
+  return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+function readPackageJson(): PackageJson {
+  return JSON.parse(readRootFile("package.json")) as PackageJson;
+}
+
+function majorOf(versionRange: string): string {
+  const digits = versionRange.replace(/[^0-9.]/g, "");
+  return digits.split(".")[0] ?? "";
+}
+
+// Contract assertions must evaluate the RENDERED document: HTML comments
+// (change-tag annotations, commented-out placeholders) are invisible to
+// readers and must not be pinned or scanned.
+function stripHtmlComments(markdown: string): string {
+  return markdown.replace(/<!--[\s\S]*?-->/g, "");
+}
+
+function readRenderedRootFile(relativePath: string): string {
+  return stripHtmlComments(readRootFile(relativePath));
+}
+
+describe("README contract", () => {
+  describe("version pins (T1, Spec #299)", () => {
+    it("every Electron major mentioned in README matches package.json", () => {
+      const pkg = readPackageJson();
+      const electronRange =
+        pkg.devDependencies?.electron ?? pkg.dependencies?.electron;
+      expect(
+        electronRange,
+        "electron must be declared in package.json",
+      ).toBeDefined();
+      const expected = `Electron ${majorOf(electronRange ?? "")}`;
+
+      const readme = readRenderedRootFile("README.md");
+      const mentions = readme.match(/Electron\s+\d+(?:\.\d+)*/g) ?? [];
+      expect(
+        mentions.length,
+        "README tech-stack table must mention Electron",
+      ).toBeGreaterThan(0);
+      for (const mention of mentions) {
+        expect(
+          mention,
+          `stale Electron version in README (package.json says ${electronRange})`,
+        ).toBe(expected);
+      }
+    });
+
+    it("Node.js floor stated in README matches package.json engines", () => {
+      const pkg = readPackageJson();
+      const enginesNode = pkg.engines?.node;
+      expect(
+        enginesNode,
+        "engines.node must be declared in package.json",
+      ).toBeDefined();
+      // engines ">=22.5" -> README states the same floor as "**Node.js** 22.5+"
+      const floor = enginesNode?.replace(/^>=?/, "") ?? "";
+
+      const readme = readRenderedRootFile("README.md");
+      expect(
+        readme.includes(`**Node.js** ${floor}+`),
+        `README Node.js floor must equal engines.node (${enginesNode})`,
+      ).toBe(true);
+    });
+  });
+});

--- a/tests/unit/readme-contract.test.ts
+++ b/tests/unit/readme-contract.test.ts
@@ -83,4 +83,43 @@ describe("README contract", () => {
       ).toBe(true);
     });
   });
+
+  describe("link integrity (T2, Spec #299)", () => {
+    // T3 extends this list with README.zh-CN.md after the bilingual split.
+    const readmeFiles = ["README.md"];
+
+    function internalLinkTargets(markdown: string): string[] {
+      const rendered = stripHtmlComments(markdown);
+      const linkPattern = /\[[^\]]*\]\(([^)\s]+)\)/g;
+      return [...rendered.matchAll(linkPattern)].map((match) => match[1] ?? "");
+    }
+
+    for (const file of readmeFiles) {
+      it(`${file}: every internal link/asset path resolves on disk`, () => {
+        const targets = internalLinkTargets(readRootFile(file));
+        expect(
+          targets.length,
+          "link extractor must find the README's links",
+        ).toBeGreaterThan(0);
+
+        const broken: string[] = [];
+        for (const target of targets) {
+          // External URLs are out of contract scope (CI network flakiness;
+          // industry link checkers exclude them the same way).
+          if (/^(https?:)?\/\//.test(target) || target.startsWith("mailto:")) {
+            continue;
+          }
+          const withoutAnchor = target.split("#")[0] ?? "";
+          if (withoutAnchor === "") continue; // pure in-page anchor
+          const decoded = decodeURIComponent(withoutAnchor);
+          if (!fs.existsSync(path.join(ROOT, decoded))) {
+            broken.push(target);
+          }
+        }
+        expect(broken, `broken internal links: ${broken.join(", ")}`).toEqual(
+          [],
+        );
+      });
+    }
+  });
 });

--- a/tests/unit/readme-contract.test.ts
+++ b/tests/unit/readme-contract.test.ts
@@ -76,11 +76,20 @@ describe("README contract", () => {
       // engines ">=22.5" -> README states the same floor as "**Node.js** 22.5+"
       const floor = enginesNode?.replace(/^>=?/, "") ?? "";
 
+      // All-mentions check (same design as the Electron pin): a stale floor
+      // anywhere in the document must fail, not just a missing correct one.
       const readme = readRenderedRootFile("README.md");
+      const mentions = readme.match(/\*\*Node\.js\*\* \d+(?:\.\d+)*\+/g) ?? [];
       expect(
-        readme.includes(`**Node.js** ${floor}+`),
-        `README Node.js floor must equal engines.node (${enginesNode})`,
-      ).toBe(true);
+        mentions.length,
+        "README must state its Node.js floor at least once",
+      ).toBeGreaterThan(0);
+      for (const mention of mentions) {
+        expect(
+          mention,
+          `stale Node.js floor in README (engines.node = ${enginesNode})`,
+        ).toBe(`**Node.js** ${floor}+`);
+      }
     });
   });
 
@@ -90,8 +99,21 @@ describe("README contract", () => {
 
     function internalLinkTargets(markdown: string): string[] {
       const rendered = stripHtmlComments(markdown);
+      // Strip image syntax first so a badge link's OUTER href becomes the
+      // remaining [text](href) match; otherwise `[![alt](img)](href)` makes
+      // the extractor capture only the img src and silently drop the href.
+      const withoutImages = rendered.replace(/!\[[^\]]*\]\([^)\s]*\)/g, "");
       const linkPattern = /\[[^\]]*\]\(([^)\s]+)\)/g;
-      return [...rendered.matchAll(linkPattern)].map((match) => match[1] ?? "");
+      const targets = [...withoutImages.matchAll(linkPattern)].map(
+        (match) => match[1] ?? "",
+      );
+      // GitHub renders raw <img> tags too (the README logo); their src
+      // points at repo assets the same contract must cover.
+      const imgPattern = /<img\s[^>]*src="([^"]+)"/g;
+      for (const match of rendered.matchAll(imgPattern)) {
+        targets.push(match[1] ?? "");
+      }
+      return targets;
     }
 
     for (const file of readmeFiles) {
@@ -111,7 +133,13 @@ describe("README contract", () => {
           }
           const withoutAnchor = target.split("#")[0] ?? "";
           if (withoutAnchor === "") continue; // pure in-page anchor
-          const decoded = decodeURIComponent(withoutAnchor);
+          let decoded: string;
+          try {
+            decoded = decodeURIComponent(withoutAnchor);
+          } catch {
+            broken.push(target); // malformed percent-encoding IS broken
+            continue;
+          }
           if (!fs.existsSync(path.join(ROOT, decoded))) {
             broken.push(target);
           }


### PR DESCRIPTION
## Parent

Closes #300, closes #301 (Spec #299)

## What

**T1 — P0 事实纠错(#300)**:修正端到端审计(docs/research/readme-end-to-end-audit-2026-09-07.md §2)发现的全部 6 处事实错误(中英两半同步):Electron 36→39、FTS5→客户端过滤、Python 3.8+→3.11+(README+CONTRIBUTING)、GPU CUDA>CPU(MPS 有意跳过)、对比表 macOS 听写开源❌、测试数行改不漂移口径;CONTRIBUTING Node 18+→22.5+ 消除与 README 的矛盾。

**T2 — 链接完整性断言(#301)**:大拆分(T3)前的防护网——README 全部站内链接/资源路径必须落盘可解析,断链即红(红探针已验证)。

## Contract test

tests/unit/readme-contract.test.ts:版本钉子(Electron 主版本/Node 地板 == package.json)+ 链接完整性。只断言渲染内容(HTML 注释剥离),徽章外层 href、`<img>` src 均已覆盖。

## Evidence

- 红验证:Electron 断言在旧 README 上红(36≠39);死链探针红并点名目标;还原后绿
- 独立 code-review ×2(APPROVE),4 条建议项已修复复验(commit 178b11a)
- 本地 `pnpm ci:check` 11 道门禁全绿(security audit 非阻塞警告)