### PR TITLE
feat: 主进程流式管线 — SSE 合并器/chunk 协议/超时矩阵/POLISH_ABORT(Spec#193 T8, #235)

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -73,6 +73,16 @@ export const preloadApi: ElectronAPI = {
   // [20260907_Feat_233_ListModels] Provider model-list derivation (T6).
   listAIModels: (baseUrl: string, apiKey: string) =>
     ipcRenderer.invoke(C.AI.LIST_MODELS, baseUrl, apiKey),
+  // [20260907_Feat_235_StreamPipeline] T8: streaming abort + chunk push.
+  abortPolish: (requestId: string) =>
+    ipcRenderer.invoke(C.AI.POLISH_ABORT, requestId),
+  onPolishChunk: (
+    callback: (chunk: import("./src/types/ipc").PolishChunk) => void,
+  ) =>
+    makeListener<import("./src/types/ipc").PolishChunk>(
+      C.EVENTS.AI_POLISH_CHUNK,
+      callback,
+    ),
   getAIModes: () => ipcRenderer.invoke(C.AI.GET_MODES),
   getAIProviderPresets: () => ipcRenderer.invoke(C.AI.GET_PROVIDER_PRESETS),
   detectLocalModels: () => ipcRenderer.invoke(C.AI.DETECT_LOCAL_MODELS),

--- a/src/electronAPI.d.ts
+++ b/src/electronAPI.d.ts
@@ -8,6 +8,7 @@ import type {
   TranscriptionSaveResult,
   TranscriptionUpdateResult,
   ListModelsResult,
+  PolishChunk,
   FileTranscriptionResult,
   ExportResult,
   ExportAllResult,
@@ -72,6 +73,9 @@ export interface ElectronAPI {
   }) => Promise<AICheckStatusResult>;
   // [20260907_Feat_233_ListModels] Provider model-list derivation (T6).
   listAIModels: (baseUrl: string, apiKey: string) => Promise<ListModelsResult>;
+  // [20260907_Feat_235_StreamPipeline] T8 streaming abort + chunk push.
+  abortPolish: (requestId: string) => Promise<OperationResult>;
+  onPolishChunk: (callback: (chunk: PolishChunk) => void) => () => void;
   getAIModes: () => Promise<AIMode[]>;
   getAIProviderPresets: () => Promise<AIProviderPreset[]>;
   detectLocalModels: () => Promise<LocalModelDetection[]>;

--- a/src/helpers/ipc-contracts.ts
+++ b/src/helpers/ipc-contracts.ts
@@ -64,6 +64,10 @@ export const AI = {
   // [20260907_Feat_233_ListModels] Provider model-list derivation (T6): a
   // GET primitive that passes the same SSRF validation as the chat request.
   LIST_MODELS: "ai-list-models",
+  // [20260907_Feat_235_StreamPipeline] T8: abort an in-flight streaming
+  // polish run by requestId. Rate-limit exempt by design (an abort must
+  // never be throttled); ownership is checked against the initiating sender.
+  POLISH_ABORT: "ai-polish-abort",
   GET_MODES: "get-ai-modes",
   GET_PROVIDER_PRESETS: "get-ai-provider-presets",
   DETECT_LOCAL_MODELS: "detect-local-models",
@@ -114,6 +118,8 @@ export const SYSTEM = {
 } as const;
 
 export const EVENTS = {
+  // [20260907_Feat_235_StreamPipeline] T8 streaming chunk push events.
+  AI_POLISH_CHUNK: "ai-polish-chunk",
   HOTKEY_TRIGGERED: "hotkey-triggered",
   WINDOW_MAXIMIZE_CHANGE: "window-maximize-change",
   SETTINGS_UPDATE: "settings-update",

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -1219,9 +1219,11 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
       // into streaming — chunk events are sent to THIS window only, and the
       // requestId becomes the abort/generation scope key.
       let stream: PolishRequest["stream"];
+      let ownedController: AbortController | undefined;
       if (requestId) {
         const senderId = event.sender.id;
         const controller = new AbortController();
+        ownedController = controller;
         streamAbortTargets.set(requestId, { controller, senderId });
         stream = {
           requestId,
@@ -1231,9 +1233,6 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
             }
           },
         };
-        (
-          controller as AbortController & { __ownerSenderId?: number }
-        ).__ownerSenderId = senderId;
       }
       try {
         return await runPolishOrchestrator(
@@ -1250,7 +1249,12 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
           },
         );
       } finally {
-        if (requestId) streamAbortTargets.delete(requestId);
+        // [20260907_Fix_235_ReviewMinor1] Delete ONLY our own entry: a
+        // superseding run reusing the requestId owns the map slot now.
+        const entry = requestId ? streamAbortTargets.get(requestId) : undefined;
+        if (entry && entry.controller === ownedController) {
+          streamAbortTargets.delete(requestId as string);
+        }
       }
     },
   );

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -367,22 +367,48 @@ async function consumePolishStream(
   };
 
   try {
+    // Deadline matrix: first-delta before any content, idle between deltas,
+    // total across the whole body ([20260907_Fix_235_TotalDeadline] — the
+    // response-headers timer cleared on arrival, so body consumption needs
+    // this explicit total bound). The read is raced against the nearest
+    // remaining deadline so a stalled upstream wakes the loop for
+    // classification.
+    let pendingRead: Promise<ReadableStreamReadResult<Uint8Array>> | null =
+      null;
     while (true) {
-      // Deadline matrix: first-delta before any content, idle between
-      // deltas. The read is raced against the nearest remaining deadline so
-      // a stalled upstream wakes the loop for classification.
       const stage = receivedFirst ? "streaming" : "awaiting_first";
-      const deadline = receivedFirst
+      const stageDeadline = receivedFirst
         ? lastActivity + timeouts.idleMs
         : startedAt + timeouts.firstDeltaMs;
+      const totalDeadline = startedAt + timeoutMs;
+      const deadline = Math.min(stageDeadline, totalDeadline);
       const remainingMs = Math.max(deadline - Date.now(), 1);
+      let timerId: ReturnType<typeof setTimeout> | undefined;
+      if (!pendingRead) pendingRead = reader.read();
       const raced = await Promise.race([
-        reader.read().then((r) => ({ kind: "read" as const, r })),
-        new Promise<{ kind: "deadline" }>((resolve) =>
-          setTimeout(() => resolve({ kind: "deadline" }), remainingMs),
-        ),
+        pendingRead.then((r) => ({ kind: "read" as const, r })),
+        new Promise<{ kind: "deadline" }>((resolve) => {
+          timerId = setTimeout(
+            () => resolve({ kind: "deadline" }),
+            remainingMs,
+          );
+        }),
       ]);
+      // A read-win clears its deadline timer; a deadline-win keeps the
+      // queued read alive for the next iteration (no orphaned reads).
+      clearTimeout(timerId);
+      if (process.env.POLISH_MERGER_DEBUG) {
+        console.log(
+          "DBG raced kind:",
+          raced.kind,
+          "now-started:",
+          Date.now() - startedAt,
+        );
+      }
       if (raced.kind === "deadline") {
+        if (Date.now() >= totalDeadline) {
+          return failWith("AI 流式响应总时长超时", "STREAM_TOTAL_TIMEOUT");
+        }
         const violation = streamDeadlineViolation(
           stage,
           startedAt,
@@ -396,32 +422,35 @@ async function consumePolishStream(
         if (violation === "idle") {
           return failWith("AI 流式响应空闲超时", "STREAM_IDLE_TIMEOUT");
         }
+        // Early wake (wall-clock jitter before the strict threshold):
+        // re-arm the deadline and keep waiting on the SAME queued read.
         continue;
       }
+      pendingRead = null;
       const { done, value } = raced.r;
       if (done) break;
       chunkCount++;
       lastActivity = Date.now();
       if (chunkCount > STREAM_MAX_CHUNKS) {
-        runHandle?.controller.abort();
         return failWith("AI 流式响应块数超过上限", "STREAM_CHUNK_CAP");
       }
       notify({ type: "progress", requestId, bytes: value.length });
       merger.push(decoder.decode(value, { stream: true }));
       if (merger.contentChars() > 0) receivedFirst = true;
       if (outputChars > POLISH_OUTPUT_MAX_CHARS) {
-        runHandle?.controller.abort();
         return failWith("AI 输出超过上限", "OUTPUT_CAP");
       }
       // T7 gates stay live mid-stream: a cancelled/superseded run settles
-      // immediately without touching the renderer state again.
+      // immediately without touching the renderer state again. Flush the
+      // window BEFORE the terminal abort chunk so no delta trails it.
       const settled = polishRunOutcomeIfSettledAside(runHandle);
       if (settled) {
-        notify({ type: "abort", requestId });
         merger.flush();
+        notify({ type: "abort", requestId });
         return settled;
       }
     }
+    decoder.decode(); // flush a possibly-split multi-byte tail
     merger.flush();
     if (!fullText) {
       return failWith("AI返回了空内容，请重试或更换模型", "EMPTY_CONTENT");

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -8,6 +8,13 @@ import { buildPrompt, loadCustomTemplates } from "../aiPrompts";
 import type { PromptTemplate } from "../aiPrompts";
 import { getProviderPresets } from "../providerPresets";
 import { detectLocalModels } from "../detectLocalModels";
+// [20260907_Feat_235_StreamPipeline] T8 chunk protocol union.
+import type { PolishChunk } from "../../types/ipc";
+import {
+  createSseMerger,
+  STREAM_MAX_CHUNKS,
+  streamDeadlineViolation,
+} from "../polish-stream";
 
 interface Logger {
   info?(message: string, ...args: unknown[]): void;
@@ -298,6 +305,150 @@ async function postChatCompletion(
   return response;
 }
 
+// [20260907_Feat_235_StreamPipeline] T8: consume the streaming response
+// body — merge upstream SSE via createSseMerger, push PolishChunk events to
+// the initiating window, enforce the deadline matrix (first-delta / idle /
+// total) and the cumulative output caps. Chunk TEXT never reaches the
+// logger: only counts, byte sizes and durations are logged.
+async function consumePolishStream(
+  response: Response,
+  stream: {
+    requestId: string;
+    notify: (chunk: PolishChunk) => void;
+    timeouts?: { firstDeltaMs: number; idleMs: number };
+  },
+  runHandle: PolishRunHandle | null,
+  logger: Logger | undefined,
+  timeoutMs: number,
+): Promise<{
+  success: boolean;
+  text?: string;
+  error?: string;
+  code?: PolishOutcomeCode;
+}> {
+  const requestId = stream.requestId;
+  const notify = (chunk: PolishChunk) => stream.notify(chunk);
+  const startedAt = Date.now();
+  let lastActivity = startedAt;
+  let receivedFirst = false;
+  let chunkCount = 0;
+  let outputChars = 0;
+  let reasoningChars = 0;
+  let fullText = "";
+  const timeouts = stream.timeouts ?? {
+    firstDeltaMs: STREAM_FIRST_DELTA_MS,
+    idleMs: STREAM_IDLE_MS,
+  };
+
+  notify({ type: "start", requestId });
+  const merger = createSseMerger({
+    now: Date.now,
+    onDelta: (t) => {
+      receivedFirst = true;
+      fullText += t;
+      outputChars += t.length;
+      notify({ type: "delta", requestId, text: t });
+    },
+    onReasoning: (t) => {
+      reasoningChars += t.length;
+    },
+  });
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  const failWith = (message: string, errorCode: string) => {
+    runHandle?.controller.abort();
+    notify({ type: "error", requestId, error: message });
+    logger?.error?.(
+      "流式润色失败:",
+      JSON.stringify({ requestId, code: errorCode, outputChars, chunkCount }),
+    );
+    return { success: false as const, error: message };
+  };
+
+  try {
+    while (true) {
+      // Deadline matrix: first-delta before any content, idle between
+      // deltas. The read is raced against the nearest remaining deadline so
+      // a stalled upstream wakes the loop for classification.
+      const stage = receivedFirst ? "streaming" : "awaiting_first";
+      const deadline = receivedFirst
+        ? lastActivity + timeouts.idleMs
+        : startedAt + timeouts.firstDeltaMs;
+      const remainingMs = Math.max(deadline - Date.now(), 1);
+      const raced = await Promise.race([
+        reader.read().then((r) => ({ kind: "read" as const, r })),
+        new Promise<{ kind: "deadline" }>((resolve) =>
+          setTimeout(() => resolve({ kind: "deadline" }), remainingMs),
+        ),
+      ]);
+      if (raced.kind === "deadline") {
+        const violation = streamDeadlineViolation(
+          stage,
+          startedAt,
+          lastActivity,
+          Date.now(),
+          timeouts,
+        );
+        if (violation === "first_delta") {
+          return failWith("AI 流式响应首块超时", "STREAM_FIRST_DELTA_TIMEOUT");
+        }
+        if (violation === "idle") {
+          return failWith("AI 流式响应空闲超时", "STREAM_IDLE_TIMEOUT");
+        }
+        continue;
+      }
+      const { done, value } = raced.r;
+      if (done) break;
+      chunkCount++;
+      lastActivity = Date.now();
+      if (chunkCount > STREAM_MAX_CHUNKS) {
+        runHandle?.controller.abort();
+        return failWith("AI 流式响应块数超过上限", "STREAM_CHUNK_CAP");
+      }
+      notify({ type: "progress", requestId, bytes: value.length });
+      merger.push(decoder.decode(value, { stream: true }));
+      if (merger.contentChars() > 0) receivedFirst = true;
+      if (outputChars > POLISH_OUTPUT_MAX_CHARS) {
+        runHandle?.controller.abort();
+        return failWith("AI 输出超过上限", "OUTPUT_CAP");
+      }
+      // T7 gates stay live mid-stream: a cancelled/superseded run settles
+      // immediately without touching the renderer state again.
+      const settled = polishRunOutcomeIfSettledAside(runHandle);
+      if (settled) {
+        notify({ type: "abort", requestId });
+        merger.flush();
+        return settled;
+      }
+    }
+    merger.flush();
+    if (!fullText) {
+      return failWith("AI返回了空内容，请重试或更换模型", "EMPTY_CONTENT");
+    }
+    notify({ type: "finish", requestId, text: fullText, reasoningChars });
+    logger?.info?.(
+      "流式润色完成:",
+      JSON.stringify({
+        requestId,
+        outputChars,
+        reasoningChars,
+        chunkCount,
+        totalMs: Date.now() - startedAt,
+      }),
+    );
+    return { success: true, text: fullText };
+  } catch (error) {
+    if (runHandle?.controller.signal.aborted) {
+      notify({ type: "abort", requestId });
+      const outcome = polishRunOutcomeIfSettledAside(runHandle);
+      if (outcome) return outcome;
+      return { success: false, error: "已取消", code: "CANCELLED" };
+    }
+    return failWith((error as Error).message || "流式处理失败", "STREAM_ERROR");
+  }
+}
+
 /**
  * Extract the human-readable message from an OpenAI-style error body.
  * Returns "" when the body has no usable message; the caller supplies its
@@ -358,6 +509,17 @@ export interface PolishRequest {
   // processTextWithAI option contract; after T3 no production caller uses it.
   systemPrompt?: string;
   userPrompt?: string;
+  // [20260907_Feat_235_StreamPipeline] T8: when present the run streams —
+  // the provider is called with stream:true, upstream SSE deltas are merged
+  // (16ms window / 2048-char cap) and pushed via notify as PolishChunk
+  // events; the deadline matrix (first-delta / idle / total) and the
+  // cumulative output cap abort the upstream on violation. Timeouts are
+  // injectable for tests.
+  stream?: {
+    requestId: string;
+    notify: (chunk: PolishChunk) => void;
+    timeouts?: { firstDeltaMs: number; idleMs: number };
+  };
   // [20260906_Feat_OrchestratorGenCancel] Spec #193 T7 (ticket #234):
   // generation-scope key for last-write-wins race protection. When two runs
   // share a scope, starting a newer run invalidates the older one: the stale
@@ -412,6 +574,11 @@ const MINIMAL_EDIT_MODES: ReadonlySet<string> = new Set([
 // a provider (or malicious gateway) response longer than this is truncated
 // before mapping, so oversized/absurd output never flows to the renderer.
 export const POLISH_OUTPUT_MAX_CHARS = 2_000_000;
+// [20260907_Feat_235_StreamPipeline] T8 streaming consumption guards: chunk
+// count cap (per-read events) and the deadline matrix values. The total
+// duration reuses the existing 150s/180s timeout passed by the entry.
+const STREAM_FIRST_DELTA_MS = 15_000;
+const STREAM_IDLE_MS = 30_000;
 
 // One in-flight run per generation scope: the epoch orders runs within the
 // scope, the controller aborts the run's provider fetch when it is
@@ -630,7 +797,9 @@ export async function runPolishOrchestrator(
       ],
       temperature: temperature,
       max_tokens: effectiveMaxTokens,
-      stream: false,
+      // [20260907_Feat_235_StreamPipeline] T8: stream the response body when
+      // the caller requested it; chunk events flow through request.stream.
+      stream: request.stream !== undefined,
     };
 
     logger.info?.("AI文本处理请求:", {
@@ -664,6 +833,27 @@ export async function runPolishOrchestrator(
     const staleOutcome = polishRunOutcomeIfSettledAside(runHandle);
     if (staleOutcome) {
       return staleOutcome;
+    }
+
+    // [20260907_Feat_235_StreamPipeline] T8: consume the SSE body via the
+    // merger + deadline matrix. A gateway that ignored stream:true (200 with
+    // a non-SSE content-type) degrades to the non-stream JSON path below.
+    if (request.stream) {
+      const contentType = response.headers.get("content-type") ?? "";
+      if (contentType.includes("text/event-stream")) {
+        return await consumePolishStream(
+          response,
+          request.stream,
+          runHandle,
+          logger,
+          timeoutMs,
+        );
+      }
+      request.stream.notify({
+        type: "degraded",
+        requestId: request.stream.requestId,
+        reason: "non_sse_response",
+      });
     }
 
     if (!response.ok) {
@@ -958,6 +1148,13 @@ interface Managers {
 
 export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   const { databaseManager, logger } = managers;
+  // [20260907_Feat_235_StreamPipeline] T8: requestId → abort controller for
+  // the initiating sender. POLISH_ABORT resolves through this map with a
+  // sender-ownership check.
+  const streamAbortTargets = new Map<
+    string,
+    { controller: AbortController; senderId: number }
+  >();
   const templatesDir =
     managers.templatesDir ||
     (() => {
@@ -971,7 +1168,13 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
 
   ipcMain.handle(
     C.AI.PROCESS,
-    async (_event, text: string, mode = "optimize", timeout?: number) => {
+    async (
+      event,
+      text: string,
+      mode = "optimize",
+      timeout?: number,
+      requestId?: string,
+    ) => {
       // [20260906_Refactor_PolishOrchestrator] Spec #193 T3 (ticket #230):
       // route the PROCESS entry straight through the shared orchestrator
       // (entry resolves its own default mode; the orchestrator owns prompt
@@ -982,18 +1185,62 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
       // orchestrator only clamps when the caller opts in, and without this
       // the 2026-08-15 empty-content fix never bound on a live path. Rewrite
       // modes and custom templates stay unclamped by design.
-      return await runPolishOrchestrator(
-        { databaseManager, logger },
-        {
-          text,
-          mode,
-          templatesDir,
-          timeout,
-          clampOutputTokens: MINIMAL_EDIT_MODES.has(mode),
-        },
-      );
+      //
+      // [20260907_Feat_235_StreamPipeline] T8: a requestId opts the call
+      // into streaming — chunk events are sent to THIS window only, and the
+      // requestId becomes the abort/generation scope key.
+      let stream: PolishRequest["stream"];
+      if (requestId) {
+        const senderId = event.sender.id;
+        const controller = new AbortController();
+        streamAbortTargets.set(requestId, { controller, senderId });
+        stream = {
+          requestId,
+          notify: (chunk: PolishChunk) => {
+            if (!event.sender.isDestroyed()) {
+              event.sender.send(C.EVENTS.AI_POLISH_CHUNK, chunk);
+            }
+          },
+        };
+        (
+          controller as AbortController & { __ownerSenderId?: number }
+        ).__ownerSenderId = senderId;
+      }
+      try {
+        return await runPolishOrchestrator(
+          { databaseManager, logger },
+          {
+            text,
+            mode,
+            templatesDir,
+            timeout,
+            clampOutputTokens: MINIMAL_EDIT_MODES.has(mode),
+            generationScope: requestId,
+            signal: streamAbortTargets.get(requestId ?? "")?.controller.signal,
+            stream,
+          },
+        );
+      } finally {
+        if (requestId) streamAbortTargets.delete(requestId);
+      }
     },
   );
+
+  // [20260907_Feat_235_StreamPipeline] T8 abort channel — rate-limit exempt
+  // (an abort must never be throttled) and sender-checked so one window
+  // cannot cancel another window's run.
+  ipcMain.handle(C.AI.POLISH_ABORT, (event, requestId: string) => {
+    const target = streamAbortTargets.get(requestId);
+    if (!target) {
+      return { success: false, reason: "unknown_request" };
+    }
+    if (target.senderId !== event.sender.id) {
+      logger.warn?.("POLISH_ABORT 拒绝：请求 id 不属于该发送者");
+      return { success: false, reason: "forbidden" };
+    }
+    target.controller.abort();
+    return { success: true };
+  });
 
   // [20260907_Feat_233_ListModels] Ticket #233: provider model-list
   // derivation. Same SSRF gate as the chat request (private https rejected,

--- a/src/helpers/polish-stream.ts
+++ b/src/helpers/polish-stream.ts
@@ -32,10 +32,6 @@ export interface SseMergerOptions {
   onDone?: () => void;
 }
 
-interface SseFrame {
-  data: string;
-}
-
 export function createSseMerger(options: SseMergerOptions): SseMerger {
   const now = options.now ?? (() => 0);
   const windowMs = SSE_MERGE_WINDOW_MS;

--- a/src/helpers/polish-stream.ts
+++ b/src/helpers/polish-stream.ts
@@ -1,0 +1,129 @@
+// [20260907_Feat_235_StreamMerger] Spec #193 T8 (ticket #235): pure-function
+// module converting an upstream OpenAI-compatible SSE text stream into
+// merged Polish delta chunks.
+//
+// Design contract (see tests/unit/polish-stream.test.ts):
+//  - torn SSE lines reassemble across push() calls (CRLF tolerated)
+//  - delta content coalesces inside a merge window (default 16ms, injected
+//    clock) and each emitted delta never exceeds maxChunkChars (2048)
+//  - thinking-model `delta.reasoning` is counted via onReasoning and NEVER
+//    mixed into onDelta content
+//  - `data: [DONE]` terminates the stream; later frames are ignored
+//  - malformed JSON frames are skipped; the stream survives
+// No clocks, no globals: the caller injects `now` and owns all timeouts.
+export const SSE_MERGE_WINDOW_MS = 16;
+export const SSE_MAX_CHUNK_CHARS = 2048;
+
+export interface SseMerger {
+  /** Feed decoded upstream text (one network chunk or any fragment). */
+  push(raw: string): void;
+  /** Emit any coalesced content held inside the merge window. */
+  flush(): void;
+  /** True once `data: [DONE]` has been seen. */
+  isDone(): boolean;
+}
+
+export interface SseMergerOptions {
+  now?: () => number;
+  onDelta: (text: string) => void;
+  onReasoning?: (text: string) => void;
+  onDone?: () => void;
+}
+
+interface SseFrame {
+  data: string;
+}
+
+export function createSseMerger(options: SseMergerOptions): SseMerger {
+  const now = options.now ?? (() => 0);
+  const windowMs = SSE_MERGE_WINDOW_MS;
+  let lineBuf = "";
+  let done = false;
+  let pending = "";
+  let pendingSince = -1;
+
+  const emitDelta = (text: string) => {
+    if (!text) return;
+    options.onDelta(text);
+  };
+
+  const bufferContent = (text: string) => {
+    if (!text) return;
+    if (pendingSince < 0) pendingSince = now();
+    pending += text;
+  };
+
+  const drain = (force: boolean) => {
+    if (!pending) return;
+    const elapsed = now() - pendingSince;
+    if (!force && elapsed < windowMs && pending.length < SSE_MAX_CHUNK_CHARS) {
+      return;
+    }
+    // Emit in slices no longer than the single-chunk cap.
+    for (let i = 0; i < pending.length; i += SSE_MAX_CHUNK_CHARS) {
+      emitDelta(pending.slice(i, i + SSE_MAX_CHUNK_CHARS));
+    }
+    pending = "";
+    pendingSince = now();
+  };
+
+  const handleFrame = (data: string) => {
+    if (done) return;
+    if (data === "[DONE]") {
+      done = true;
+      options.onDone?.();
+      return;
+    }
+    try {
+      const parsed = JSON.parse(data) as {
+        choices?: Array<{ delta?: { content?: string; reasoning?: string } }>;
+      };
+      const delta = parsed.choices?.[0]?.delta;
+      if (!delta) return;
+      if (typeof delta.reasoning === "string" && delta.reasoning) {
+        options.onReasoning?.(delta.reasoning);
+      }
+      if (typeof delta.content === "string" && delta.content) {
+        bufferContent(delta.content);
+      }
+    } catch {
+      // Malformed frame: skip it, keep the stream alive.
+    }
+  };
+
+  const handleLine = (line: string) => {
+    const trimmed = line.replace(/\r$/, "");
+    if (!trimmed.startsWith("data:")) return;
+    handleFrame(trimmed.slice(5).trim());
+  };
+
+  return {
+    push(raw: string) {
+      if (done) return;
+      // [20260907_Feat_235_StreamMerger] Flush the window BEFORE buffering
+      // newly arrived content: content that arrives after the window
+      // elapsed starts a fresh delta, it never joins the previous one.
+      drain(false);
+      lineBuf += raw;
+      // The last element is a possibly-torn line — keep it buffered.
+      const lines = lineBuf.split("\n");
+      lineBuf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (done) break;
+        handleLine(line);
+      }
+      drain(false);
+    },
+    flush() {
+      if (lineBuf) {
+        const rest = lineBuf;
+        lineBuf = "";
+        handleLine(rest);
+      }
+      drain(true);
+    },
+    isDone() {
+      return done;
+    },
+  };
+}

--- a/src/helpers/polish-stream.ts
+++ b/src/helpers/polish-stream.ts
@@ -21,6 +21,8 @@ export interface SseMerger {
   flush(): void;
   /** True once `data: [DONE]` has been seen. */
   isDone(): boolean;
+  /** Total content chars RECEIVED (including ones still inside the window). */
+  contentChars(): number;
 }
 
 export interface SseMergerOptions {
@@ -41,6 +43,7 @@ export function createSseMerger(options: SseMergerOptions): SseMerger {
   let done = false;
   let pending = "";
   let pendingSince = -1;
+  let contentReceived = 0;
 
   const emitDelta = (text: string) => {
     if (!text) return;
@@ -84,6 +87,7 @@ export function createSseMerger(options: SseMergerOptions): SseMerger {
         options.onReasoning?.(delta.reasoning);
       }
       if (typeof delta.content === "string" && delta.content) {
+        contentReceived += delta.content.length;
         bufferContent(delta.content);
       }
     } catch {
@@ -125,5 +129,45 @@ export function createSseMerger(options: SseMergerOptions): SseMerger {
     isDone() {
       return done;
     },
+    contentChars() {
+      return contentReceived;
+    },
   };
+}
+
+// [20260907_Feat_235_TimeoutMatrix] Ticket #235: the response-body
+// consumption deadline matrix. Stages: no content delta within
+// firstDeltaMs of the response headers; no delta at all within idleMs of
+// the last activity; total duration is enforced by the caller (the
+// existing 150s/180s timeout). All values overridable for tests.
+export interface StreamTimeouts {
+  firstDeltaMs: number;
+  idleMs: number;
+}
+
+export const DEFAULT_STREAM_TIMEOUTS: StreamTimeouts = {
+  firstDeltaMs: 15_000,
+  idleMs: 30_000,
+};
+
+export const STREAM_MAX_CHUNKS = 100_000;
+
+export type StreamDeadlineViolation = "first_delta" | "idle" | null;
+
+/**
+ * Pure deadline check for one iteration of the stream-consumption loop.
+ * `receivedDelta` is false until the first content delta arrives; after
+ * that the idle deadline takes over. Returns the violated stage or null.
+ */
+export function streamDeadlineViolation(
+  stage: "awaiting_first" | "streaming",
+  startedAtMs: number,
+  lastActivityAtMs: number,
+  nowMs: number,
+  timeouts: StreamTimeouts = DEFAULT_STREAM_TIMEOUTS,
+): StreamDeadlineViolation {
+  if (stage === "awaiting_first") {
+    return nowMs - startedAtMs > timeouts.firstDeltaMs ? "first_delta" : null;
+  }
+  return nowMs - lastActivityAtMs > timeouts.idleMs ? "idle" : null;
 }

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -144,6 +144,17 @@ export interface ExportResult {
 // [20260907_Feat_233_ListModels] Ticket #233: provider model derivation.
 // success=false carries a reason and an empty list — the renderer silently
 // degrades to the manual-input path.
+// [20260907_Feat_235_StreamPipeline] T8 chunk protocol — a tagged union
+// pushed to the initiating window while a streaming polish runs.
+export type PolishChunk =
+  | { type: "start"; requestId: string }
+  | { type: "delta"; requestId: string; text: string }
+  | { type: "progress"; requestId: string; bytes: number }
+  | { type: "degraded"; requestId: string; reason: string }
+  | { type: "finish"; requestId: string; text: string; reasoningChars: number }
+  | { type: "abort"; requestId: string }
+  | { type: "error"; requestId: string; error: string };
+
 export interface ListModelsResult {
   success: boolean;
   reason?: string;

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -1611,3 +1611,185 @@ describe("aiHandlers", () => {
     });
   });
 });
+// [20260907_Feat_235_StreamPipeline] T8 abort channel + total timeout:
+// POLISH_ABORT ownership (sender check), unknown_request, and the
+// STREAM_TOTAL_TIMEOUT leg of the deadline matrix. Self-contained harness:
+// the fetch stub's SSE reader PENDS forever (and rejects when the fetch
+// init signal fires), so the run stays in flight until aborted or timed
+// out.
+describe("[20260907_Feat_235_StreamPipeline] POLISH_ABORT / total timeout", () => {
+  let registeredHandlers: Record<string, (...args: unknown[]) => unknown>;
+  let sendBySender: Map<number, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    sendBySender = new Map([
+      [1, vi.fn()],
+      [2, vi.fn()],
+    ]);
+  });
+
+  function senderEvent(id: number) {
+    return {
+      sender: {
+        id,
+        isDestroyed: vi.fn(() => false),
+        send: sendBySender.get(id) ?? vi.fn(),
+      },
+    };
+  }
+
+  function setup() {
+    registeredHandlers = {};
+    const ipcMain = {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        registeredHandlers[channel] = fn;
+      }),
+    };
+    const db = {
+      getSetting: vi.fn(async (key: string) =>
+        key === "ai_base_url"
+          ? "https://api.example.com/v1"
+          : key === "ai_api_key"
+            ? "sk"
+            : key === "ai_model"
+              ? "gpt-x"
+              : null,
+      ),
+    };
+    const register = aiHandlersNS.register;
+    register(
+      ipcMain as never,
+      {
+        databaseManager: db,
+        funasrManager: null,
+        processTextWithAI: vi.fn(),
+        windowManager: { mainWindow: null },
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      } as never,
+    );
+    return import("../../src/helpers/ipc-contracts");
+  }
+
+  // SSE body whose read() pends until the FETCH signal aborts, then rejects.
+  function sseResponsePending(initSignal?: AbortSignal): unknown {
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "text/event-stream" }),
+      body: {
+        getReader: () => ({
+          read: () =>
+            new Promise((_resolve, reject) => {
+              const onAbort = () =>
+                reject(new DOMException("aborted", "AbortError"));
+              if (initSignal?.aborted) onAbort();
+              else
+                initSignal?.addEventListener("abort", onAbort, { once: true });
+            }),
+        }),
+      },
+    } as unknown;
+  }
+
+  it("abort via POLISH_ABORT cancels the in-flight run and emits abort chunk", async () => {
+    const C = await setup();
+    // PROCESS from sender 1, streaming with requestId r1.
+    // [20260907_Feat_235_StreamPipeline] SSE stub bound to THIS test only.
+    const prevFetch = global.fetch;
+    global.fetch = vi.fn(
+      async (_url: unknown, init?: { signal?: AbortSignal }) =>
+        sseResponsePending(init?.signal),
+    ) as unknown as typeof fetch;
+    void prevFetch;
+    const processPromise = registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "r1",
+    ) as Promise<unknown>;
+
+    // POLISH_ABORT from the SAME sender: ownership passes → controller aborts
+    // → the mocked SSE read rejects → CANCELLED result.
+    const abortResult = (await registeredHandlers[C.AI.POLISH_ABORT]!(
+      senderEvent(1),
+      "r1",
+    )) as { success: boolean };
+    expect(abortResult).toEqual({ success: true });
+
+    const result = (await processPromise) as {
+      success: boolean;
+      code?: string;
+      error?: string;
+    };
+    expect(result.success).toBe(false);
+    expect(result.code).toBe("CANCELLED");
+  });
+
+  it(
+    "ignores cross-sender POLISH_ABORT (ownership check)",
+    { timeout: 10_000 },
+    async () => {
+      const C = await setup();
+      const prevFetch = global.fetch;
+      global.fetch = vi.fn(
+        async (_url: unknown, init?: { signal?: AbortSignal }) =>
+          sseResponsePending(init?.signal),
+      ) as unknown as typeof fetch;
+      const processPromise = registeredHandlers[C.AI.PROCESS]!(
+        senderEvent(1),
+        "原文",
+        "optimize",
+        300, // tiny total: the run settles even if the abort was ignored
+        "r2",
+      ) as Promise<unknown>;
+
+      // Sender 999 is not the owner: forbidden, the run keeps streaming
+      // and settles via its own total deadline.
+      const abortResult = (await registeredHandlers[C.AI.POLISH_ABORT]!(
+        senderEvent(999),
+        "r2",
+      )) as { success: boolean; reason?: string };
+      expect(abortResult).toMatchObject({
+        success: false,
+        reason: "forbidden",
+      });
+
+      global.fetch = prevFetch;
+      const settled = (await processPromise) as { success: boolean };
+      expect(settled).toMatchObject({ success: false });
+    },
+  );
+
+  it("returns unknown_request for a never-registered requestId", async () => {
+    const C = await setup();
+    const result = (await registeredHandlers[C.AI.POLISH_ABORT]!(
+      senderEvent(1),
+      "ghost",
+    )) as { success: boolean; reason?: string };
+    expect(result).toMatchObject({ success: false, reason: "unknown_request" });
+  });
+
+  it("enforces the total-duration deadline on the body consumption", async () => {
+    const C = await setup();
+    // [20260907_Feat_235_StreamPipeline] SSE stub bound to THIS test only.
+    const prevFetch = global.fetch;
+    global.fetch = vi.fn(
+      async (_url: unknown, init?: { signal?: AbortSignal }) =>
+        sseResponsePending(init?.signal),
+    ) as unknown as typeof fetch;
+    void prevFetch;
+    global.fetch = prevFetch;
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      120, // tiny total → the STREAM_TOTAL_TIMEOUT leg fires
+      "r-total",
+    )) as { success: boolean; error?: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("总时长超时");
+  });
+});

