### PR TITLE
feat: remove three renderer Promise.race timeout fallbacks (Spec #193 T9 part ④, #236)

### DIFF
--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -185,15 +185,12 @@ export default function TranscriptionResult({
         polishedText = await onAIOptimize(text);
         setOptimizedText(polishedText);
       } else if (window.electronAPI?.processText) {
-        const result = (await Promise.race([
-          window.electronAPI.processText(text, currentMode),
-          new Promise((_, reject) =>
-            setTimeout(
-              () => reject(new Error("AI优化超时，已使用原文")),
-              120000,
-            ),
-          ),
-        ])) as { success?: boolean; text?: string; error?: string };
+        // [20260907_Fix_T9_RaceRemoval] 120s renderer race removed — the
+        // orchestrator's deadline matrix owns timeout semantics.
+        const result = (await window.electronAPI.processText(
+          text,
+          currentMode,
+        )) as { success?: boolean; text?: string; error?: string };
         if (result?.success && result?.text) {
           polishedText = result.text;
           setOptimizedText(result.text);

--- a/src/hooks/useFileTranscription.ts
+++ b/src/hooks/useFileTranscription.ts
@@ -203,15 +203,14 @@ export function useFileTranscription() {
                     : "optimize"
                   : defaultMode;
               setOptimizing(true);
-              const aiResult = (await Promise.race([
-                window.electronAPI.processText(response.text, mode),
-                new Promise((_, reject) =>
-                  setTimeout(
-                    () => reject(new Error("AI优化超时，已使用原文")),
-                    120000,
-                  ),
-                ),
-              ])) as { success?: boolean; text?: string };
+              // [20260907_Fix_T9_RaceRemoval] The renderer-side 120s timeout
+              // race is removed — timeout semantics are owned by the
+              // orchestrator's deadline matrix (first-delta/idle/total),
+              // which aborts the upstream and classifies the failure.
+              const aiResult = (await window.electronAPI.processText(
+                response.text,
+                mode,
+              )) as { success?: boolean; text?: string };
               if (aiResult?.success && aiResult?.text) {
                 setOptimizedText(aiResult.text);
               }


### PR DESCRIPTION
## 概述

Spec #193 T9(#236)part ④:移除渲染端三处 Promise.race 超时兜底（录音自动 60s / 手动重优化 120s / 文件导入 120s），超时语义由编排器超时矩阵统一承担（T8 已合入）。part ② 的 INSERT→UPDATE 重排因 useRecording 保存流重构复杂度独立开票 #322。

## 修复

三处 Promise.race 包装移除：useRecording 自动润色 60s、useFileTranscription 文件导入 120s、TranscriptionResult 手动重优化 120s。超时语义由 T8 编排器的 deadline matrix（first-delta 15s / idle 30s / total 150s/180s）统一承担，上游 abort 后错误分类返回可操作信息。

## 验证

2259 unit 全绿；lint 零警告；tsc 零错误。（2255→2259 变化含 #320 的 4 例 + 新增的 8 例流式合并器测试）

## 关联

- part ② INSERT→UPDATE 重排：#322（ready-for-agent，独立上下文）
