### PR TITLE
fix/test: 6 张 fast-follow — T7 钳制激活/写回失败 toast/模板信任边界/AI_REVIEW 可达/Python 覆盖率 46

### DIFF
--- a/scripts/run-python-tests.js
+++ b/scripts/run-python-tests.js
@@ -27,7 +27,9 @@ const TESTS_DIR = path.join(ROOT, "tests", "python");
 // today is the big reserve) — never lower without a spec. Note:
 // --fail-under compares the UNROUNDED total while the table prints
 // rounded integers (a 42.6% actual prints 43% yet fails the gate).
-const PYTHON_FAIL_UNDER = 43;
+// [20260907_Fix_317_PythonBranchFill] raised from 43 after the protocol/
+// lifecycle branch tests lifted funasr_server.py 34%→39% (total 47%).
+const PYTHON_FAIL_UNDER = 46;
 
 // Modules exercised by tests/python; everything else in the repo is out of
 // the Python measurement scope.

--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -113,6 +113,7 @@ export default function FileImport({
           id={result.id}
           onCopy={handleCopy}
           onAIOptimize={handleAIOptimize}
+          preferOnAIOptimize={true}
         />
         <button
           onClick={reset}

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -1,4 +1,8 @@
 import * as React from "react";
+// [20260907_Fix_314_PolishSaveToast] Toast surfaces a polish write-back
+// failure; useTranslation routes the warning through i18n.
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { LoadingDots } from "./ui/loading-dots";
 import ExportPanel from "./ExportPanel";
 import ProcessingPanel from "./ProcessingPanel";
@@ -48,6 +52,8 @@ export default function TranscriptionResult({
   onCopy,
   onAIOptimize,
 }: TranscriptionResultProps) {
+  // [20260907_Fix_314_PolishSaveToast] i18n for the write-back failure toast.
+  const { t } = useTranslation();
   const [expandedSegment, setExpandedSegment] = React.useState<
     string | number | null
   >(null);
@@ -126,7 +132,16 @@ export default function TranscriptionResult({
         text: polishedText,
       });
     } catch (err) {
+      // [20260907_Fix_314_PolishSaveToast] The polished text stays on screen
+      // (do not erase what the user is reading), but a persistence failure
+      // must be visible: after a restart the record reverts to the original.
       console.warn("Failed to persist polished transcription:", err);
+      toast.warning(
+        t(
+          "transcription.polishSaveFailed",
+          "润色结果保存失败，重启后将显示原文本",
+        ),
+      );
     }
   };
 

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -24,6 +24,12 @@ interface TranscriptionResultProps {
   isOptimizing?: boolean;
   onCopy?: (text: string) => void;
   onAIOptimize?: (text: string) => Promise<string>;
+  // [20260907_Fix_316_PreferReviewProp] When the parent provides its own
+  // optimize channel (e.g. file import's server-side review by record id),
+  // it must take precedence over the ambient processText — otherwise the
+  // injected channel is unreachable in production. Default false keeps the
+  // recording path's mode-selector UX.
+  preferOnAIOptimize?: boolean;
 }
 
 function formatTimestamp(ms?: number): string {
@@ -51,6 +57,7 @@ export default function TranscriptionResult({
   isOptimizing,
   onCopy,
   onAIOptimize,
+  preferOnAIOptimize,
 }: TranscriptionResultProps) {
   // [20260907_Fix_314_PolishSaveToast] i18n for the write-back failure toast.
   const { t } = useTranslation();
@@ -171,7 +178,12 @@ export default function TranscriptionResult({
       // processText and the injected onAIOptimize flow) converge here so
       // the write-back fires exactly once per successful polish.
       let polishedText: string | null = null;
-      if (window.electronAPI?.processText) {
+      if (preferOnAIOptimize && onAIOptimize) {
+        // [20260907_Fix_316_PreferReviewProp] Parent-declared channel wins
+        // (file import's aiReviewTranscription review-by-id).
+        polishedText = await onAIOptimize(text);
+        setOptimizedText(polishedText);
+      } else if (window.electronAPI?.processText) {
         const result = (await Promise.race([
           window.electronAPI.processText(text, currentMode),
           new Promise((_, reject) =>

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -127,10 +127,27 @@ export default function TranscriptionResult({
   ): Promise<void> => {
     if (!window.electronAPI?.updateTranscription) return;
     try {
-      await window.electronAPI.updateTranscription(recordId, {
+      // [20260907_Fix_314_ReviewFix] The handler wraps every failure (DB
+      // locked, missing record, zero changes, whitelist rejection) in a
+      // RESOLVED {success:false, error} envelope — only invoke-level faults
+      // reject. Both shapes must warn.
+      const result = await window.electronAPI.updateTranscription(recordId, {
         processed_text: polishedText,
         text: polishedText,
       });
+      if (!result?.success) {
+        console.warn(
+          "Failed to persist polished transcription:",
+          result?.error,
+        );
+        toast.warning(
+          t(
+            "transcription.polishSaveFailed",
+            "润色结果保存失败，重启后将显示原文本",
+          ),
+        );
+        return;
+      }
     } catch (err) {
       // [20260907_Fix_314_PolishSaveToast] The polished text stays on screen
       // (do not erase what the user is reading), but a persistence failure

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -28,7 +28,8 @@ interface TranscriptionResultProps {
   // optimize channel (e.g. file import's server-side review by record id),
   // it must take precedence over the ambient processText — otherwise the
   // injected channel is unreachable in production. Default false keeps the
-  // recording path's mode-selector UX.
+  // recording path's mode-selector UX. If the flag is set but the channel
+  // is absent, the ambient processText path is used (graceful degradation).
   preferOnAIOptimize?: boolean;
 }
 

--- a/src/helpers/aiPrompts.ts
+++ b/src/helpers/aiPrompts.ts
@@ -166,7 +166,9 @@ export function buildPrompt(
     // {output_lang} renders the explicit output language and {speakers} the
     // assembled speaker lines — both render as "" when the corresponding
     // option is absent. Custom system prompts stay verbatim (no built-in
-    // shared prefix), and legacy {text}-only templates are byte-identical.
+    // shared prefix). Legacy {text}-only templates were byte-identical until
+    // [20260907_Fix_315_TemplateTrustBoundary] appended the injection guard
+    // to the rendered user body (ticket #315).
     // [20260906_Feat_PromptEngineering_Review] Function-form replacements:
     // transcript/speaker text may contain "$&"-style sequences that the
     // string form of replace() would interpret as special patterns.

--- a/src/helpers/aiPrompts.ts
+++ b/src/helpers/aiPrompts.ts
@@ -180,6 +180,13 @@ export function buildPrompt(
           ? assembleSpeakerSegments(speakerSegments)
           : "",
       );
+    // [20260907_Fix_315_TemplateTrustBoundary] Ticket #315 plan A: shared
+    // templates interpolate the raw transcript, so the injection guard is
+    // appended to the rendered USER body (the user-authored system prompt
+    // stays verbatim). Output size for templates is already bounded by the
+    // orchestrator's absolute char cap; the token-budget clamp intentionally
+    // does not apply to rewrite-class template outputs.
+    user = `${user}\n${INJECTION_GUARD}`;
     return { system: custom.system, user };
   }
 

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -65,6 +65,23 @@ export interface RunResult {
   lastInsertRowid: number;
 }
 
+// [20260906_Feat_TranscriptionUpdate_Review] UPDATE patch whitelist — hoisted
+// to module scope so the Sets are allocated once, not per updateTranscription
+// call (review LOW finding; the previous in-function placement contradicted
+// this comment, fixed by [20260907_Fix_313_HoistUpdateSets]).
+const UPDATABLE_COLUMNS = new Set([
+  "processed_text",
+  "text",
+  // [20260906_Feat_ManualEditProtection] The manual-edit flag itself is
+  // patchable (see updateTranscription block comment); it is stored as
+  // INTEGER 0/1.
+  "manually_edited",
+]);
+// [20260906_Feat_ManualEditProtection] Columns that carry SQLite booleans
+// (INTEGER 0/1). Their patch values may be JS booleans or the numbers
+// 0/1; anything else is rejected, and booleans are bound as 1/0.
+const BOOLEAN_COLUMNS = new Set(["manually_edited"]);
+
 // [20260726_TechDebt_TypedRows] Typed helper wrapping the engine's
 // untyped .get()/.all() returns. Eliminates the 10 `as { field: type }`
 // casts that were scattered across this file. The engine returns
@@ -396,19 +413,8 @@ class DatabaseManager {
     patch: Record<string, unknown>,
     options?: { skipWhenManuallyEdited?: boolean },
   ): RunResult & { skipped?: boolean } {
-    // [20260906_Feat_TranscriptionUpdate_Review] Hoisted to module scope —
-    // no per-call re-allocation (review LOW finding).
-    const UPDATABLE_COLUMNS = new Set([
-      "processed_text",
-      "text",
-      // [20260906_Feat_ManualEditProtection] The manual-edit flag itself is
-      // patchable (see block comment above); it is stored as INTEGER 0/1.
-      "manually_edited",
-    ]);
-    // [20260906_Feat_ManualEditProtection] Columns that carry SQLite booleans
-    // (INTEGER 0/1). Their patch values may be JS booleans or the numbers
-    // 0/1; anything else is rejected, and booleans are bound as 1/0.
-    const BOOLEAN_COLUMNS = new Set(["manually_edited"]);
+    // [20260907_Fix_313_HoistUpdateSets] UPDATABLE_COLUMNS / BOOLEAN_COLUMNS
+    // live at module scope (see above) — this function only consumes them.
 
     if (!patch || typeof patch !== "object") {
       throw new Error("更新数据无效");

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -922,9 +922,21 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
       // route the PROCESS entry straight through the shared orchestrator
       // (entry resolves its own default mode; the orchestrator owns prompt
       // building, the provider call and response/error mapping).
+      //
+      // [20260907_Fix_312_WireClampEntry] Activate the minimal-edit output
+      // budget clamp for this entry (issue #312, first T7 wiring step): the
+      // orchestrator only clamps when the caller opts in, and without this
+      // the 2026-08-15 empty-content fix never bound on a live path. Rewrite
+      // modes and custom templates stay unclamped by design.
       return await runPolishOrchestrator(
         { databaseManager, logger },
-        { text, mode, templatesDir, timeout },
+        {
+          text,
+          mode,
+          templatesDir,
+          timeout,
+          clampOutputTokens: MINIMAL_EDIT_MODES.has(mode),
+        },
       );
     },
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -361,5 +361,8 @@
     "tooltipProcessing": "Murmur - Processing...",
     "aboutTitle": "About Murmur",
     "aboutDescription": "Free and open-source AI voice input tool"
+  },
+  "transcription": {
+    "polishSaveFailed": "Couldn't save the polished text — it will revert after restart"
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -361,5 +361,8 @@
     "tooltipProcessing": "Murmur - 正在处理...",
     "aboutTitle": "关于 Murmur",
     "aboutDescription": "开源免费的 AI 语音输入工具"
+  },
+  "transcription": {
+    "polishSaveFailed": "润色结果保存失败，重启后将显示原文本"
   }
 }

--- a/tests/python/test_protocol_lifecycle_branches.py
+++ b/tests/python/test_protocol_lifecycle_branches.py
@@ -1,0 +1,251 @@
+# [20260907_Fix_317_PythonBranchFill] Ticket #317: behavior tests for the
+# protocol/lifecycle branches of funasr_server.py that the delegation-level
+# suites stub away (the coverage audit found funasr_server at 34%). Every
+# test here drives the REAL method body — no stubbing of the unit under
+# test. Real AutoModel-loading bodies stay exempt (they require the heavy
+# funasr stack; loading arms are covered by test_seaco_fallback /
+# test_unload_reload fake-module injection where reachable).
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ),
+)
+
+os.environ.setdefault("MURMUR_DEVICE", "cpu")
+
+import funasr_server  # noqa: E402
+from funasr_server import FunASRServer  # noqa: E402
+
+
+def make_server(**attrs):
+    srv = FunASRServer(damo_root="/tmp/test-damo")
+    for key, value in attrs.items():
+        setattr(srv, key, value)
+    return srv
+
+
+class ValidateAudioPathTest(unittest.TestCase):
+    def setUp(self):
+        self.srv = make_server()
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(
+            lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True)
+        )
+
+    def _wav(self, name="a.wav"):
+        path = os.path.join(self.tmp, name)
+        with open(path, "w") as f:
+            f.write("x")
+        return path
+
+    def test_rejects_empty_path(self):
+        ok, err = self.srv._validate_audio_path("")
+        self.assertFalse(ok)
+        self.assertIn("无效", err)
+
+    def test_rejects_non_string_path(self):
+        ok, err = self.srv._validate_audio_path(123)
+        self.assertFalse(ok)
+        self.assertIn("无效", err)
+
+    def test_rejects_unsupported_extension(self):
+        path = os.path.join(self.tmp, "notes.txt")
+        with open(path, "w") as f:
+            f.write("x")
+        ok, err = self.srv._validate_audio_path(path)
+        self.assertFalse(ok)
+        self.assertIn("不支持的音频格式", err)
+
+    def test_rejects_missing_file(self):
+        ok, err = self.srv._validate_audio_path(
+            os.path.join(self.tmp, "gone.wav")
+        )
+        self.assertFalse(ok)
+        self.assertIn("文件不存在", err)
+
+    def test_rejects_unreadable_file(self):
+        path = self._wav()
+        with mock.patch("os.access", return_value=False):
+            ok, err = self.srv._validate_audio_path(path)
+        self.assertFalse(ok)
+        self.assertIn("文件不可读", err)
+
+    def test_accepts_a_readable_wav(self):
+        path = self._wav()
+        ok, real = self.srv._validate_audio_path(path)
+        self.assertTrue(ok)
+        self.assertTrue(os.path.isabs(real))
+
+
+class MergeSegmentsTest(unittest.TestCase):
+    def setUp(self):
+        self.srv = make_server()
+
+    def test_empty_input_returns_empty_list(self):
+        self.assertEqual(self.srv._merge_segments([]), [])
+        self.assertEqual(self.srv._merge_segments(None), [])
+
+    def test_single_segment_passes_through(self):
+        seg = {"start_ms": 0, "end_ms": 1000, "text": "你好。"}
+        self.assertEqual(self.srv._merge_segments([seg]), [seg])
+
+    def test_sentence_final_punctuation_starts_a_new_segment(self):
+        segs = [
+            {"start_ms": 0, "end_ms": 800, "text": "第一句。"},
+            {"start_ms": 900, "end_ms": 1600, "text": "第二句。"},
+        ]
+        merged = self.srv._merge_segments(segs)
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(merged[0]["text"], "第一句。")
+
+    def test_long_segment_starts_a_new_segment(self):
+        segs = [
+            {"start_ms": 0, "end_ms": 6000, "text": "长句无标点"},
+            {"start_ms": 6100, "end_ms": 6800, "text": "短句"},
+        ]
+        merged = self.srv._merge_segments(segs)
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(merged[0]["text"], "长句无标点")
+
+    def test_short_unpunctuated_segments_merge_forward(self):
+        segs = [
+            {"start_ms": 0, "end_ms": 500, "text": "还"},
+            {"start_ms": 600, "end_ms": 900, "text": "没"},
+            {"start_ms": 1000, "end_ms": 1200, "text": "说完"},
+        ]
+        merged = self.srv._merge_segments(segs)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["text"], "还没说完")
+        self.assertEqual(merged[0]["end_ms"], 1200)
+
+
+class LifecycleGuardsTest(unittest.TestCase):
+    def test_signal_handler_stops_the_server(self):
+        srv = make_server(running=True)
+        srv._signal_handler(15, None)
+        self.assertFalse(srv.running)
+
+    def test_cleanup_memory_collects_gc(self):
+        srv = make_server()
+        with mock.patch("gc.collect") as collect:
+            srv._cleanup_memory()
+        collect.assert_called_once()
+
+    def test_cleanup_memory_swallows_gc_failure(self):
+        srv = make_server()
+        with mock.patch("gc.collect", side_effect=RuntimeError("gc")):
+            srv._cleanup_memory()  # must not raise
+
+    def test_get_performance_stats_divides_by_max_one(self):
+        srv = make_server(
+            transcription_count=0,
+            total_audio_duration=0.0,
+            initialized=False,
+        )
+        stats = srv.get_performance_stats()
+        self.assertEqual(stats["average_duration"], 0)
+        self.assertFalse(stats["initialized"])
+
+    def test_get_performance_stats_reports_models_and_generation(self):
+        srv = make_server(
+            transcription_count=2,
+            total_audio_duration=5.0,
+            initialized=True,
+            asr_model=object(),
+            vad_model=None,
+            punc_model=object(),
+            asr_model_name="damo/speech_seaco",
+        )
+        stats = srv.get_performance_stats()
+        self.assertEqual(stats["transcription_count"], 2)
+        self.assertEqual(stats["average_duration"], 2.5)
+        self.assertTrue(stats["models_loaded"]["asr"])
+        self.assertFalse(stats["models_loaded"]["vad"])
+        self.assertEqual(stats["models_loaded"]["asr_model"], "damo/speech_seaco")
+
+
+class CheckStatusTest(unittest.TestCase):
+    def setUp(self):
+        self.real_funasr = sys.modules.get("funasr")
+
+    def tearDown(self):
+        if self.real_funasr is not None:
+            sys.modules["funasr"] = self.real_funasr
+        else:
+            sys.modules.pop("funasr", None)
+
+    def test_reports_installed_with_version_and_models(self):
+        import types
+
+        fake = types.ModuleType("funasr")
+        fake.__version__ = "9.9.9"
+        sys.modules["funasr"] = fake
+        srv = make_server(
+            initialized=True,
+            asr_model=object(),
+            asr_model_name="damo/x",
+        )
+        status = srv.check_status()
+        self.assertTrue(status["success"])
+        self.assertTrue(status["installed"])
+        self.assertEqual(status["version"], "9.9.9")
+        self.assertTrue(status["models"]["asr"])
+
+    def test_reports_not_installed_when_funasr_import_fails(self):
+        sys.modules["funasr"] = None  # forces ImportError on `import funasr`
+        srv = make_server()
+        status = srv.check_status()
+        self.assertFalse(status["success"])
+        self.assertFalse(status["installed"])
+        self.assertIn("error", status)
+
+
+class EnsureInitializedTest(unittest.TestCase):
+    def test_short_circuits_when_already_initialized(self):
+        srv = make_server(initialized=True)
+        calls = []
+        srv.initialize = lambda: calls.append(1) or {"success": True}
+        self.assertTrue(srv._ensure_initialized())
+        self.assertEqual(calls, [])
+
+    def test_initializes_once_when_not_initialized(self):
+        srv = make_server(initialized=False)
+        calls = []
+        srv.initialize = lambda: calls.append(1) or {"success": True}
+        self.assertTrue(srv._ensure_initialized())
+        self.assertEqual(calls, [1])
+
+    def test_returns_false_when_initialize_reports_failure(self):
+        srv = make_server(initialized=False)
+        srv.initialize = lambda: {"success": False, "error": "模型未下载"}
+        self.assertFalse(srv._ensure_initialized())
+
+
+class GetLogPathTest(unittest.TestCase):
+    def test_env_var_routes_the_log_dir(self):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(
+            lambda: __import__("shutil").rmtree(tmp, ignore_errors=True)
+        )
+        old = os.environ.get("ELECTRON_USER_DATA")
+        os.environ["ELECTRON_USER_DATA"] = tmp
+        try:
+            path = funasr_server.get_log_path()
+        finally:
+            if old is None:
+                os.environ.pop("ELECTRON_USER_DATA", None)
+            else:
+                os.environ["ELECTRON_USER_DATA"] = old
+        self.assertTrue(path.startswith(os.path.join(tmp, "logs")))
+        self.assertTrue(path.endswith("funasr_server.log"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -29,6 +29,7 @@ type AiHandlersModule = typeof import("../../src/helpers/ipc/aiHandlers");
 // all tests, so per-test isolation via resetModules was never needed here.
 // The require shim (_tsresolve.setup) was only needed to load .ts source.
 import * as aiHandlersNS from "../../src/helpers/ipc/aiHandlers";
+import { INJECTION_GUARD } from "../../src/helpers/aiPrompts";
 
 // [20260906_Refactor_PolishOrchestrator] Spec #193 T3 (ticket #230): the
 // SECOND polish entry is the file-import review handler registered by
@@ -1066,7 +1067,12 @@ describe("aiHandlers", () => {
         const body = readRequestBody();
         expect(body.messages).toEqual([
           { role: "system", content: "你是会议纪要助手。" },
-          { role: "user", content: "整理：正文" },
+          // [20260907_Fix_315_TemplateTrustBoundary] template user body
+          // carries the appended injection guard (issue #315).
+          {
+            role: "user",
+            content: `整理：正文\n${INJECTION_GUARD}`,
+          },
         ]);
       } finally {
         fs.rmSync(dir, { recursive: true });

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -997,9 +997,48 @@ describe("aiHandlers", () => {
           { role: "user", content: "<transcript>\n原始文本\n</transcript>" },
         ],
         temperature: 0.3,
-        max_tokens: 2000,
+        // [20260907_Fix_312_WireClampEntry] optimize is a minimal-edit mode:
+        // the entry now wires clampOutputTokens, so the short input lands on
+        // the 4096 floor instead of the raw 2000 user cap.
+        max_tokens: aiHandlersNS.POLISH_CLAMP_MIN_TOKENS,
         stream: false,
       });
+    });
+
+    // ---- [20260907_Fix_312_WireClampEntry] PROCESS entry clamp activation ----
+
+    it("wires clampOutputTokens for minimal-edit modes at the IPC entry", async () => {
+      // Issue #312: the orchestrator's budget clamp only binds when the
+      // caller passes clampOutputTokens — the PROCESS entry never did, so
+      // the minimal-edit clamp (2026-08-15 empty-content fix) never bound on
+      // a live path. Through the IPC handler, optimize at 2000×2=4000 must
+      // hit the 4096 floor.
+      const handlers = captureHandlers(register, {
+        databaseManager: createPolishDb(null),
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      });
+      mockFetch({ choices: [{ message: { content: "润色完成" } }] });
+
+      await handlers[C.AI.PROCESS]!({}, "字".repeat(2000), "optimize");
+
+      expect(readRequestBody().max_tokens).toBe(
+        aiHandlersNS.POLISH_CLAMP_MIN_TOKENS,
+      );
+    });
+
+    it("keeps rewrite-class modes unclamped at the IPC entry", async () => {
+      const handlers = captureHandlers(register, {
+        databaseManager: createPolishDb(null),
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      });
+      mockFetch({ choices: [{ message: { content: "摘要完成" } }] });
+
+      await handlers[C.AI.PROCESS]!({}, "字".repeat(2000), "summarize");
+
+      // summarize is rewrite-class: the user cap binds, no clamp floor.
+      expect(readRequestBody().max_tokens).toBe(2000);
     });
 
     it("PROCESS prefers a custom template from templatesDir over built-in modes", async () => {

--- a/tests/unit/aiPrompts-prompt-engineering.test.ts
+++ b/tests/unit/aiPrompts-prompt-engineering.test.ts
@@ -7,7 +7,7 @@
 // mirroring tests/unit/aiHandlers.test.ts) so each assertion fails for the
 // right reason before the implementation lands.
 import { describe, it, expect } from "vitest";
-import { buildPrompt } from "../../src/helpers/aiPrompts";
+import { buildPrompt, INJECTION_GUARD } from "../../src/helpers/aiPrompts";
 
 // [20260906_Feat_PromptEngineering] Golden expectations for the shared
 // prefix block. Test-owned literals: the source may reword around them, but
@@ -211,7 +211,8 @@ describe("AI prompt engineering package (Spec #193 T4 / ticket #231)", () => {
       const result = buildPrompt("templated", "正文", {
         customTemplates: templates,
       });
-      expect(result.user).toBe("语言：\n\n内容：正文");
+      // [20260907_Fix_315_TemplateTrustBoundary] guard appended (ticket #315).
+      expect(result.user).toBe(`语言：\n\n内容：正文\n${INJECTION_GUARD}`);
     });
   });
 
@@ -223,12 +224,13 @@ describe("AI prompt engineering package (Spec #193 T4 / ticket #231)", () => {
       const result = buildPrompt("review", "唯一文本", {
         customTemplates: templates,
       });
-      expect(result.user).toBe("Review: 唯一文本");
-      // Exactly one occurrence of the raw text — no appended duplicate.
+      // [20260907_Fix_315_TemplateTrustBoundary] guard appended after the
+      // interpolated body (ticket #315); the dedup contract still holds.
+      expect(result.user).toBe(`Review: 唯一文本\n${INJECTION_GUARD}`);
       expect(result.user.split("唯一文本")).toHaveLength(2);
     });
 
-    it("legacy {text}-only templates keep working byte-for-byte", () => {
+    it("legacy {text}-only templates keep working (guard appended since #315)", () => {
       const templates = [
         {
           name: "meeting",
@@ -241,7 +243,12 @@ describe("AI prompt engineering package (Spec #193 T4 / ticket #231)", () => {
         customTemplates: templates,
       });
       expect(result.system).toBe("你是会议助手。");
-      expect(result.user).toBe("<meeting>讨论了项目进展</meeting>");
+      // [20260907_Fix_315_TemplateTrustBoundary] the pre-#315 byte-identical
+      // guarantee for the user body is superseded by the appended guard;
+      // the system prompt stays verbatim.
+      expect(result.user).toBe(
+        `<meeting>讨论了项目进展</meeting>\n${INJECTION_GUARD}`,
+      );
     });
 
     it("template without any {text}: wrapped transcript is appended so the model still sees the body", () => {
@@ -252,8 +259,48 @@ describe("AI prompt engineering package (Spec #193 T4 / ticket #231)", () => {
         customTemplates: templates,
       });
       expect(result.user).toBe(
-        "请总结以下内容。\n<transcript>\n正文内容\n</transcript>",
+        `请总结以下内容。\n<transcript>\n正文内容\n</transcript>\n${INJECTION_GUARD}`,
       );
+    });
+  });
+
+  // [20260907_Fix_315_TemplateTrustBoundary] Ticket #315 plan A: shared
+  // templates are a prompt-injection surface — the injection guard is
+  // appended to the rendered USER body (never to the user-authored system
+  // prompt, which stays verbatim). The 2M-char absolute output cap already
+  // covers template outputs at the orchestrator level, so no extra cap here.
+  describe("custom template injection guard (#315)", () => {
+    it("appends the injection guard after the transcript wrap (no {text})", () => {
+      const templates = [
+        { name: "t", label: "T", system: "系统提示", user: "请总结以下内容。" },
+      ];
+      const result = buildPrompt("t", "正文内容", {
+        customTemplates: templates,
+      });
+      expect(result.user).toBe(
+        `请总结以下内容。\n<transcript>\n正文内容\n</transcript>\n${INJECTION_GUARD}`,
+      );
+    });
+
+    it("appends the injection guard after the interpolated {text}", () => {
+      const templates = [
+        { name: "review", label: "R", system: "S", user: "Review: {text}" },
+      ];
+      const result = buildPrompt("review", "唯一文本", {
+        customTemplates: templates,
+      });
+      expect(result.user).toBe(`Review: 唯一文本\n${INJECTION_GUARD}`);
+    });
+
+    it("keeps the user-authored system prompt verbatim (no shared prefix)", () => {
+      const templates = [
+        { name: "t", label: "T", system: "系统提示", user: "请总结以下内容。" },
+      ];
+      const result = buildPrompt("t", "正文内容", {
+        customTemplates: templates,
+      });
+      expect(result.system).toBe("系统提示");
+      expect(result.system).not.toContain("INJECTION");
     });
   });
 });

--- a/tests/unit/aiPrompts.test.ts
+++ b/tests/unit/aiPrompts.test.ts
@@ -20,6 +20,7 @@ import {
   buildPrompt,
   parseTemplateFile,
   loadCustomTemplates,
+  INJECTION_GUARD,
 } from "../../src/helpers/aiPrompts";
 
 describe("aiPrompts", () => {
@@ -165,7 +166,10 @@ user_template: "请处理: {text}"
         customTemplates,
       });
       expect(result.system).toBe("你是会议助手。");
-      expect(result.user).toBe("<meeting>讨论了项目进展</meeting>");
+      // [20260907_Fix_315_TemplateTrustBoundary] guard appended to the user body
+      expect(result.user).toBe(
+        `<meeting>讨论了项目进展</meeting>\n${INJECTION_GUARD}`,
+      );
     });
 
     it("custom template overrides built-in mode", () => {
@@ -191,7 +195,9 @@ user_template: "请处理: {text}"
         },
       ];
       const result = buildPrompt("review", "the content", { customTemplates });
-      expect(result.user).toBe("Review: the content\nPlease check.");
+      expect(result.user).toBe(
+        `Review: the content\nPlease check.\n${INJECTION_GUARD}`,
+      );
     });
   });
 

--- a/tests/unit/file-import.test.tsx
+++ b/tests/unit/file-import.test.tsx
@@ -46,6 +46,7 @@ interface MockApi {
   diarizeAudio: ReturnType<typeof vi.fn>;
   copyText: ReturnType<typeof vi.fn>;
   aiReviewTranscription: ReturnType<typeof vi.fn>;
+  processText?: ReturnType<typeof vi.fn>;
 }
 
 function makeElectronAPI(overrides: Partial<MockApi> = {}): MockApi {

--- a/tests/unit/file-import.test.tsx
+++ b/tests/unit/file-import.test.tsx
@@ -367,6 +367,13 @@ describe("[20260816_Test_FileImportExpanded] FileImport — remaining branches",
         id: 42,
         duration: 3,
       }),
+      // [20260907_Fix_316_PreferReviewProp] processText IS present in
+      // production — the stub must include it so the test proves the
+      // preferOnAIOptimize flag (not the stub's omission) routes the file
+      // import to aiReviewTranscription.
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "错误通道的文本" }),
       getAIModes: vi
         .fn()
         .mockResolvedValue([

--- a/tests/unit/python-coverage-runner.test.ts
+++ b/tests/unit/python-coverage-runner.test.ts
@@ -59,10 +59,12 @@ describe("[20260906_Spec259_T4] python coverage runner", () => {
     expect(exit).toBe(1);
   });
 
-  it("pins the fail-under floor to the first measured value", () => {
+  it("pins the fail-under floor to the measured value", () => {
     // First measured 2026-09-07 (embedded python 3.11 + coverage 7.16):
     // TOTAL 43% (funasr_server 34 / audio_preprocessing 87 / download_models 90).
-    expect(runner.PYTHON_FAIL_UNDER).toBe(43);
+    // [20260907_Fix_317_PythonBranchFill] raised 43→46 after the protocol/
+    // lifecycle branch tests lifted funasr_server 34%→39% (TOTAL 47%).
+    expect(runner.PYTHON_FAIL_UNDER).toBe(46);
     expect(runner.COVERAGE_INCLUDE).toContain("funasr_server.py");
   });
 });

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -516,10 +516,55 @@ describe("TranscriptionResult — polish write-back failure (#314)", () => {
       });
     });
     await waitFor(() => {
-      expect(toastMocks.toast.warning).toHaveBeenCalledTimes(1);
+      expect(toastMocks.toast.warning).toHaveBeenCalledWith(
+        expect.stringContaining("保存失败"),
+      );
     });
     // The polished result stays on screen (documented intent).
     expect(screen.getByText("润色后文本")).toBeInTheDocument();
     consoleSpy.mockRestore();
+  });
+
+  // [20260907_Fix_314_ReviewFix] The DOMINANT production failure shape: the
+  // main-process handler wraps every failure (DB locked, missing record,
+  // zero changes, whitelist rejection) in a RESOLVED {success:false, error}
+  // envelope — the catch never runs for it.
+  it("warns when the write-back resolves unsuccessful (envelope shape)", async () => {
+    const consoleSpy2 = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (globalThis.window as unknown as TestWindow).electronAPI = {
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "润色后文本" }),
+      updateTranscription: vi.fn().mockResolvedValue({
+        success: false,
+        error: "db locked",
+      }),
+      getAIModes: vi
+        .fn()
+        .mockResolvedValue([
+          { name: "optimize", label: "智能润色", description: "" },
+        ]),
+    };
+
+    render(
+      React.createElement(TranscriptionResult, {
+        text: "原始文本",
+        id: 42,
+        onCopy: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+
+    await waitFor(() => {
+      expect(toastMocks.toast.warning).toHaveBeenCalledWith(
+        expect.stringContaining("保存失败"),
+      );
+    });
+    // Not wiped: the polished text stays on screen.
+    expect(screen.getByText("润色后文本")).toBeInTheDocument();
+    consoleSpy2.mockRestore();
   });
 });

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -8,6 +8,21 @@ import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import TranscriptionResult from "../../src/components/TranscriptionResult";
 
+// [20260907_Fix_314_PolishSaveToast] Spy on toast — the polish write-back
+// failure path (issue #314) must surface a user-visible warning.
+const toastMocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: toastMocks.toast,
+  Toaster: () => React.createElement("div", { "data-testid": "toaster" }),
+}));
+
 // Stub window.electronAPI — TranscriptionResult reads AI modes on mount.
 beforeAll(() => {
   (window as unknown as { electronAPI: unknown }).electronAPI = {
@@ -438,5 +453,73 @@ describe("TranscriptionResult — branch push", () => {
     expect(screen.getByText("正文")).toBeInTheDocument();
     // The tiny font-semibold speaker span is only rendered for truthy spk.
     expect(container.querySelector("span.text-\\[10px\\]")).toBeNull();
+  });
+});
+
+// [20260907_Fix_314_PolishSaveToast] Issue #314: when persisting the polish
+// result fails (updateTranscription rejects), the user keeps looking at text
+// that was never saved — a silent console.warn is not enough. The failure
+// must surface a warning toast while keeping the polished text on screen.
+describe("TranscriptionResult — polish write-back failure (#314)", () => {
+  type TestWindow = Omit<Window, "electronAPI"> & {
+    electronAPI?: {
+      processText?: (text: string, mode: string) => Promise<unknown>;
+      updateTranscription?: (
+        id: number,
+        patch: Record<string, unknown>,
+      ) => Promise<unknown>;
+      getAIModes?: () => Promise<unknown[]>;
+    };
+  };
+
+  const originalAPI = (globalThis.window as unknown as TestWindow).electronAPI;
+
+  afterEach(() => {
+    const win = globalThis.window as unknown as TestWindow;
+    if (originalAPI === undefined) delete win.electronAPI;
+    else win.electronAPI = originalAPI;
+    vi.clearAllMocks();
+  });
+
+  it("warns the user when the write-back rejects, keeping the polished text", async () => {
+    (globalThis.window as unknown as TestWindow).electronAPI = {
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "润色后文本" }),
+      updateTranscription: vi.fn().mockRejectedValue(new Error("db locked")),
+      getAIModes: vi
+        .fn()
+        .mockResolvedValue([
+          { name: "optimize", label: "智能润色", description: "" },
+        ]),
+    };
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      React.createElement(TranscriptionResult, {
+        text: "原始文本",
+        id: 42,
+        onCopy: vi.fn(),
+      }),
+    );
+
+    // Drive the manual optimize flow (ProcessingPanel renders after modes load).
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+
+    await waitFor(() => {
+      const api = (globalThis.window as unknown as TestWindow).electronAPI!;
+      expect(api.updateTranscription).toHaveBeenCalledWith(42, {
+        processed_text: "润色后文本",
+        text: "润色后文本",
+      });
+    });
+    await waitFor(() => {
+      expect(toastMocks.toast.warning).toHaveBeenCalledTimes(1);
+    });
+    // The polished result stays on screen (documented intent).
+    expect(screen.getByText("润色后文本")).toBeInTheDocument();
+    consoleSpy.mockRestore();
   });
 });

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -460,6 +460,99 @@ describe("TranscriptionResult — branch push", () => {
 // result fails (updateTranscription rejects), the user keeps looking at text
 // that was never saved — a silent console.warn is not enough. The failure
 // must surface a warning toast while keeping the polished text on screen.
+// [20260907_Fix_316_PreferReviewProp] File import's server-side review
+// channel (aiReviewTranscription via onAIOptimize) must win over the ambient
+// processText when the parent opts in — without the flag the injected
+// channel is unreachable in production.
+describe("TranscriptionResult — preferOnAIOptimize (#316)", () => {
+  type TestWindow = Omit<Window, "electronAPI"> & {
+    electronAPI?: {
+      processText?: (text: string, mode: string) => Promise<unknown>;
+      getAIModes?: () => Promise<unknown[]>;
+    };
+  };
+
+  const originalAPI = (globalThis.window as unknown as TestWindow).electronAPI;
+
+  afterEach(() => {
+    const win = globalThis.window as unknown as TestWindow;
+    if (originalAPI === undefined) delete win.electronAPI;
+    else win.electronAPI = originalAPI;
+    vi.clearAllMocks();
+  });
+
+  it("prefers onAIOptimize over processText when preferOnAIOptimize is set", async () => {
+    const processText = vi
+      .fn()
+      .mockResolvedValue({ success: true, text: "错误通道的文本" });
+    const onAIOptimize = vi.fn().mockResolvedValue("评审通道的文本");
+    (globalThis.window as unknown as TestWindow).electronAPI = {
+      processText: processText as unknown as (
+        text: string,
+        mode: string,
+      ) => Promise<unknown>,
+      getAIModes: vi
+        .fn()
+        .mockResolvedValue([
+          { name: "optimize", label: "智能润色", description: "" },
+        ]),
+    };
+
+    render(
+      React.createElement(TranscriptionResult, {
+        text: "原始文本",
+        onCopy: vi.fn(),
+        onAIOptimize,
+        preferOnAIOptimize: true,
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("评审通道的文本")).toBeInTheDocument();
+    });
+    expect(processText).not.toHaveBeenCalled();
+  });
+
+  it("keeps processText preferred without the flag (recording mode-selector UX)", async () => {
+    const processText = vi
+      .fn()
+      .mockResolvedValue({ success: true, text: "默认通道的文本" });
+    const onAIOptimize = vi.fn().mockResolvedValue("错误通道的文本");
+    (globalThis.window as unknown as TestWindow).electronAPI = {
+      processText: processText as unknown as (
+        text: string,
+        mode: string,
+      ) => Promise<unknown>,
+      getAIModes: vi
+        .fn()
+        .mockResolvedValue([
+          { name: "optimize", label: "智能润色", description: "" },
+        ]),
+    };
+
+    render(
+      React.createElement(TranscriptionResult, {
+        text: "原始文本",
+        onCopy: vi.fn(),
+        onAIOptimize,
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("默认通道的文本")).toBeInTheDocument();
+    });
+    expect(onAIOptimize).not.toHaveBeenCalled();
+  });
+});
+
 describe("TranscriptionResult — polish write-back failure (#314)", () => {
   type TestWindow = Omit<Window, "electronAPI"> & {
     electronAPI?: {


### PR DESCRIPTION
## 概述

Spec#259 审视产出的 6 张 fast-follow 票(#312–#317)全部端到端完成。每票严格 TDD + 独立 code-review(共 5 轮,含一次 REQUEST CHANGES 的 HIGH 修复),全部关票。

## 各票落地

- **#312 T7 激活第一期**:PROCESS 入口对最小修改模式(optimize/optimize_long/format/correct)接通 `clampOutputTokens`——2026-08-15 空内容回归的修复首次在活路径绑定;generation/AbortSignal 接线推迟决策已补记于 #234
- **#313**:UPDATE 白名单两个 Set 真正提升到模块级,修正"声称已提升"的陈旧注释
- **#314**:润色写回失败补双语 warning toast;**评审 HIGH 修复**——主进程所有失败走 resolved `{success:false}` envelope 而非 reject,catch-only toast 在生产永不触发,envelope 与 reject 双形态均告警
- **#315** 方案 A:自定义模板渲染后的 user 正文统一追加 INJECTION_GUARD(用户自写 system 保持逐字);输出上限由编排器 2M 字符硬顶覆盖
- **#316** 方案 A:新增 `preferOnAIOptimize` prop,文件导入的服务端评审通道(aiReviewTranscription 按 id)生产可达——此前被环境 processText 遮蔽且测试 stub 未含 processText 掩盖了这一点
- **#317**:funasr_server.py 新增 22 例协议/生命周期行为测试(验证音频路径五臂/分段合并契约/信号处理/内存清理/性能统计/状态检查/初始化守卫/日志路径),覆盖率 **34%→39%**,Python fail-under floor **43→46**

## 验证

- `pnpm ci:check` **11/11 全绿**(add6b67 后复验)
- 2215 unit 测试全绿;Python 98+22 全绿(TOTAL 47%)
- 全量 unit 覆盖 96.94/93.5/95.63/97.56;Python floor 46 由 meta-test 钉住(本 PR 含一次有意的 floor 抬升,meta-test 同步更新并留测量史)

## 备注

- 与 #266 的去重联动注记已落各票评论(#273↔#281 meta-test 分工、#274↔#280 平台臂去重、#273 豁免条款随 T06–T08 联动)
- T8/T9 接线时需处理的评审 LOW 项已跟踪在 #312 评论(未知 mode 的钳制同源性、同名模板钳制)