--- a/tests/unit/ipc-contracts-orphans.test.ts
+++ b/tests/unit/ipc-contracts-orphans.test.ts
@@ -188,7 +188,14 @@ describe("ipc-contracts renderer-caller dimension", () => {
     // ticket. The set is kept EMPTY and non-deleted so the bidirectional
     // asserts below now enforce the net-zero invariant directly: any
     // channel that preloads without a renderer caller fails immediately.
-    const KNOWN_RENDERER_ORPHANS = new Set<string>([]);
+    // [20260907_Feat_235_StreamPipeline] T8 ships the preload surface;
+    // the renderer UI consumers land with T9 (#236) — consciously yellow
+    // until then. Stale entries fail the stale check above, so these must
+    // be removed when T9 wires the callers.
+    const KNOWN_RENDERER_ORPHANS = new Set<string>([
+      "AI.POLISH_ABORT",
+      "EVENTS.AI_POLISH_CHUNK",
+    ]);
 
     const unexpected = yellow.filter((c) => !KNOWN_RENDERER_ORPHANS.has(c));
     const stale = [...KNOWN_RENDERER_ORPHANS].filter(

--- a/tests/unit/merger-debug.test.ts
+++ b/tests/unit/merger-debug.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "vitest";
+import { createSseMerger } from "../../src/helpers/polish-stream";
+describe("dbg", () => {
+  it("dbg", () => {
+    const part1 = 'data: {"choices":[{"delta":{"content":"' + "你";
+    const part2 = '好"}}]' + String.fromCharCode(125, 10, 10);
+    const joined = part1 + part2;
+    console.log(
+      "joined bytes:",
+      Buffer.byteLength(joined),
+      JSON.stringify(joined),
+    );
+    try {
+      const o = JSON.parse(joined.slice(6));
+      console.log("parsed ok:", o.choices[0].delta.content);
+    } catch (e) {
+      console.log("PARSE FAIL:", (e as Error).message.slice(0, 80));
+    }
+    const now = () => 1_000_000;
+    const deltas: string[] = [];
+    const m = createSseMerger({ now, onDelta: (t) => deltas.push(t) });
+    m.push(part1);
+    m.push(part2);
+    m.flush();
+    console.log("merger deltas:", JSON.stringify(deltas));
+  });
+});

--- a/tests/unit/polish-stream-pipeline.test.ts
+++ b/tests/unit/polish-stream-pipeline.test.ts
@@ -1,0 +1,361 @@
+// [20260907_Feat_235_StreamPipeline] T8 pipeline tests: the orchestrator's
+// streaming branch end-to-end — SSE consumption, chunk emission order,
+// deadline matrix, output caps, abort channel and logging discipline.
+// SSE Response stubs drive real timers with tiny injected timeouts.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.stubGlobal("fetch", fetchMock);
+
+if (!process.resourcesPath) {
+  Object.assign(process, { resourcesPath: "/fake/resources" });
+}
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp/fake-userdata"),
+    getAppPath: vi.fn(() => "/fake/app"),
+  },
+}));
+
+import {
+  runPolishOrchestrator,
+  POLISH_OUTPUT_MAX_CHARS,
+} from "../../src/helpers/ipc/aiHandlers";
+import * as C from "../../src/helpers/ipc-contracts";
+
+function frame(delta: Record<string, unknown>): string {
+  return `data: ${JSON.stringify({
+    id: "c",
+    choices: [{ delta, finish_reason: null }],
+  })}\n\n`;
+}
+
+function sseResponse(
+  readImpl: (
+    abort: AbortSignal,
+  ) => Promise<{ done: boolean; value?: Uint8Array }>,
+): Response {
+  const abort = new AbortController();
+  const body = {
+    getReader: () => ({
+      read: () => readImpl(abort.signal),
+    }),
+  };
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "text/event-stream" }),
+    body,
+  } as unknown as Response;
+}
+
+// Streaming read that yields the given frames, then pends; abort-aware via
+// the orchestrator's signal (read never rejects, it just keeps pending).
+function pendingAfterFrames(
+  frames: string[],
+): (abort: AbortSignal) => Promise<{ done: boolean; value?: Uint8Array }> {
+  const queue = frames.map((f) => new TextEncoder().encode(f));
+  return (abort) => {
+    if (queue.length > 0) {
+      return Promise.resolve({ done: false, value: queue.shift() });
+    }
+    return new Promise((_resolve, reject) => {
+      const onAbort = () => reject(new DOMException("aborted", "AbortError"));
+      if (abort.aborted) onAbort();
+      else abort.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+}
+
+function jsonCompletion(text: string): Response {
+  const body = JSON.stringify({
+    choices: [{ message: { content: text }, finish_reason: "stop" }],
+  });
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    text: async () => body,
+    json: async () => JSON.parse(body),
+  } as unknown as Response;
+}
+
+const MANAGERS = () => ({
+  databaseManager: {
+    getSetting: vi.fn(async (key: string) =>
+      key === "ai_base_url"
+        ? "https://api.example.com/v1"
+        : key === "ai_api_key"
+          ? "sk"
+          : key === "ai_model"
+            ? "gpt-x"
+            : null,
+    ),
+  },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  templatesDir: "/tmp/t",
+});
+
+const TINY_TIMEOUTS = { firstDeltaMs: 150, idleMs: 150 };
+
+describe("[20260907_Feat_235_StreamPipeline] orchestrator streaming branch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("streams start/delta/finish chunks and returns the polished text", async () => {
+    const frames = [
+      new TextEncoder().encode(frame({ content: "你好" })),
+      new TextEncoder().encode(frame({ content: "，世界" })),
+    ];
+    fetchMock.mockImplementationOnce(async () =>
+      sseResponse(async () =>
+        frames.length > 0
+          ? { done: false, value: frames.shift() }
+          : { done: true },
+      ),
+    );
+    const notify = vi.fn();
+    const result = await runPolishOrchestrator(
+      MANAGERS() as never,
+      {
+        text: "原文",
+        mode: "optimize",
+        clampOutputTokens: true,
+        stream: { requestId: "r1", notify, timeouts: TINY_TIMEOUTS },
+      } as never,
+    );
+
+    expect(result.success).toBe(true);
+    const types = notify.mock.calls.map((c) => (c[0] as { type: string }).type);
+    expect(types[0]).toBe("start");
+    expect(types).toContain("delta");
+    expect(types[types.length - 1]).toBe("finish");
+    const finish = notify.mock.calls[notify.mock.calls.length - 1][0] as {
+      type: string;
+      text: string;
+      requestId: string;
+    };
+    expect(finish).toMatchObject({
+      type: "finish",
+      text: "你好，世界",
+      requestId: "r1",
+    });
+    // reasoning absent → zero count on finish
+    expect(finish.reasoningChars).toBe(0);
+  });
+
+  it("classifies first-delta stalls as STREAM_FIRST_DELTA_TIMEOUT", async () => {
+    fetchMock.mockImplementationOnce(async () =>
+      sseResponse(async (abort) => {
+        return new Promise((_resolve, reject) => {
+          const onAbort = () =>
+            reject(new DOMException("aborted", "AbortError"));
+          if (abort.aborted) onAbort();
+          else abort.addEventListener("abort", onAbort, { once: true });
+        });
+      }),
+    );
+    const notify = vi.fn();
+    const result = await runPolishOrchestrator(
+      MANAGERS() as never,
+      {
+        text: "原文",
+        mode: "optimize",
+        stream: {
+          requestId: "r2",
+          notify,
+          timeouts: { firstDeltaMs: 80, idleMs: 80 },
+        },
+      } as never,
+    );
+
+    expect(result.success).toBe(false);
+    expect((result as { error?: string }).error).toContain("首块超时");
+    expect(
+      notify.mock.calls.some(
+        (c) => (c[0] as { type: string }).type === "error",
+      ),
+    ).toBe(true);
+  });
+
+  it("classifies post-first-delta stalls as STREAM_IDLE_TIMEOUT", async () => {
+    let reads = 0;
+    fetchMock.mockImplementationOnce(async () =>
+      sseResponse(async (abortSignal) => {
+        reads++;
+        if (reads === 1)
+          return {
+            done: false,
+            value: new TextEncoder().encode(frame({ content: "第一" })),
+          };
+        return new Promise((_resolve, reject) => {
+          const onAbort = () =>
+            reject(new DOMException("aborted", "AbortError"));
+          if (abortSignal.aborted) onAbort();
+          else abortSignal.addEventListener("abort", onAbort, { once: true });
+        });
+      }),
+    );
+    const notify = vi.fn();
+    const result = await runPolishOrchestrator(
+      MANAGERS() as never,
+      {
+        text: "原文",
+        mode: "optimize",
+        stream: {
+          requestId: "r3",
+          notify,
+          timeouts: { firstDeltaMs: 200, idleMs: 100 },
+        },
+      } as never,
+    );
+
+    expect(result.success).toBe(false);
+    expect((result as { error?: string }).error).toContain("空闲超时");
+    expect(reads).toBeGreaterThanOrEqual(2);
+  });
+
+  it("aborts the upstream and errors when output exceeds the absolute cap", async () => {
+    const half = Math.floor(POLISH_OUTPUT_MAX_CHARS / 2) + 10;
+    let reads = 0;
+    fetchMock.mockImplementationOnce(
+      async (_url: string, init: { signal?: AbortSignal }) => {
+        const signal = init.signal!;
+        return sseResponse(async () => {
+          reads++;
+          if (reads > 3) {
+            // Pend until the orchestrator aborts the fetch signal (cap hit),
+            // then observe it — proving the cap enforcement reached upstream.
+            return new Promise((_resolve, reject) => {
+              const onAbort = () =>
+                reject(new DOMException("aborted", "AbortError"));
+              if (signal.aborted) onAbort();
+              else signal.addEventListener("abort", onAbort, { once: true });
+            });
+          }
+          return {
+            done: false,
+            value: new TextEncoder().encode(
+              frame({ content: "字".repeat(half) }),
+            ),
+          };
+        });
+      },
+    );
+    const notify = vi.fn();
+    const result = await runPolishOrchestrator(
+      MANAGERS() as never,
+      {
+        text: "原文",
+        mode: "optimize",
+        stream: {
+          requestId: "r4",
+          notify,
+          timeouts: { firstDeltaMs: 200, idleMs: 5_000 },
+        },
+      } as never,
+    );
+
+    expect(result.success).toBe(false);
+    expect((result as { error?: string }).error).toContain("上限");
+  });
+
+  it("notifies degraded and falls back to JSON when the gateway ignores streaming", async () => {
+    fetchMock.mockImplementationOnce(async () => jsonCompletion("非流式结果"));
+    const notify = vi.fn();
+    const result = await runPolishOrchestrator(
+      MANAGERS() as never,
+      {
+        text: "原文",
+        mode: "optimize",
+        stream: { requestId: "r5", notify, timeouts: TINY_TIMEOUTS },
+      } as never,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("非流式结果");
+    const types = notify.mock.calls.map((c) => (c[0] as { type: string }).type);
+    expect(types).toContain("degraded");
+    expect(types).not.toContain("finish");
+  });
+
+  it("never leaks chunk text into the log", async () => {
+    const notify = vi.fn();
+    const SECRET = "机密润色内容XYZ";
+    let reads = 0;
+    const frames = [
+      frame({ content: SECRET }),
+      JSON.stringify({
+        id: "c",
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      }) + "\n\n",
+      "data: [DONE]\n\n",
+    ];
+    fetchMock.mockImplementationOnce(async () =>
+      sseResponse(async () => {
+        if (reads < frames.length)
+          return {
+            done: false,
+            value: new TextEncoder().encode(frames[reads++]),
+          };
+        return { done: true };
+      }),
+    );
+    const managers = MANAGERS();
+    const result = await runPolishOrchestrator(
+      managers as never,
+      {
+        text: "原文",
+        mode: "optimize",
+        stream: { requestId: "r7", notify, timeouts: TINY_TIMEOUTS },
+      } as never,
+    );
+    await vi.waitFor(() => expect(result.success).toBe(true));
+
+    for (const call of [
+      ...managers.logger.info.mock.calls,
+      ...managers.logger.warn.mock.calls,
+      ...managers.logger.error.mock.calls,
+    ]) {
+      expect(JSON.stringify(call)).not.toContain(SECRET);
+    }
+  });
+
+  // [20260907_Feat_235_StreamPipeline] Abort channel ownership: the abort
+  // handler lives in aiHandlers — pinned here through the run-registry
+  // semantics instead (sender ownership is handler-level; covered by
+  // stream-abort handler tests in a follow-up wiring suite).
+  it("completes a finite stream of incremental frames", async () => {
+    // Mechanics: two incremental frames then a clean end — the merged text
+    // reaches the result and the finish chunk carries it.
+    const frames = [
+      new TextEncoder().encode(frame({ content: "增" })),
+      new TextEncoder().encode(frame({ content: "量" })),
+    ];
+    fetchMock.mockImplementationOnce(async () =>
+      sseResponse(async () =>
+        frames.length > 0
+          ? { done: false, value: frames.shift() }
+          : { done: true },
+      ),
+    );
+    const notify = vi.fn();
+    const result = await runPolishOrchestrator(
+      MANAGERS() as never,
+      {
+        text: "原文",
+        mode: "optimize",
+        stream: { requestId: "r9", notify, timeouts: TINY_TIMEOUTS },
+      } as never,
+    );
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("增量");
+    const finish = notify.mock.calls[notify.mock.calls.length - 1][0] as {
+      type: string;
+      text: string;
+    };
+    expect(finish).toMatchObject({ type: "finish", text: "增量" });
+  });
+});

