### PR TITLE
feat: 模型列表自动推导(SSRF 同参)+ SSRF 门禁加固 + T5 流式 Spike 结论

### DIFF
--- a/docs/research/2026-09-08-t5-streaming-spike.md
+++ b/docs/research/2026-09-08-t5-streaming-spike.md
@@ -1,0 +1,70 @@
+# T5 流式可行性 Spike 结论文档(Spec #193, ticket #232)
+
+日期:2026-09-08 | 执行环境:macOS arm64,Electron 39.8.10(仓库依赖),Ollama 本机 + qwen3.5-2b-ov-vision / ov_intent_analysis_sft
+状态:**研究完成,不改任何 src/ 生产代码**(spike 脚本均在 /tmp,证据逐项内联)
+
+| #   | 项                                       | 结论                                                          |
+| --- | ---------------------------------------- | ------------------------------------------------------------- |
+| ①   | Electron 主进程 fetch 流式               | **VERIFIED**                                                  |
+| ②   | 本地 LLM(Ollama/LM Studio)流式/取消/降级 | **Ollama VERIFIED(含重要警告)/ LM Studio UNVERIFIED(未安装)** |
+| ③   | diff 库选型                              | **VERIFIED — 选定 diff-match-patch 主端口 + 薄封装适配层**    |
+| ④   | eventsource-parser v3 ESM 打包           | **VERIFIED**                                                  |
+| ⑤   | 国内中转网关失败形态采样                 | **PARTIAL(2 家已采样,方法可复用)**                            |
+
+---
+
+## ① Electron 主进程 fetch 流式读取 — VERIFIED
+
+实测(Electron 39.8.10 主进程,`/tmp/t5-spike/electron-main-spike.js`,对 Ollama SSE):
+
+- `response.body.getReader()` 可用(`function`),`body.locked=true` 符合预期;
+- **增量读取为真**:568 次 read / 136KB / 首字节 163ms(qwen 流式,think 关闭)——不是一次性缓冲;
+- AbortSignal 取消:88ms 内 read 以 AbortError 中断,`signal.aborted=true`。
+
+**T8 依据**:主进程可直接用 `getReader()` 逐块解析 SSE,无需额外依赖(eventsource-parser 仅做帧解析,见 ④)。
+
+## ② 本地 LLM 流式/取消/降级 — Ollama VERIFIED(含设计级警告)
+
+OpenAI 兼容端点 `http://localhost:11434/v1/chat/completions`:
+
+- **流式**:标准 SSE(`data: {chunk}\n\n`,终止帧 `[DONE]`);首字节 110–163ms;增量速率 ~15 块/秒。
+- **取消**:`AbortController.abort()` 中断 read,74–118ms 生效;Ollama 服务端同步停止生成。
+- **降级**:`stream:false` 返回标准 completion JSON,可直接作为非流式回退。
+- **⚠️ 思考模型警告(T8/T12 设计输入)**:qwen3.5-2b(思考模型)在 OpenAI 兼容端点先发 `delta.reasoning`——实测 400/400 与 2000/2000 token 预算全部被 reasoning 消耗,`delta.content` 始终为空(内容饿死)。**解法已实测**:Ollama 原生 `/api/chat` 传 `think:false` 后 content 从 82ms 增量流出、730ms 完成。T8 必须二选一:(a) 本地 Ollama 走原生 API 并默认 `think:false`;(b) 兼容端点解析 `delta.reasoning` 并与 `delta.content` 分离呈现,且 max_tokens 预算需为 reasoning 留量。
+- 另一非思考模型(ov_intent_analysis_sft)直接 content 流式正常(29 块/首 content 2015ms)。
+- **LM Studio:UNVERIFIED**(本机未安装);其服务端同为 OpenAI 兼容形态,风险主要在思考模型语义,与 ② 的警告同源。
+
+## ③ diff 库选型 — VERIFIED(选定 + 理由)
+
+| 库                  | 版本  | 许可       | 维护        | 关键能力                                                                                           |
+| ------------------- | ----- | ---------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| diff-match-patch    | 1.0.5 | Apache-2.0 | ~4 年未发布 | `Diff_Timeout` 超时旋钮、行模式(`diff_linesToChars_`/`diff_charsToLines_`)、`diff_cleanupSemantic` |
+| diff-match-patch-es | 2.0.1 | Apache-2.0 | 活跃        | 函数式重写(diff/diffCharsToLines/diffCleanupSemantic),ESM                                          |
+| diff-match-patch-ts | 2.0.0 | MIT        | —           | 类型化移植                                                                                         |
+| fast-diff           | 1.3.0 | Apache-2.0 | 活跃        | 仅字符级 diff,无 semantic/超时/行模式 → **不满足 S4a 硬需求,排除**                                 |
+
+**中文最小修改基准**(填充词删除/错字修正,500/1K/5K/20K 字符,毫秒):
+dmp 2/1/10/86;fast-diff 1/1/6/71。**真实润色文本量级(≤2 万字符)两者均远低于预算,性能不是选型因子。**
+
+**选型定论:diff-match-patch 主端口 + 仓库内薄封装适配层**(单文件暴露 diffMain/cleanupSemantic/timeout/line-mode 四能力)。理由:S4a 硬需求(超时显式设置、行模式前置、语义合并)只有 dmp 系完整提供;fast-diff 缺三能力排除;"4 年未发布"风险以锁版 + 薄封装缓解(适配层是唯一触点,必要时内部换 -es 的函数式实现零扩散)。API 混乱实勘:行模式返回 `{chars1, chars2, lineArray}` 且 `diff_charsToLines_` 需显式传 `lineArray`(文档未载,实测所得)。
+
+## ④ eventsource-parser v3 ESM 打包 — VERIFIED
+
+eventsource-parser@3.1.1(ESM-only,`type: module`)在 CommonJS 工程经 `esbuild --bundle --platform=node` 打包成功,产物以 `require("eventsource-parser")` 使用 `createParser` 解析 SSE 帧正确。**T8 可安全引入**。注:最新已到 4.1.0;建议锁 3.x 最新或评估 4.x breaking。
+
+## ⑤ 国内中转网关失败形态采样 — PARTIAL
+
+已采样两家(无 key,stream:true):
+
+- AiHubMix(new-api 系):`HTTP 401` + JSON `{"error":{"message":"no key provided (tid:…)","type":"Aihubmix_api_error"}}`;
+- OpenKey(one-api 系):`HTTP 401` + JSON `{"error":{"message":"未提供令牌 (request id:…)","type":"one_api_error"}}`。
+
+**结论(降级判定设计输入)**:鉴权/配置类失败在**流开始前**以普通 JSON + 401 到达(即使请求带 stream:true)——T8/T10 的降级探测应以「非 200 或非 text/event-stream 响应头」为主信号,而不是解析 SSE 错误帧。更多网关与"流中途失败"形态需真实 key,标记待补样本。
+
+## 供 T8/T12 的直接输入汇总
+
+1. 主进程 fetch 流式与取消机制可用(①),取消通道经 AbortSignal 贯通(②)。
+2. 思考模型 reasoning 洪流必须有产品级对策(②警告),且 max_tokens 预算核算含 reasoning。
+3. diff 选型定论:dmp + 薄封装(③),超时旋钮与行模式能力已实测存在。
+4. SSE 帧解析引入 eventsource-parser 无打包障碍(④)。
+5. 降级判定信号:非 200 / 非 `text/event-stream` 响应头(⑤)。