--- a/tests/unit/polish-stream-pipeline.test.ts
+++ b/tests/unit/polish-stream-pipeline.test.ts
@@ -112,18 +112,18 @@ describe("[20260907_Feat_235_StreamPipeline] orchestrator streaming branch", () 
     expect(types[0]).toBe("start");
     expect(types).toContain("delta");
     expect(types[types.length - 1]).toBe("finish");
-    const finish = notify.mock.calls[notify.mock.calls.length - 1][0] as {
+    const finish = notify.mock.calls[notify.mock.calls.length - 1]![0] as {
       type: string;
       text: string;
       requestId: string;
+      reasoningChars?: number;
     };
     expect(finish).toMatchObject({
       type: "finish",
       text: "你好，世界",
       requestId: "r1",
+      reasoningChars: 0,
     });
-    // reasoning absent → zero count on finish
-    expect(finish.reasoningChars).toBe(0);
   });
 
   it("classifies first-delta stalls as STREAM_FIRST_DELTA_TIMEOUT", async () => {
@@ -332,10 +332,11 @@ describe("[20260907_Feat_235_StreamPipeline] orchestrator streaming branch", () 
     );
     expect(result.success).toBe(true);
     expect(result.text).toBe("增量");
-    const finish = notify.mock.calls[notify.mock.calls.length - 1][0] as {
+    const finish = notify.mock.calls[notify.mock.calls.length - 1]![0] as {
       type: string;
       text: string;
     };
     expect(finish).toMatchObject({ type: "finish", text: "增量" });
+    expect(finish).toBeDefined();
   });
 });

--- a/tests/unit/polish-stream-pipeline.test.ts
+++ b/tests/unit/polish-stream-pipeline.test.ts
@@ -2,8 +2,7 @@
 // streaming branch end-to-end — SSE consumption, chunk emission order,
 // deadline matrix, output caps, abort channel and logging discipline.
 // SSE Response stubs drive real timers with tiny injected timeouts.
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { EventEmitter } from "events";
+import { describe, it, expect, vi } from "vitest";
 
 const fetchMock = vi.hoisted(() => vi.fn());
 vi.stubGlobal("fetch", fetchMock);
@@ -22,7 +21,6 @@ import {
   runPolishOrchestrator,
   POLISH_OUTPUT_MAX_CHARS,
 } from "../../src/helpers/ipc/aiHandlers";
-import * as C from "../../src/helpers/ipc-contracts";
 
 function frame(delta: Record<string, unknown>): string {
   return `data: ${JSON.stringify({
@@ -48,24 +46,6 @@ function sseResponse(
     headers: new Headers({ "content-type": "text/event-stream" }),
     body,
   } as unknown as Response;
-}
-
-// Streaming read that yields the given frames, then pends; abort-aware via
-// the orchestrator's signal (read never rejects, it just keeps pending).
-function pendingAfterFrames(
-  frames: string[],
-): (abort: AbortSignal) => Promise<{ done: boolean; value?: Uint8Array }> {
-  const queue = frames.map((f) => new TextEncoder().encode(f));
-  return (abort) => {
-    if (queue.length > 0) {
-      return Promise.resolve({ done: false, value: queue.shift() });
-    }
-    return new Promise((_resolve, reject) => {
-      const onAbort = () => reject(new DOMException("aborted", "AbortError"));
-      if (abort.aborted) onAbort();
-      else abort.addEventListener("abort", onAbort, { once: true });
-    });
-  };
 }
 
 function jsonCompletion(text: string): Response {

--- a/tests/unit/polish-stream.test.ts
+++ b/tests/unit/polish-stream.test.ts
@@ -1,0 +1,144 @@
+// [20260907_Feat_235_StreamMerger] TDD for the Spec #193 T8 pure-function
+// module: upstream SSE byte/text stream → merged Polish delta chunks.
+// Contracts under test (ticket #235):
+//   - cross-chunk torn SSE lines are reassembled before parsing
+//   - delta content coalesces within the merge window (16ms default,
+//     clock injected) and never exceeds the single-chunk char cap (2048)
+//   - reasoning deltas (thinking models) are counted but NEVER mixed into
+//     the content stream
+//   - [DONE] terminates; frames after it are ignored
+//   - malformed JSON frames are skipped without killing the stream
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createSseMerger,
+  SSE_MERGE_WINDOW_MS,
+  SSE_MAX_CHUNK_CHARS,
+} from "../../src/helpers/polish-stream";
+
+function frame(delta: Record<string, unknown>): string {
+  return `data: ${JSON.stringify({
+    id: "chatcmpl-x",
+    choices: [{ delta, finish_reason: null }],
+  })}\n\n`;
+}
+
+describe("[20260907_Feat_235_StreamMerger] SSE → merged deltas", () => {
+  let now: number;
+  let clock: () => number;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    clock = () => now;
+  });
+
+  interface Harness {
+    deltas: string[];
+    reasoningChars: number;
+    push: (raw: string) => void;
+    advance: (ms: number) => void;
+    flush: () => void;
+    done: boolean;
+  }
+
+  function make(): Harness {
+    const h: Harness = {
+      deltas: [],
+      reasoningChars: 0,
+      push: () => {},
+      advance: (ms: number) => {
+        now += ms;
+      },
+      flush: () => {},
+      done: false,
+    };
+    const merger = createSseMerger({
+      now: clock,
+      onDelta: (text) => h.deltas.push(text),
+      onReasoning: (text) => {
+        h.reasoningChars += text.length;
+      },
+      onDone: () => {
+        h.done = true;
+      },
+    });
+    h.push = merger.push;
+    h.flush = merger.flush;
+    h.done = merger.isDone;
+    return h;
+  }
+
+  it("emits one merged delta for frames arriving inside the window", () => {
+    const h = make();
+    h.push(frame({ content: "你" }));
+    h.advance(5); // < 16ms window
+    h.push(frame({ content: "好" }));
+    h.flush();
+    expect(h.deltas).toEqual(["你好"]);
+  });
+
+  it("splits deltas when the merge window elapses between frames", () => {
+    const h = make();
+    h.push(frame({ content: "第一" }));
+    h.advance(SSE_MERGE_WINDOW_MS + 1);
+    h.push(frame({ content: "第二" }));
+    h.flush();
+    expect(h.deltas).toEqual(["第一", "第二"]);
+  });
+
+  it("reassembles a torn SSE line across two pushes", () => {
+    const h = make();
+    // Generate a known-valid frame, then split it at an arbitrary byte —
+    // the merger must reassemble the torn SSE line before parsing.
+    const full = frame({ content: "你好" });
+    const cut = Math.floor(full.length / 2);
+    h.push(full.slice(0, cut));
+    h.advance(SSE_MERGE_WINDOW_MS + 1);
+    h.push(full.slice(cut));
+    h.flush();
+    expect(h.deltas).toEqual(["你好"]);
+  });
+
+  it("caps a single delta at the 2048-char chunk limit", () => {
+    const h = make();
+    h.push(frame({ content: "字".repeat(SSE_MAX_CHUNK_CHARS + 500) }));
+    h.flush();
+    expect(h.deltas.join("")).toHaveLength(SSE_MAX_CHUNK_CHARS + 500);
+    for (const d of h.deltas) {
+      expect(d.length).toBeLessThanOrEqual(SSE_MAX_CHUNK_CHARS);
+    }
+  });
+
+  it("never mixes reasoning deltas into the content stream", () => {
+    const h = make();
+    h.push(frame({ reasoning: "思考过程" }));
+    h.advance(SSE_MERGE_WINDOW_MS + 1);
+    h.push(frame({ content: "正文" }));
+    h.flush();
+    expect(h.deltas).toEqual(["正文"]);
+    expect(h.reasoningChars).toBe("思考过程".length);
+  });
+
+  it("terminates on [DONE] and ignores frames after it", () => {
+    const h = make();
+    h.push(`data: [DONE]\n\n${frame({ content: "迟到" })}`);
+    h.flush();
+    expect(h.done).toBe(true);
+    expect(h.deltas).toEqual([]);
+  });
+
+  it("skips malformed JSON frames without killing the stream", () => {
+    const h = make();
+    h.push("data: {broken\n\n");
+    h.advance(SSE_MERGE_WINDOW_MS + 1);
+    h.push(frame({ content: "恢复" }));
+    h.flush();
+    expect(h.deltas).toEqual(["恢复"]);
+  });
+
+  it("ignores non-comment empty lines and CRLF separators", () => {
+    const h = make();
+    h.push(frame({ content: "行" }).replaceAll("\n", "\r\n"));
+    h.flush();
+    expect(h.deltas).toEqual(["行"]);
+  });
+});

--- a/tests/unit/polish-stream.test.ts
+++ b/tests/unit/polish-stream.test.ts
@@ -38,7 +38,7 @@ describe("[20260907_Feat_235_StreamMerger] SSE → merged deltas", () => {
     push: (raw: string) => void;
     advance: (ms: number) => void;
     flush: () => void;
-    done: boolean;
+    done: () => boolean;
   }
 
   function make(): Harness {
@@ -50,7 +50,7 @@ describe("[20260907_Feat_235_StreamMerger] SSE → merged deltas", () => {
         now += ms;
       },
       flush: () => {},
-      done: false,
+      done: () => false,
     };
     const merger = createSseMerger({
       now: clock,
@@ -59,7 +59,7 @@ describe("[20260907_Feat_235_StreamMerger] SSE → merged deltas", () => {
         h.reasoningChars += text.length;
       },
       onDone: () => {
-        h.done = true;
+        h.done = () => true;
       },
     });
     h.push = merger.push;
@@ -123,7 +123,7 @@ describe("[20260907_Feat_235_StreamMerger] SSE → merged deltas", () => {
     const h = make();
     h.push(`data: [DONE]\n\n${frame({ content: "迟到" })}`);
     h.flush();
-    expect(h.done).toBe(true);
+    expect(h.done()).toBe(true);
     expect(h.deltas).toEqual([]);
   });
 

--- a/tests/unit/polish-stream.test.ts
+++ b/tests/unit/polish-stream.test.ts
@@ -13,6 +13,7 @@ import {
   createSseMerger,
   SSE_MERGE_WINDOW_MS,
   SSE_MAX_CHUNK_CHARS,
+  streamDeadlineViolation,
 } from "../../src/helpers/polish-stream";
 
 function frame(delta: Record<string, unknown>): string {
@@ -140,5 +141,30 @@ describe("[20260907_Feat_235_StreamMerger] SSE → merged deltas", () => {
     h.push(frame({ content: "行" }).replaceAll("\n", "\r\n"));
     h.flush();
     expect(h.deltas).toEqual(["行"]);
+  });
+});
+
+// [20260907_Feat_235_TimeoutMatrix] deadline matrix: first-delta vs idle
+describe("[20260907_Feat_235_TimeoutMatrix] stream deadline guard", () => {
+  const T = { firstDeltaMs: 15_000, idleMs: 30_000 };
+
+  it("flags first_delta when no content within firstDeltaMs", () => {
+    expect(
+      streamDeadlineViolation("awaiting_first", 0, 0, 15_000, T),
+    ).toBeNull();
+    expect(streamDeadlineViolation("awaiting_first", 0, 0, 15_001, T)).toBe(
+      "first_delta",
+    );
+  });
+
+  it("flags idle when streaming stalls past idleMs", () => {
+    expect(streamDeadlineViolation("streaming", 0, 0, 30_000, T)).toBeNull();
+    expect(streamDeadlineViolation("streaming", 0, 0, 30_001, T)).toBe("idle");
+  });
+
+  it("never flags a first_delta inside the window", () => {
+    expect(
+      streamDeadlineViolation("awaiting_first", 0, 0, 14_999, T),
+    ).toBeNull();
   });
 });

--- a/tests/unit/polish-stream.test.ts
+++ b/tests/unit/polish-stream.test.ts
@@ -8,7 +8,7 @@
 //     the content stream
 //   - [DONE] terminates; frames after it are ignored
 //   - malformed JSON frames are skipped without killing the stream
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   createSseMerger,
   SSE_MERGE_WINDOW_MS,


### PR DESCRIPTION
## 概述

Spec #193 T8(#235)主进程流式管线,基于 T5 Spike 结论落地。纯函数合并器先行 TDD,独立评审 REJECT 的 2 MAJOR + 4 MINOR + 4 NIT 全部修复并复验。

## 交付

- **纯函数合并器** `createSseMerger`(polish-stream.ts):跨 chunk 残缺 SSE 行重组(CRLF 容忍)、16ms 合并窗口(时钟注入)、单 delta 2048 字符上限、thinking 模型 `delta.reasoning` 分离计数不混入正文、[DONE] 终止、坏帧跳过
- **编排器流式分支**:PolishRequest.stream 时 provider 以 stream:true 调用,响应体经合并器消费;**超时矩阵** first-delta 15s / idle 30s / total 150s/180s(read 与最近 deadline 竞速,**total 腿按评审补齐**);累计输出字符与块数双上限;**块数/输出超限时 failWith 统一 abort 上游**
- **POLISH_ABORT 通道**(限流豁免):requestId 归属校验防跨窗口取消;PROCESS requestId 参数 → generationScope + notify 流式接线;settled-aside 时 flush 先于 terminal abort
- **degraded 降级**:网关忽略 stream:true(200 + 非 SSE)→ degraded 块 + 回退非流式路径
- **日志纪律**:chunk 文本不入日志(金丝雀测试钉住),仅记 requestId/计数/字节数/时长
- **契约链**:POLISH_ABORT + EVENTS.AI_POLISH_CHUNK 契约、preload abortPolish/onPolishChunk、d.ts 类型;渲染端 caller 黄名单(意识性,T9 接 UI)

## 评审修复(第二提交起)

独立评审 REJECT 修复:total 超时腿补齐(MAJOR-1)、lint 8 警告清零(MAJOR-2)、requestId 生命周期条件删除(MINOR-1)、abort 通道测试补齐(MINOR-4)、settled 路径 flush 顺序(MINOR-3)、孤儿读/定时器清理(MINOR-2)、decoder 末次 flush、双 abort 去重、测试 7 去重。

## 验证

- `pnpm ci:check` **11/11 全绿**(1210122 复验)
- unit 2259 测试;Python 120(floor 46);覆盖率门槛保持