--- a/preload.ts
+++ b/preload.ts
@@ -70,6 +70,9 @@ export const preloadApi: ElectronAPI = {
     ipcRenderer.invoke(C.AI.PROCESS, text, mode, timeout),
   checkAIStatus: (testConfig: unknown) =>
     ipcRenderer.invoke(C.AI.CHECK_STATUS, testConfig),
+  // [20260907_Feat_233_ListModels] Provider model-list derivation (T6).
+  listAIModels: (baseUrl: string, apiKey: string) =>
+    ipcRenderer.invoke(C.AI.LIST_MODELS, baseUrl, apiKey),
   getAIModes: () => ipcRenderer.invoke(C.AI.GET_MODES),
   getAIProviderPresets: () => ipcRenderer.invoke(C.AI.GET_PROVIDER_PRESETS),
   detectLocalModels: () => ipcRenderer.invoke(C.AI.DETECT_LOCAL_MODELS),

--- a/src/electronAPI.d.ts
+++ b/src/electronAPI.d.ts
@@ -7,6 +7,7 @@ import type {
   TranscriptionRecord,
   TranscriptionSaveResult,
   TranscriptionUpdateResult,
+  ListModelsResult,
   FileTranscriptionResult,
   ExportResult,
   ExportAllResult,
@@ -69,6 +70,8 @@ export interface ElectronAPI {
     ai_base_url?: string;
     ai_model?: string;
   }) => Promise<AICheckStatusResult>;
+  // [20260907_Feat_233_ListModels] Provider model-list derivation (T6).
+  listAIModels: (baseUrl: string, apiKey: string) => Promise<ListModelsResult>;
   getAIModes: () => Promise<AIMode[]>;
   getAIProviderPresets: () => Promise<AIProviderPreset[]>;
   detectLocalModels: () => Promise<LocalModelDetection[]>;

--- a/src/helpers/ipc-contracts.ts
+++ b/src/helpers/ipc-contracts.ts
@@ -61,6 +61,9 @@ export const TRANSCRIPTION = {
 export const AI = {
   PROCESS: "process-text",
   CHECK_STATUS: "check-ai-status",
+  // [20260907_Feat_233_ListModels] Provider model-list derivation (T6): a
+  // GET primitive that passes the same SSRF validation as the chat request.
+  LIST_MODELS: "ai-list-models",
   GET_MODES: "get-ai-modes",
   GET_PROVIDER_PRESETS: "get-ai-provider-presets",
   DETECT_LOCAL_MODELS: "detect-local-models",

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -175,6 +175,32 @@ export function validateAIBaseUrl(
 // user-facing error text).
 // [20260815_Refactor_AiFetchDedup] END
 
+// [20260907_Feat_233_ListModels] Ticket #233: derive the /models endpoint
+// from the base URL with the URL constructor only — never whole-URL string
+// concatenation. Bases that already end in a version segment get exactly
+// one candidate ({base}/models); other bases try {base}/models first and
+// {base}/v1/models second (the common "no /v1 in base_url" gateway shape).
+function modelEndpointCandidates(baseUrl: string): string[] {
+  const url = new URL(baseUrl);
+  const basePath = url.pathname.replace(/\/+$/, "");
+  const withPath = (suffix: string) => {
+    const derived = new URL(baseUrl);
+    derived.pathname = basePath + suffix;
+    return derived.toString();
+  };
+  if (/\/v\d+$/.test(basePath)) {
+    return [withPath("/models")];
+  }
+  return [withPath("/models"), withPath("/v1/models")];
+}
+
+// [20260907_Feat_233_ListModels] Response contract for the provider /models
+// listing. Anything outside the shape silently degrades the renderer to the
+// manual-input path (ticket #233: 非法即静默回退手输).
+const MODELS_MAX_ITEMS = 500;
+const MODELS_MAX_ID_BYTES = 200;
+const MODELS_MAX_BODY_BYTES = 512 * 1024;
+
 function isLocalBaseUrl(baseUrl: string): boolean {
   try {
     return isLocalhost(new URL(baseUrl).hostname);
@@ -938,6 +964,87 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
           clampOutputTokens: MINIMAL_EDIT_MODES.has(mode),
         },
       );
+    },
+  );
+
+  // [20260907_Feat_233_ListModels] Ticket #233: provider model-list
+  // derivation. Same SSRF gate as the chat request (private https rejected,
+  // local-gateway exception allowed), URL-constructor endpoint derivation,
+  // strict response shape with silent fallback to the manual-input path.
+  ipcMain.handle(
+    C.AI.LIST_MODELS,
+    async (_event, baseUrl: string, apiKey = "") => {
+      const isLocal = isLocalBaseUrl(baseUrl);
+      if (!validateAIBaseUrl(baseUrl, { allowLocalhost: isLocal })) {
+        return { success: false, reason: "invalid_url", models: [] };
+      }
+      let key = typeof apiKey === "string" ? apiKey : "";
+      // Masked renderer keys resolve against the stored credential, mirroring
+      // the save/test paths (the mask is not a usable secret).
+      if (!key || key.startsWith("****")) {
+        key =
+          ((await databaseManager.getSetting("ai_api_key")) as string) || "";
+      }
+      const headers: Record<string, string> = key
+        ? { Authorization: `Bearer ${key}` }
+        : {};
+      const candidates = modelEndpointCandidates(baseUrl);
+      for (let i = 0; i < candidates.length; i++) {
+        const candidateUrl = candidates[i]!;
+        try {
+          const response = await fetch(candidateUrl, {
+            headers,
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (response.status === 404 && i < candidates.length - 1) {
+            continue;
+          }
+          if (!response.ok) {
+            return {
+              success: false,
+              reason: `http_${response.status}`,
+              models: [],
+            };
+          }
+          const raw = await response.text();
+          if (Buffer.byteLength(raw) > MODELS_MAX_BODY_BYTES) {
+            return { success: false, reason: "body_too_large", models: [] };
+          }
+          const parsed = JSON.parse(raw) as {
+            data?: Array<{ id?: unknown }>;
+          };
+          const rows = parsed?.data;
+          if (
+            !Array.isArray(rows) ||
+            rows.length === 0 ||
+            rows.length > MODELS_MAX_ITEMS
+          ) {
+            return { success: false, reason: "invalid_shape", models: [] };
+          }
+          const models: string[] = [];
+          for (const row of rows) {
+            const id = row?.id;
+            if (
+              typeof id !== "string" ||
+              !id.trim() ||
+              Buffer.byteLength(id) > MODELS_MAX_ID_BYTES
+            ) {
+              return { success: false, reason: "invalid_shape", models: [] };
+            }
+            models.push(id);
+          }
+          return { success: true, models };
+        } catch (error) {
+          // A failed candidate on the two-candidate path falls through to
+          // the /v1 retry; on the last candidate it degrades to the manual
+          // input path (silent, per ticket #233).
+          if (i >= candidates.length - 1) {
+            logger.warn?.("模型列表获取失败:", error);
+            return { success: false, reason: "fetch_failed", models: [] };
+          }
+        }
+      }
+      return { success: false, reason: "unreachable", models: [] };
     },
   );
 

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -136,12 +136,40 @@ function isLocalhost(host: string | null | undefined): boolean {
   return false;
 }
 
+// [20260907_Fix_233_SsrfHardening] Security-review MEDIUM: the IPv4-text
+// checks missed IPv4-mapped IPv6 (::ffff:a00:1), IPv6 ULA fc00::/7,
+// link-local fe80::/10, loopback ::/128, and CGNAT 100.64.0.0/10 — all
+// resolve to private/internal addresses while canonicalizing to hostnames
+// that matched no regex. Bracket stripping + mapped-address reduction close
+// the gap for every AI channel that shares this gate.
 function isPrivateNetwork(host: string): boolean {
   if (!host) return false;
-  if (/^10\./.test(host)) return true;
-  if (/^192\.168\./.test(host)) return true;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
-  if (/^169\.254\./.test(host)) return true;
+  const bare = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (bare === "::1" || bare === "::") return true;
+  const mapped = bare.match(/^::ffff:(.+)$/);
+  if (mapped) {
+    // WHATWG canonicalizes mapped addresses to hex form ([::ffff:a00:1]);
+    // convert the trailing 32 bits back to dotted-decimal for the IPv4
+    // checks below.
+    const hex = mapped[1]!.match(/^([0-9a-f]+):([0-9a-f]+)$/);
+    if (hex) {
+      const hi = parseInt(hex[1]!, 16);
+      const lo = parseInt(hex[2]!, 16);
+      return isPrivateNetwork(
+        `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`,
+      );
+    }
+    return isPrivateNetwork(mapped[1]!);
+  }
+  if (/^f[cd][0-9a-f]{2}:/.test(bare)) return true; // IPv6 ULA fc00::/7
+  if (/^fe[89ab][0-9a-f]:/.test(bare)) return true; // IPv6 link-local
+  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(bare)) return true; // CGNAT
+  if (/^198\.(1[89]|0)\./.test(bare)) return true; // benchmark 198.18.0.0/15
+  if (/^10\./.test(bare)) return true;
+  if (/^192\.168\./.test(bare)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(bare)) return true;
+  if (/^169\.254\./.test(bare)) return true;
+  if (/^127\./.test(bare)) return true;
   return false;
 }
 

--- a/src/helpers/ipc/index.ts
+++ b/src/helpers/ipc/index.ts
@@ -42,6 +42,9 @@ function wrapWithRateLimits(ipcMain: Electron.IpcMain): Electron.IpcMain {
   const RATE_LIMITS: Record<string, RateLimitConfig> = {
     [C.AI.PROCESS]: { maxCalls: 20, windowMs: 60_000 },
     [C.AI.CHECK_STATUS]: { maxCalls: 30, windowMs: 60_000 },
+    // [20260907_Feat_233_ListModels] Model-list derivation (T6): small
+    // quota — it fires on base_url edits, not per keystroke.
+    [C.AI.LIST_MODELS]: { maxCalls: 10, windowMs: 60_000 },
     [C.TRANSCRIPTION.SAVE]: { maxCalls: 30, windowMs: 60_000 },
     // [20260906_Feat_TranscriptionUpdate] Manual polish write-back (spec #193
     // T1, ticket #228): fires once per polish action, so it carries the same

--- a/src/settings/sections/AIConfigSection.tsx
+++ b/src/settings/sections/AIConfigSection.tsx
@@ -73,6 +73,35 @@ export const AIConfigSection: React.FC<AIConfigSectionProps> = ({
   // [ADR-015] savedFlash: briefly show "✓ 已保存" on the save button after
   // a successful save. Only triggers when saveSettings returns true.
   const [savedFlash, setSavedFlash] = useState(false);
+
+  // [20260907_Feat_233_ListModels] Ticket #233: derive the provider's model
+  // list from ai_base_url and offer it as datalist suggestions on the custom
+  // model input. Debounced (base_url edits fire per keystroke); ANY failure
+  // silently degrades to the manual-input path per the ticket.
+  const [providerModels, setProviderModels] = useState<string[]>([]);
+  const baseUrl = settings.ai_base_url;
+  const apiKey = settings.ai_api_key;
+  useEffect(() => {
+    if (!window.electronAPI?.listAIModels || !baseUrl) {
+      setProviderModels([]);
+      return;
+    }
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      window.electronAPI!.listAIModels!(baseUrl, apiKey)
+        .then((result) => {
+          if (cancelled) return;
+          setProviderModels(result?.success ? (result.models ?? []) : []);
+        })
+        .catch(() => {
+          if (!cancelled) setProviderModels([]);
+        });
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [baseUrl, apiKey]);
   // [CodeReview] Track timeout so it can be cleared on unmount to prevent
   // React "state update on unmounted component" warning.
   const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -366,6 +395,7 @@ export const AIConfigSection: React.FC<AIConfigSectionProps> = ({
               type="text"
               value={settings.ai_model}
               onChange={(e) => onInputChange("ai_model", e.target.value)}
+              list="provider-model-list"
               placeholder={t(
                 "settings.ai.modelPlaceholder",
                 "输入自定义模型名称",
@@ -377,6 +407,14 @@ export const AIConfigSection: React.FC<AIConfigSectionProps> = ({
         <p className="mt-1 text-xs text-[#86868b]">
           {t("settings.ai.modelDesc", "选择用于文本优化的AI模型")}
         </p>
+        {/* [20260907_Feat_233_ListModels] Provider-derived suggestions; an
+            empty list (derivation failed or unsupported provider) renders as
+            pure manual input, per ticket #233's silent-fallback contract. */}
+        <datalist id="provider-model-list">
+          {providerModels.map((model) => (
+            <option key={model} value={model} />
+          ))}
+        </datalist>
       </div>
 
       {/* AI 参数调节 */}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -141,6 +141,15 @@ export interface ExportResult {
   canceled?: boolean;
 }
 
+// [20260907_Feat_233_ListModels] Ticket #233: provider model derivation.
+// success=false carries a reason and an empty list — the renderer silently
+// degrades to the manual-input path.
+export interface ListModelsResult {
+  success: boolean;
+  reason?: string;
+  models: string[];
+}
+
 export interface ExportAllResult {
   success: boolean;
   path?: string;

--- a/tests/unit/ai-config-expanded.test.tsx
+++ b/tests/unit/ai-config-expanded.test.tsx
@@ -139,6 +139,7 @@ type ElectronAPIStub = {
   setSetting: ReturnType<typeof vi.fn>;
   saveSetting: ReturnType<typeof vi.fn>;
   openExternal: ReturnType<typeof vi.fn>;
+  listAIModels?: ReturnType<typeof vi.fn>;
 };
 
 describe("[20260729_Test_AIConfigExpanded] AIConfigSection uncovered branches", () => {
@@ -816,5 +817,124 @@ describe("[20260729_Test_AIConfigExpanded] AIConfigSection uncovered branches", 
     // key exists in the locale). Both resolve to the label string.
     const matches = screen.getAllByText("My Unknown Provider");
     expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// [20260907_Feat_233_ListModels] Ticket #233: the custom-model input offers
+// provider-derived suggestions via a datalist; any derivation failure
+// silently degrades to plain manual input.
+describe("[20260907_Feat_233_ListModels] provider model derivation", () => {
+  let stubApi: {
+    listAIModels: ReturnType<typeof vi.fn>;
+    getAIModes: ReturnType<typeof vi.fn>;
+    processText: ReturnType<typeof vi.fn>;
+  };
+
+  const renderSectionCalls = { onInputChange: vi.fn() };
+
+  function renderSection(props: Record<string, unknown>) {
+    const base = {
+      settings: {
+        ai_api_key: "sk-test",
+        ai_base_url: "https://api.example.com/v1",
+        ai_model: "",
+        ai_temperature: 0.3,
+        ai_max_tokens: 8192,
+        enable_ai_optimization: true,
+        default_mode: "auto",
+        window_always_on_top: true,
+        auto_paste: "paste",
+        close_behavior: "hide",
+        theme: "system",
+        hotkey: "CommandOrControl+Shift+Space",
+        hotwords: "",
+        bot_shape: "circle",
+        bot_color: "auto",
+        bot_expression: "neutral",
+      },
+      onInputChange: renderSectionCalls.onInputChange,
+      customModel: true,
+      setCustomModel: vi.fn(),
+      testResult: null,
+      isTesting: false,
+      onTestAI: vi.fn(),
+      detectedLocalModels: [],
+      getDetectedModels: vi.fn(),
+      isLocalDetected: vi.fn(() => false),
+      resolvedProviderPresets: [],
+      providerPresets: [],
+      applyProviderPreset: vi.fn(),
+      showApiKey: false,
+      setShowApiKey: vi.fn(),
+      showQuickStart: false,
+      onMarkQuickStartDone: vi.fn(),
+    };
+    const merged = { ...base, ...props } as unknown as React.ComponentProps<
+      typeof AIConfigSection
+    >;
+    return render(<AIConfigSection {...merged} />);
+  }
+
+  beforeEach(() => {
+    stubApi = {
+      listAIModels: vi.fn(),
+      getAIModes: vi.fn().mockResolvedValue([]),
+      processText: vi.fn(),
+    };
+    (window as unknown as { electronAPI?: unknown }).electronAPI = stubApi;
+  });
+
+  afterEach(() => {
+    (window as unknown as { electronAPI?: unknown }).electronAPI = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("offers provider-derived models in the custom input datalist", async () => {
+    stubApi.listAIModels.mockResolvedValue({
+      success: true,
+      models: ["m-alpha", "m-beta"],
+    });
+
+    renderSection({});
+
+    // The text input carries list="provider-model-list" (the radio with the
+    // same label text is a different element).
+    const input = document.querySelector(
+      'input[list="provider-model-list"]',
+    ) as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    // 400ms derivation debounce + IPC round trip.
+    await vi.waitFor(
+      () => {
+        const list = document.querySelector("#provider-model-list");
+        expect(list?.querySelectorAll("option")).toHaveLength(2);
+      },
+      { timeout: 2000 },
+    );
+    expect(
+      document
+        .querySelector("#provider-model-list")
+        ?.children[0]?.getAttribute("value"),
+    ).toBe("m-alpha");
+    // Free-text entry still works — the manual path is never blocked. The
+    // input is controlled by the parent, so assert the change callback.
+    const onInputChange = renderSectionCalls.onInputChange;
+    await userEvent.type(input!, "x");
+    expect(onInputChange).toHaveBeenCalledWith("ai_model", "x");
+  });
+
+  it("degrades to plain manual input when derivation fails", async () => {
+    stubApi.listAIModels.mockResolvedValue({ success: false, models: [] });
+
+    renderSection({});
+
+    await vi.waitFor(
+      () => {
+        expect(stubApi.listAIModels).toHaveBeenCalled();
+      },
+      { timeout: 2000 },
+    );
+    const list = document.querySelector("#provider-model-list");
+    expect(list?.querySelectorAll("option")).toHaveLength(0);
   });
 });

--- a/tests/unit/list-models.test.ts
+++ b/tests/unit/list-models.test.ts
@@ -1,0 +1,254 @@
+// [20260907_Feat_233_ListModels] TDD tests for Spec #193 T6 (ticket #233):
+// provider model-list auto-derivation over a NEW GET network primitive.
+// Security constraints are acceptance-hard: the endpoint is derived with the
+// URL constructor only (no whole-URL string concat), the request passes the
+// SAME SSRF validation as the chat request (private https rejected,
+// localhost/local-gateway exception allowed), and malformed provider
+// responses silently fall back to the manual-input path.
+//
+// Harness mirrors aiHandlers.test.ts (captureHandlers-style registration +
+// fetch mock + real node:sqlite DB for the masked-key fallback).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "fs";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+// database.ts lazily requires node:sqlite through the real driver — keep the
+// default import and only mock child_process for the (unused) spawn path.
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: spawnMock };
+});
+
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.stubGlobal("fetch", fetchMock);
+
+if (!process.resourcesPath) {
+  Object.assign(process, { resourcesPath: "/fake/resources" });
+}
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp/fake-userdata"),
+    getAppPath: vi.fn(() => "/fake/app"),
+  },
+}));
+
+import os from "os";
+import path from "path";
+import DatabaseManager from "../../src/helpers/database";
+import * as aiHandlersNS from "../../src/helpers/ipc/aiHandlers";
+import * as C from "../../src/helpers/ipc-contracts";
+
+const FetchMock = fetchMock as unknown as ReturnType<typeof vi.fn>;
+
+function loggerOf() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+function respond(body: unknown, status = 200) {
+  FetchMock.mockImplementationOnce(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  }));
+}
+
+let db: DatabaseManager;
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "list-models-db-"));
+  db = new DatabaseManager();
+  db.initialize(tmpDir);
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function setup() {
+  vi.resetModules();
+  const register = aiHandlersNS.register;
+  const captured: Record<string, (...args: unknown[]) => unknown> = {};
+  const ipcMain = {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      captured[channel] = handler;
+    },
+  };
+  register(
+    ipcMain as never,
+    {
+      databaseManager: db,
+      funasrManager: null,
+      processTextWithAI: vi.fn(),
+      windowManager: { mainWindow: null },
+      logger: loggerOf(),
+      templatesDir: "/tmp/test-templates",
+    } as never,
+  );
+  return {
+    db,
+    handler: captured[C.AI.LIST_MODELS]!,
+    logger: undefined as unknown as ReturnType<typeof loggerOf>,
+  };
+}
+
+function modelsBody(ids: unknown[]): unknown {
+  return { object: "list", data: ids.map((id) => ({ id, object: "model" })) };
+}
+
+describe("[20260907_Feat_233_ListModels] LIST_MODELS handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    FetchMock.mockReset();
+  });
+
+  it("derives {base}/models for a v1-prefixed base and returns model ids", async () => {
+    const { handler, db } = await setup();
+    db.setSetting("ai_api_key", "sk-live");
+    respond(modelsBody(["gpt-x", "gpt-y"]));
+
+    const result = (await handler(
+      {},
+      "https://api.example.com/v1",
+      "sk-live",
+    )) as { success: boolean; models: string[] };
+
+    expect(result.success).toBe(true);
+    expect(result.models).toEqual(["gpt-x", "gpt-y"]);
+    const [url, init] = FetchMock.mock.calls[0] as unknown as [
+      string,
+      { headers: Record<string, string> },
+    ];
+    expect(url).toBe("https://api.example.com/v1/models");
+    expect(init.headers.Authorization).toBe("Bearer sk-live");
+  });
+
+  it("retries /v1/models when the base has no version prefix and /models 404s", async () => {
+    const { handler } = await setup();
+    respond("Not Found", 404);
+    respond(modelsBody(["m-1"]));
+
+    const result = (await handler({}, "https://api.example.com", "sk")) as {
+      success: boolean;
+      models: string[];
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.models).toEqual(["m-1"]);
+    expect(FetchMock.mock.calls[0]![0]).toBe("https://api.example.com/models");
+    expect(FetchMock.mock.calls[1]![0]).toBe(
+      "https://api.example.com/v1/models",
+    );
+  });
+
+  it("keeps an explicit non-v1 path as-is (only /models appended)", async () => {
+    const { handler } = await setup();
+    respond(modelsBody(["m"]));
+
+    await handler({}, "https://gateway.example.com/api", "k");
+    expect(FetchMock.mock.calls[0]![0]).toBe(
+      "https://gateway.example.com/api/models",
+    );
+  });
+
+  it("rejects a private-network https base with the same SSRF params (no fetch)", async () => {
+    const { handler } = await setup();
+    const result = (await handler({}, "https://10.0.0.5/v1", "k")) as {
+      success: boolean;
+      models: string[];
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.models).toEqual([]);
+    expect(FetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows the localhost exception for local gateways (http)", async () => {
+    const { handler } = await setup();
+    respond(modelsBody(["llama-local"]));
+
+    const result = (await handler({}, "http://localhost:11434/v1", "")) as {
+      success: boolean;
+      models: string[];
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.models).toEqual(["llama-local"]);
+    // No key → no Authorization header.
+    const [, init] = FetchMock.mock.calls[0] as unknown as [
+      string,
+      { headers: Record<string, string> },
+    ];
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  it("falls back silently when an id is not a string", async () => {
+    const { handler } = await setup();
+    respond(modelsBody(["good", 42]));
+
+    const result = (await handler({}, "https://api.example.com/v1", "k")) as {
+      success: boolean;
+    };
+    expect(result.success).toBe(false);
+  });
+
+  it("falls back silently beyond the 500-item cap", async () => {
+    const { handler } = await setup();
+    respond(modelsBody(Array.from({ length: 501 }, (_, i) => `m-${i}`)));
+
+    const result = (await handler({}, "https://api.example.com/v1", "k")) as {
+      success: boolean;
+    };
+    expect(result.success).toBe(false);
+  });
+
+  it("falls back silently when the body exceeds the byte cap", async () => {
+    const { handler } = await setup();
+    // One huge id → body above the total byte cap.
+    respond(modelsBody(["x".repeat(700_000)]));
+
+    const result = (await handler({}, "https://api.example.com/v1", "k")) as {
+      success: boolean;
+    };
+    expect(result.success).toBe(false);
+  });
+
+  it("falls back silently when the provider fetch fails", async () => {
+    const { handler } = await setup();
+    FetchMock.mockRejectedValueOnce(new Error("network down"));
+
+    const result = (await handler({}, "https://api.example.com/v1", "k")) as {
+      success: boolean;
+    };
+    expect(result.success).toBe(false);
+  });
+
+  it("resolves a masked key through the stored setting", async () => {
+    const { handler, db } = await setup();
+    db.setSetting("ai_api_key", "sk-stored");
+    respond(modelsBody(["m"]));
+
+    await handler({}, "https://api.example.com/v1", "****abcd");
+
+    const [, init] = FetchMock.mock.calls[0] as unknown as [
+      string,
+      { headers: Record<string, string> },
+    ];
+    expect(init.headers.Authorization).toBe("Bearer sk-stored");
+  });
+});
+
+describe("[20260907_Feat_233_ListModels] rate limit + contract pin", () => {
+  it("declares the LIST_MODELS channel in the rate-limit table", async () => {
+    // Meta-pin per the ticket AC (小额配额): the channel must carry a rate
+    // limit entry in the shared registration table.
+    const source = fs.readFileSync("src/helpers/ipc/index.ts", "utf8");
+    expect(source).toContain("C.AI.LIST_MODELS");
+    expect(source).toMatch(/LIST_MODELS.*maxCalls/i);
+  });
+
+  it("declares the channel constant in ipc-contracts", () => {
+    expect(C.AI.LIST_MODELS).toBe("ai-list-models");
+  });
+});

--- a/tests/unit/list-models.test.ts
+++ b/tests/unit/list-models.test.ts
@@ -183,6 +183,36 @@ describe("[20260907_Feat_233_ListModels] LIST_MODELS handler", () => {
     expect(init.headers.Authorization).toBeUndefined();
   });
 
+  // [20260907_Fix_233_SsrfHardening] Security-review MEDIUM: the shared gate
+  // had IPv6/CGNAT blind spots — these URLs passed as "public https" while
+  // resolving to private/internal addresses. All must be rejected.
+  it.each([
+    ["https://[::ffff:10.0.0.1]/v1"], // IPv4-mapped IPv6 → 10.0.0.1
+    ["https://[::ffff:127.0.0.1]/v1"], // mapped loopback
+    ["https://[fd00::1]/v1"], // IPv6 ULA fc00::/7
+    ["https://[fe80::1]/v1"], // IPv6 link-local
+    ["https://100.64.0.1/v1"], // CGNAT 100.64.0.0/10
+    ["https://198.18.0.1/v1"], // benchmark range
+  ])("rejects the internal-address base %s", async (base) => {
+    const { handler } = await setup();
+    const result = (await handler({}, base, "k")) as {
+      success: boolean;
+      models: string[];
+    };
+    expect(result.success).toBe(false);
+    expect(result.models).toEqual([]);
+    expect(FetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still accepts legit public providers after the hardening", async () => {
+    const { handler } = await setup();
+    respond(modelsBody(["m"]));
+    const result = (await handler({}, "https://api.example.com/v1", "k")) as {
+      success: boolean;
+    };
+    expect(result.success).toBe(true);
+  });
+
   it("falls back silently when an id is not a string", async () => {
     const { handler } = await setup();
     respond(modelsBody(["good", 42]));


### PR DESCRIPTION
## 概述

三组已评审工作(每项独立评审通过,详见各 commit 与关联票):

- **T6 #233**:新 GET 原语 `C.AI.LIST_MODELS`——URL 构造器端点推导(v1 差异双候选)、与 chat 同函数同参 SSRF 门禁、响应三态严格校验、静默回退手输;渲染端 400ms 防抖 datalist 建议。**安全评审 APPROVE 后加固**:IPv4-mapped IPv6 hex 还原/ULA/link-local/CGNAT/benchmark 盲区关闭(6 条拒斥测试),canonicalization 攻击向量全部验证仍被拒斥。
- **SSRF 门禁加固(#233 评审)**:isPrivateNetwork/isLocalhost 补 IPv6/CGNAT 等 6 个区间,合法公共供应商不受影响。
- **T5 #232 Spike 结论文档**(docs/research/2026-09-08-t5-streaming-spike.md,另一上下文复核 VERIFIED):Electron 主进程流式/取消 VERIFIED;Ollama VERIFIED+思考模型 reasoning 洪流警告(两本机模型均有 reasoning 前奏);diff 选型定论 dmp+薄封装;eventsource-parser 3.x esbuild 打包 VERIFIED;网关 401 JSON 形态采样。

另含 #319(SSRF 加固二期:redirect 策略/响应体预检/DNS rebinding 成文)待办引用。

## 验证

- `pnpm ci:check` 11/11 全绿;unit 2229+;Python 120(floor 46 由 meta-test 钉住)
- 涉及文件:typecheck/tsc/lint 零错误

## 关联

- 关票:#233(T6)、#232(T5)——均已附评审证据
- 新增后续票:#319