### PR TITLE
feat: 渲染端流式体验 — 逐字渲染/取消按钮/文件导入块进度(Spec#193 T9 ①③, #236)

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -66,8 +66,12 @@ export const preloadApi: ElectronAPI = {
   downloadModels: () => ipcRenderer.invoke(C.MODELS.DOWNLOAD),
 
   // AI text processing
-  processText: (text: string, mode: string, timeout?: number) =>
-    ipcRenderer.invoke(C.AI.PROCESS, text, mode, timeout),
+  processText: (
+    text: string,
+    mode: string,
+    timeout?: number,
+    requestId?: string,
+  ) => ipcRenderer.invoke(C.AI.PROCESS, text, mode, timeout, requestId),
   checkAIStatus: (testConfig: unknown) =>
     ipcRenderer.invoke(C.AI.CHECK_STATUS, testConfig),
   // [20260907_Feat_233_ListModels] Provider model-list derivation (T6).

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 // failure; useTranslation routes the warning through i18n.
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+// [20260907_Feat_236_StreamingUi] T9 ①: streaming polish coordinator.
+import { usePolishStream } from "../hooks/usePolishStream";
 import { LoadingDots } from "./ui/loading-dots";
 import ExportPanel from "./ExportPanel";
 import ProcessingPanel from "./ProcessingPanel";
@@ -62,6 +64,9 @@ export default function TranscriptionResult({
 }: TranscriptionResultProps) {
   // [20260907_Fix_314_PolishSaveToast] i18n for the write-back failure toast.
   const { t } = useTranslation();
+  // [20260907_Feat_236_StreamingUi] T9 ①: streaming polish coordinator —
+  // owns chunk subscription, incremental delta state and the cancel channel.
+  const polishStream = usePolishStream();
   const [expandedSegment, setExpandedSegment] = React.useState<
     string | number | null
   >(null);
@@ -118,7 +123,10 @@ export default function TranscriptionResult({
 
   const hasSegments = segments && segments.length > 0;
 
-  const displayText = optimizedText || text || "";
+  // [20260907_Feat_236_StreamingUi] T9 ①: the in-flight stream renders in
+  // place of the text (deltas replace it word by word); once finished the
+  // optimized text takes over via optimizedText.
+  const displayText = optimizedText || polishStream.streamText || text || "";
   const displayRawText = rawText && rawText !== displayText ? rawText : null;
   const hasAIResult = displayRawText !== null;
 
@@ -170,6 +178,10 @@ export default function TranscriptionResult({
     }
   };
 
+  // [20260907_Feat_236_StreamingUi] T9 ①: cancel the in-flight streaming
+  // run; the abort chunk settles the run silently (no error surfaced).
+  const handleCancelPolish = polishStream.cancel;
+
   const handleAIOptimize = async () => {
     if (!text) return;
     setIsOptimizingInternal(true);
@@ -184,13 +196,32 @@ export default function TranscriptionResult({
         // (file import's aiReviewTranscription review-by-id).
         polishedText = await onAIOptimize(text);
         setOptimizedText(polishedText);
-      } else if (window.electronAPI?.processText) {
-        // [20260907_Fix_T9_RaceRemoval] 120s renderer race removed — the
-        // orchestrator's deadline matrix owns timeout semantics.
-        const result = (await window.electronAPI.processText(
-          text,
-          currentMode,
-        )) as { success?: boolean; text?: string; error?: string };
+      } else if (typeof window.electronAPI?.processText === "function") {
+        // [20260907_Feat_236_StreamingUi] T9 ①: streaming when the chunk
+        // channel exists; timeout semantics live in the orchestrator's
+        // deadline matrix (T8). A user cancel is silent.
+        const api = window.electronAPI;
+        const streamingCapable =
+          typeof api.onPolishChunk === "function" &&
+          typeof api.abortPolish === "function";
+        let result: {
+          success?: boolean;
+          text?: string;
+          error?: string;
+          cancelled?: boolean;
+        };
+        if (streamingCapable) {
+          result = await polishStream.start(api, text, currentMode);
+          if (result.cancelled) {
+            return; // silent user cancel — no error surfaced
+          }
+        } else {
+          result = (await api.processText(text, currentMode)) as {
+            success?: boolean;
+            text?: string;
+            error?: string;
+          };
+        }
         if (result?.success && result?.text) {
           polishedText = result.text;
           setOptimizedText(result.text);
@@ -277,7 +308,22 @@ export default function TranscriptionResult({
               </button>
             )}
           </div>
-          {showOptimizing ? (
+          {polishStream.isStreaming ? (
+            /* [20260907_Feat_236_StreamingUi] T9 ①: word-by-word rendering
+               with a cancel button; a user cancel is silent. */
+            <div className="space-y-2">
+              <p className="text-sm text-[#1d1d1d] dark:text-[#f5f5f7]/80 whitespace-pre-wrap">
+                {displayText}
+              </p>
+              <button
+                type="button"
+                onClick={handleCancelPolish}
+                className="px-3 py-1.5 text-xs font-medium text-[#ff5f57] hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+              >
+                {t("transcription.cancelPolish", "取消")}
+              </button>
+            </div>
+          ) : showOptimizing ? (
             <div className="flex items-center space-x-2 text-[#0071e3] dark:text-[#2997ff]">
               <LoadingDots />
               <span className="text-sm">AI正在优化文本...</span>

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -229,7 +229,15 @@ export default function TranscriptionResult({
           // [20260815_Fix_AiEmptyContent] Surface the main-process error
           // (e.g. max_tokens exhausted by model reasoning) instead of a
           // generic message that hides the actionable cause.
-          setOptimizeError(result?.error || "AI处理失败，请重试");
+          // [20260907_Fix_236_Review] Hook sentinels map to localized text
+          // here (the hook layer carries no user-visible strings).
+          const machineError = result?.error;
+          const localizedError =
+            machineError === "STREAM_INVOKE_FAILED"
+              ? t("transcription.polishInvokeFailed", "AI处理失败，请重试")
+              : machineError ||
+                t("transcription.polishFailed", "AI处理失败，请重试");
+          setOptimizeError(localizedError);
         }
       } else if (onAIOptimize) {
         const result = await onAIOptimize(text);

--- a/src/electronAPI.d.ts
+++ b/src/electronAPI.d.ts
@@ -65,6 +65,7 @@ export interface ElectronAPI {
     text: string,
     mode: string,
     timeout?: number,
+    requestId?: string,
   ) => Promise<AIProcessResult>;
   checkAIStatus: (testConfig?: {
     ai_api_key?: string;

--- a/src/hooks/useFileTranscription.ts
+++ b/src/hooks/useFileTranscription.ts
@@ -1,4 +1,6 @@
 import * as React from "react";
+// [20260907_Feat_236_StreamingUi] T9 ③: chunk-progress coordinator.
+import { usePolishStream } from "./usePolishStream";
 
 // [20260905_Feat_BloubFileLift] exported so App/lib can map file state to the
 // bot mascot without redefining the union
@@ -48,6 +50,9 @@ export function useFileTranscription() {
   const [error, setError] = React.useState<string | null>(null);
   const [isOptimizing, setOptimizing] = React.useState(false);
   const [optimizedText, setOptimizedText] = React.useState<string | null>(null);
+  // [20260907_Feat_236_StreamingUi] T9 ③: streaming polish coordinator —
+  // exposes chunk progress (bytes) for the file-import optimizing UI.
+  const polishStream = usePolishStream();
   const progressCleanup = React.useRef<(() => void) | null>(null);
 
   const cleanupProgress = () => {
@@ -180,7 +185,12 @@ export function useFileTranscription() {
         setState("done");
 
         // 触发AI处理（如果启用）
-        if (window.electronAPI?.processText && window.electronAPI?.getSetting) {
+        // [20260907_Feat_236_StreamingUi] Boolean() wrappers keep the runtime
+        // truthiness semantics without tripping TS2774 on the optional chain.
+        if (
+          Boolean(window.electronAPI?.processText) &&
+          Boolean(window.electronAPI?.getSetting)
+        ) {
           try {
             const defaultMode = (await window.electronAPI.getSetting(
               "default_mode",
@@ -203,14 +213,25 @@ export function useFileTranscription() {
                     : "optimize"
                   : defaultMode;
               setOptimizing(true);
-              // [20260907_Fix_T9_RaceRemoval] The renderer-side 120s timeout
-              // race is removed — timeout semantics are owned by the
-              // orchestrator's deadline matrix (first-delta/idle/total),
-              // which aborts the upstream and classifies the failure.
-              const aiResult = (await window.electronAPI.processText(
-                response.text,
-                mode,
-              )) as { success?: boolean; text?: string };
+              // [20260907_Feat_236_StreamingUi] T9 ③: consume the stream when
+              // the chunk channel exists — progress chunks surface as block
+              // progress; timeout semantics stay in the orchestrator (T8).
+              const api = window.electronAPI;
+              const streamingCapable =
+                Boolean(api.onPolishChunk) && Boolean(api.abortPolish);
+              let aiResult: { success?: boolean; text?: string };
+              if (streamingCapable) {
+                aiResult = (await polishStream.start(
+                  api,
+                  response.text,
+                  mode,
+                )) as { success?: boolean; text?: string };
+              } else {
+                aiResult = (await api.processText(response.text, mode)) as {
+                  success?: boolean;
+                  text?: string;
+                };
+              }
               if (aiResult?.success && aiResult?.text) {
                 setOptimizedText(aiResult.text);
               }
@@ -231,7 +252,10 @@ export function useFileTranscription() {
       setError((err as Error).message || "转录过程中出错");
       setState("error");
     }
-  }, [fileInfo]);
+    // [20260907_Fix_236_StreamingUi] polishStream.start is a stable
+    // useCallback; the ref-stable object satisfies exhaustive-deps without
+    // invalidating the transcription callback per render.
+  }, [fileInfo, polishStream]);
 
   const cancelTranscription = React.useCallback(async () => {
     try {
@@ -264,6 +288,8 @@ export function useFileTranscription() {
     result,
     error,
     isOptimizing,
+    polishChunkBytes: polishStream.streamBytes,
+    isPolishStreaming: polishStream.isStreaming,
     optimizedText,
     selectFile,
     selectFileFromPath,

--- a/src/hooks/usePolishStream.ts
+++ b/src/hooks/usePolishStream.ts
@@ -27,6 +27,7 @@ type StreamingApi = {
 
 export function usePolishStream() {
   const [streamText, setStreamText] = React.useState<string | null>(null);
+  const [streamBytes, setStreamBytes] = React.useState(0);
   const [isStreaming, setIsStreaming] = React.useState(false);
   const requestIdRef = React.useRef<string | null>(null);
   const abortRef = React.useRef<StreamingApi["abortPolish"] | null>(null);
@@ -34,7 +35,12 @@ export function usePolishStream() {
   const cancel = React.useCallback(() => {
     const id = requestIdRef.current;
     if (id && abortRef.current) {
-      void abortRef.current(id);
+      abortRef.current(id).catch((error) => {
+        // [20260907_Fix_236_Review] An abort IPC failure must not surface
+        // as an unhandled rejection — the run still settles via the
+        // orchestrator's deadline matrix.
+        console.warn("abortPolish failed:", error);
+      });
     }
   }, []);
 
@@ -47,11 +53,23 @@ export function usePolishStream() {
       text: string,
       mode: string,
     ): Promise<PolishResult> => {
-      const requestId = crypto.randomUUID();
+      // [20260907_Fix_236_Review] Guard against overlapping runs — checked
+      // BEFORE the ref is claimed: one coordinator, one live stream (the UI
+      // disables apply during a run; this makes it explicit at the boundary).
+      if (requestIdRef.current !== null) {
+        return { success: false, error: "STREAM_IN_FLIGHT" };
+      }
+      // [20260907_Fix_236_Review] jsdom lacks crypto.randomUUID — fall back
+      // to a time-based id (uniqueness within one window is sufficient).
+      const requestId =
+        typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `polish-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       requestIdRef.current = requestId;
       abortRef.current = api.abortPolish;
       setIsStreaming(true);
       setStreamText("");
+      setStreamBytes(0);
 
       return await new Promise<PolishResult>((resolve) => {
         let settled = false;
@@ -63,8 +81,11 @@ export function usePolishStream() {
           requestIdRef.current = null;
           abortRef.current = null;
           setIsStreaming(false);
-          if (result.success && result.text) setStreamText(null);
-          if (result.cancelled) setStreamText(null);
+          // [20260907_Fix_236_Review] Clear the stream on EVERY terminal
+          // outcome: a mid-stream error must not leave the truncated
+          // partial rendered as the user's transcription. Success hands
+          // over to optimizedText; cancel/error restore the original.
+          setStreamText(null);
           resolve(result);
         };
         const unsubscribe = api.onPolishChunk((chunk) => {
@@ -72,6 +93,17 @@ export function usePolishStream() {
           if (chunk.type === "delta" && chunk.text) {
             streamedSoFar += chunk.text;
             setStreamText(streamedSoFar);
+          } else if (chunk.type === "degraded") {
+            // [20260907_Fix_236_Review] Intentionally ignored here: the
+            // degraded run settles via the invoke's own JSON result (no
+            // finish chunk ever arrives); the static optimizing indicator
+            // keeps showing until then.
+          } else if (chunk.type === "progress") {
+            // [20260907_Feat_236_StreamingUi] T9 ③: block progress (bytes)
+            // for consumers without per-word rendering (file import).
+            setStreamBytes(
+              (prev) => prev + ((chunk as { bytes?: number }).bytes ?? 0),
+            );
           } else if (chunk.type === "finish") {
             settle({ success: true, text: chunk.text });
           } else if (chunk.type === "error") {
@@ -85,11 +117,32 @@ export function usePolishStream() {
           .then((invokeResult) => {
             settle(invokeResult as PolishResult);
           })
-          .catch(() => settle({ success: false, error: "AI处理失败，请重试" }));
+          .catch((error) => {
+            // [20260907_Fix_236_Review] Log the IPC-level cause, settle with
+            // a machine sentinel — the component maps it to an i18n message.
+            console.warn("streaming polish invoke failed:", error);
+            settle({ success: false, error: "STREAM_INVOKE_FAILED" });
+          });
       });
     },
     [],
   );
 
-  return { streamText, isStreaming, start, cancel };
+  // [20260907_Fix_236_Review] Unmount teardown: release the chunk listener
+  // and abort the orphaned run instead of letting it burn tokens until the
+  // deadline matrix kills it.
+  React.useEffect(() => {
+    return () => {
+      const id = requestIdRef.current;
+      requestIdRef.current = null;
+      abortRef.current = null;
+      if (id && window.electronAPI?.abortPolish) {
+        window.electronAPI.abortPolish(id).catch(() => {
+          // window torn down — nothing to abort
+        });
+      }
+    };
+  }, []);
+
+  return { streamText, streamBytes, isStreaming, start, cancel };
 }

--- a/src/hooks/usePolishStream.ts
+++ b/src/hooks/usePolishStream.ts
@@ -1,0 +1,95 @@
+// [20260907_Feat_236_StreamingUi] T9 ①: renderer-side streaming polish
+// coordinator (ticket #236). Owns the chunk subscription lifecycle so the
+// component stays declarative: subscribe BEFORE the invoke, incremental
+// delta state, settle on finish/error/abort, unsubscribe exactly once.
+// A user cancel is silent (no error surfaced — the run resolves
+// {cancelled:true}).
+import * as React from "react";
+import type { PolishChunk } from "../types/ipc";
+
+type PolishResult = {
+  success?: boolean;
+  text?: string;
+  error?: string;
+  cancelled?: boolean;
+};
+
+type StreamingApi = {
+  processText: (
+    text: string,
+    mode: string,
+    timeout?: number,
+    requestId?: string,
+  ) => Promise<unknown>;
+  onPolishChunk: (cb: (chunk: PolishChunk) => void) => () => void;
+  abortPolish: (requestId: string) => Promise<unknown>;
+};
+
+export function usePolishStream() {
+  const [streamText, setStreamText] = React.useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = React.useState(false);
+  const requestIdRef = React.useRef<string | null>(null);
+  const abortRef = React.useRef<StreamingApi["abortPolish"] | null>(null);
+
+  const cancel = React.useCallback(() => {
+    const id = requestIdRef.current;
+    if (id && abortRef.current) {
+      void abortRef.current(id);
+    }
+  }, []);
+
+  // Runs one streaming polish to completion. The listener is registered
+  // before the invoke and removed on the FIRST terminal chunk (or the
+  // invoke's own settlement for the degraded JSON path).
+  const start = React.useCallback(
+    async (
+      api: StreamingApi,
+      text: string,
+      mode: string,
+    ): Promise<PolishResult> => {
+      const requestId = crypto.randomUUID();
+      requestIdRef.current = requestId;
+      abortRef.current = api.abortPolish;
+      setIsStreaming(true);
+      setStreamText("");
+
+      return await new Promise<PolishResult>((resolve) => {
+        let settled = false;
+        let streamedSoFar = "";
+        const settle = (result: PolishResult) => {
+          if (settled) return;
+          settled = true;
+          unsubscribe();
+          requestIdRef.current = null;
+          abortRef.current = null;
+          setIsStreaming(false);
+          if (result.success && result.text) setStreamText(null);
+          if (result.cancelled) setStreamText(null);
+          resolve(result);
+        };
+        const unsubscribe = api.onPolishChunk((chunk) => {
+          if (chunk.requestId !== requestId) return;
+          if (chunk.type === "delta" && chunk.text) {
+            streamedSoFar += chunk.text;
+            setStreamText(streamedSoFar);
+          } else if (chunk.type === "finish") {
+            settle({ success: true, text: chunk.text });
+          } else if (chunk.type === "error") {
+            settle({ success: false, error: chunk.error });
+          } else if (chunk.type === "abort") {
+            settle({ success: false, cancelled: true });
+          }
+        });
+        api
+          .processText(text, mode, undefined, requestId)
+          .then((invokeResult) => {
+            settle(invokeResult as PolishResult);
+          })
+          .catch(() => settle({ success: false, error: "AI处理失败，请重试" }));
+      });
+    },
+    [],
+  );
+
+  return { streamText, isStreaming, start, cancel };
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -363,6 +363,7 @@
     "aboutDescription": "Free and open-source AI voice input tool"
   },
   "transcription": {
-    "polishSaveFailed": "Couldn't save the polished text — it will revert after restart"
+    "polishSaveFailed": "Couldn't save the polished text — it will revert after restart",
+    "cancelPolish": "Cancel"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -364,6 +364,8 @@
   },
   "transcription": {
     "polishSaveFailed": "Couldn't save the polished text — it will revert after restart",
-    "cancelPolish": "Cancel"
+    "cancelPolish": "Cancel",
+    "polishInvokeFailed": "AI processing failed, please retry",
+    "polishFailed": "AI processing failed, please retry"
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -364,6 +364,8 @@
   },
   "transcription": {
     "polishSaveFailed": "润色结果保存失败，重启后将显示原文本",
-    "cancelPolish": "取消"
+    "cancelPolish": "取消",
+    "polishInvokeFailed": "AI处理失败，请重试",
+    "polishFailed": "AI处理失败，请重试"
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -363,6 +363,7 @@
     "aboutDescription": "开源免费的 AI 语音输入工具"
   },
   "transcription": {
-    "polishSaveFailed": "润色结果保存失败，重启后将显示原文本"
+    "polishSaveFailed": "润色结果保存失败，重启后将显示原文本",
+    "cancelPolish": "取消"
   }
 }

--- a/tests/unit/fileImportController.test.tsx
+++ b/tests/unit/fileImportController.test.tsx
@@ -21,6 +21,8 @@ function stubController(
     error: null,
     isOptimizing: false,
     optimizedText: null,
+    polishChunkBytes: 0,
+    isPolishStreaming: false,
     selectFile: vi.fn(),
     selectFileFromPath: vi.fn(),
     startTranscription: vi.fn(),

--- a/tests/unit/ipc-contracts-orphans.test.ts
+++ b/tests/unit/ipc-contracts-orphans.test.ts
@@ -192,10 +192,9 @@ describe("ipc-contracts renderer-caller dimension", () => {
     // the renderer UI consumers land with T9 (#236) — consciously yellow
     // until then. Stale entries fail the stale check above, so these must
     // be removed when T9 wires the callers.
-    const KNOWN_RENDERER_ORPHANS = new Set<string>([
-      "AI.POLISH_ABORT",
-      "EVENTS.AI_POLISH_CHUNK",
-    ]);
+    // [20260907_Feat_236_StreamingUi] T9 ① wired abortPolish
+    // (usePolishStream.cancel) — removed from the conscious yellow list.
+    const KNOWN_RENDERER_ORPHANS = new Set<string>(["EVENTS.AI_POLISH_CHUNK"]);
 
     const unexpected = yellow.filter((c) => !KNOWN_RENDERER_ORPHANS.has(c));
     const stale = [...KNOWN_RENDERER_ORPHANS].filter(

--- a/tests/unit/preload-bridge-contract.test.ts
+++ b/tests/unit/preload-bridge-contract.test.ts
@@ -141,4 +141,24 @@ describe("preload bridge contract", () => {
 
     expect(invokeMock).toHaveBeenCalledTimes(10);
   });
+
+  // [20260907_Fix_236_Review] T9 ①: the streaming requestId MUST reach the
+  // main process — a dropped 4th argument makes streaming inert and the
+  // cancel button dead (review HIGH on #236).
+  it("processText forwards the requestId as the 4th invoke argument", () => {
+    const api = mockState.exposed.electronAPI as Record<
+      string,
+      (...args: unknown[]) => unknown
+    >;
+    const invokeMock = ipcRenderer.invoke as ReturnType<typeof vi.fn>;
+    invokeMock.mockClear();
+    api.processText!("hello", "optimize", undefined, "req-42");
+    expect(invokeMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "hello",
+      "optimize",
+      undefined,
+      "req-42",
+    );
+  });
 });

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -138,6 +138,8 @@ describe("TranscriptionResult — AI optimize paths", () => {
     await waitFor(() => {
       expect(screen.getByText("优化后文本")).toBeInTheDocument();
     });
+    // [20260907_Feat_236_StreamingUi] no chunk channel in this stub →
+    // non-streaming fallback: the classic two-argument invoke.
     expect(processText).toHaveBeenCalledWith("原始待优化", expect.any(String));
   });
 
@@ -659,5 +661,147 @@ describe("TranscriptionResult — polish write-back failure (#314)", () => {
     // Not wiped: the polished text stays on screen.
     expect(screen.getByText("润色后文本")).toBeInTheDocument();
     consoleSpy2.mockRestore();
+  });
+});
+
+// [20260907_Feat_236_StreamingUi] T9 ①: manual polish streams via
+// onPolishChunk (subscribe-before-invoke, unsubscribe on settle) and a
+// cancel button aborts via abortPolish — a user cancel shows NO error.
+describe("TranscriptionResult — streaming manual polish (#236 ①)", () => {
+  type Chunk = {
+    type: string;
+    requestId?: string;
+    text?: string;
+    reason?: string;
+    error?: string;
+  };
+  type TestWindow = Omit<Window, "electronAPI"> & {
+    electronAPI?: {
+      processText?: (
+        text: string,
+        mode: string,
+        timeout?: number,
+        requestId?: string,
+      ) => Promise<unknown>;
+      onPolishChunk?: (cb: (chunk: Chunk) => void) => () => void;
+      abortPolish?: (requestId: string) => Promise<unknown>;
+      updateTranscription?: (
+        id: number,
+        patch: Record<string, unknown>,
+      ) => Promise<unknown>;
+      getAIModes?: () => Promise<unknown[]>;
+    };
+  };
+
+  const originalAPI = (globalThis.window as unknown as TestWindow).electronAPI;
+  let chunkListener: ((chunk: Chunk) => void) | null = null;
+  let unsubSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    chunkListener = null;
+    unsubSpy = vi.fn(() => {});
+    (globalThis.window as unknown as TestWindow).electronAPI = {
+      processText: vi.fn(
+        () => new Promise(() => {}) /* pends until chunks drive it */,
+      ),
+      onPolishChunk: vi.fn((cb: (chunk: Chunk) => void) => {
+        chunkListener = cb;
+        return unsubSpy;
+      }),
+      abortPolish: vi.fn().mockResolvedValue({ success: true }),
+      updateTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, changes: 1 }),
+      getAIModes: vi
+        .fn()
+        .mockResolvedValue([
+          { name: "optimize", label: "智能润色", description: "" },
+        ]),
+    };
+  });
+
+  afterEach(() => {
+    const win = globalThis.window as unknown as TestWindow;
+    if (originalAPI === undefined) delete win.electronAPI;
+    else win.electronAPI = originalAPI;
+    vi.clearAllMocks();
+  });
+
+  function renderManual() {
+    return render(
+      React.createElement(TranscriptionResult, {
+        text: "原始文本",
+        onCopy: vi.fn(),
+      }),
+    );
+  }
+
+  it("renders streamed deltas incrementally before the finish", async () => {
+    renderManual();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+
+    // Subscribed BEFORE the invoke (no listener leak).
+    await vi.waitFor(() => {
+      expect(
+        (globalThis.window as unknown as TestWindow).electronAPI!.onPolishChunk,
+      ).toHaveBeenCalled();
+    });
+    const api = (globalThis.window as unknown as TestWindow).electronAPI!;
+    const requestId = (api.processText as ReturnType<typeof vi.fn>).mock
+      .calls[0]![3] as string;
+    expect(typeof requestId).toBe("string");
+
+    chunkListener!({ type: "start", requestId });
+    chunkListener!({ type: "delta", requestId, text: "流式" });
+    await screen.findByText("流式");
+    chunkListener!({ type: "delta", requestId, text: "文本" });
+    await screen.findByText("流式文本");
+  });
+
+  it("finish chunk replaces the stream with the final text and unsubscribes", async () => {
+    renderManual();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    await vi.waitFor(() => expect(chunkListener).not.toBeNull());
+    const api = (globalThis.window as unknown as TestWindow).electronAPI!;
+    const requestId = (api.processText as ReturnType<typeof vi.fn>).mock
+      .calls[0]![3] as string;
+
+    chunkListener!({ type: "delta", requestId, text: "部分" });
+    chunkListener!({
+      type: "finish",
+      requestId,
+      text: "最终润色结果",
+      reasoningChars: 0,
+    });
+
+    await screen.findByText("最终润色结果");
+    await vi.waitFor(() => expect(unsubSpy).toHaveBeenCalled());
+  });
+
+  it("cancel button aborts via abortPolish and shows no error", async () => {
+    renderManual();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    await vi.waitFor(() => expect(chunkListener).not.toBeNull());
+    const api = (globalThis.window as unknown as TestWindow).electronAPI!;
+    const requestId = (api.processText as ReturnType<typeof vi.fn>).mock
+      .calls[0]![3] as string;
+    chunkListener!({ type: "delta", requestId, text: "部分输出" });
+
+    const cancel = await screen.findByRole("button", { name: "取消" });
+    fireEvent.click(cancel);
+
+    await vi.waitFor(() => {
+      expect(api.abortPolish).toHaveBeenCalledWith(requestId);
+    });
+    // The abort chunk arrives; the UI must NOT surface an error.
+    chunkListener!({ type: "abort", requestId });
+    await vi.waitFor(() => expect(unsubSpy).toHaveBeenCalled());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -674,6 +674,7 @@ describe("TranscriptionResult — streaming manual polish (#236 ①)", () => {
     text?: string;
     reason?: string;
     error?: string;
+    reasoningChars?: number;
   };
   type TestWindow = Omit<Window, "electronAPI"> & {
     electronAPI?: {
@@ -706,7 +707,7 @@ describe("TranscriptionResult — streaming manual polish (#236 ①)", () => {
       ),
       onPolishChunk: vi.fn((cb: (chunk: Chunk) => void) => {
         chunkListener = cb;
-        return unsubSpy;
+        return unsubSpy as unknown as () => void;
       }),
       abortPolish: vi.fn().mockResolvedValue({ success: true }),
       updateTranscription: vi
@@ -803,5 +804,112 @@ describe("TranscriptionResult — streaming manual polish (#236 ①)", () => {
     chunkListener!({ type: "abort", requestId });
     await vi.waitFor(() => expect(unsubSpy).toHaveBeenCalled());
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});
+
+// [20260907_Fix_236_Review] Regression: a mid-stream ERROR must not leave
+// the truncated partial rendered as the transcription, and the invoke
+// rejection path surfaces a localized message.
+describe("TranscriptionResult — streaming error paths (#236 review)", () => {
+  type Chunk = {
+    type: string;
+    requestId?: string;
+    text?: string;
+    error?: string;
+    reasoningChars?: number;
+  };
+  type TestWindow = Omit<Window, "electronAPI"> & {
+    electronAPI?: {
+      processText?: (
+        text: string,
+        mode: string,
+        timeout?: number,
+        requestId?: string,
+      ) => Promise<unknown>;
+      onPolishChunk?: (cb: (chunk: Chunk) => void) => () => void;
+      abortPolish?: (requestId: string) => Promise<unknown>;
+      updateTranscription?: (
+        id: number,
+        patch: Record<string, unknown>,
+      ) => Promise<unknown>;
+      getAIModes?: () => Promise<unknown[]>;
+    };
+  };
+  const originalAPI = (globalThis.window as unknown as TestWindow).electronAPI;
+  let chunkListener: ((chunk: Chunk) => void) | null = null;
+  let unsubSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    chunkListener = null;
+    unsubSpy = vi.fn(() => {});
+    (globalThis.window as unknown as TestWindow).electronAPI = {
+      processText: vi.fn(() => new Promise(() => {})),
+      onPolishChunk: vi.fn((cb: (chunk: Chunk) => void) => {
+        chunkListener = cb;
+        return unsubSpy as unknown as () => void;
+      }),
+      abortPolish: vi.fn().mockResolvedValue({ success: true }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
+      getAIModes: vi
+        .fn()
+        .mockResolvedValue([
+          { name: "optimize", label: "智能润色", description: "" },
+        ]),
+    };
+  });
+
+  afterEach(() => {
+    const win = globalThis.window as unknown as TestWindow;
+    if (originalAPI === undefined) delete win.electronAPI;
+    else win.electronAPI = originalAPI;
+    vi.clearAllMocks();
+  });
+
+  it("restores the original text after a mid-stream error chunk", async () => {
+    render(
+      React.createElement(TranscriptionResult, {
+        text: "原始转写内容",
+        onCopy: vi.fn(),
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    await vi.waitFor(() => expect(chunkListener).not.toBeNull());
+    const api = (globalThis.window as unknown as TestWindow).electronAPI!;
+    const requestId = (api.processText as ReturnType<typeof vi.fn>).mock
+      .calls[0]![3] as string;
+
+    chunkListener!({ type: "delta", requestId, text: "被截断的部分" });
+    await screen.findByText("被截断的部分");
+    chunkListener!({ type: "error", requestId, error: "上游 500" });
+
+    // Original transcription restored; error surfaced; partial gone.
+    await vi.waitFor(() => {
+      expect(screen.getByText("原始转写内容")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("被截断的部分")).not.toBeInTheDocument();
+    expect(screen.getByText("上游 500")).toBeInTheDocument();
+    await vi.waitFor(() => expect(unsubSpy).toHaveBeenCalled());
+  });
+
+  it("maps the invoke-rejection sentinel to a localized message", async () => {
+    (globalThis.window as unknown as TestWindow).electronAPI!.processText = vi
+      .fn()
+      .mockRejectedValue(new Error("ipc gone"));
+    render(
+      React.createElement(TranscriptionResult, {
+        text: "原始转写内容",
+        onCopy: vi.fn(),
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("AI处理失败，请重试")).toBeInTheDocument();
+    });
+    expect(screen.getByText("原始转写内容")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概述

Spec #193 T9 ①③(#236):渲染端流式体验——手动润色逐字渲染 + 取消按钮(usePolishStream hook),文件导入消费 progress chunk 显示块进度。独立评审 REQUEST CHANGES 的 2 HIGH + 3 MEDIUM + 5 LOW 全部修复并复验。

## 交付

- **usePolishStream hook**:chunk 订阅生命周期唯一所有者——先订阅再 invoke、settle-exactly-once(finish/error/abort/invoke resolve/reject 五路归一)、保证解订;取消经 abortPolish,用户取消静默(T7 abort 语义);错误路径清空流文本(被截断的部分不会残留为用户转写);unmount teardown 解订 + abort 孤儿运行;并发 start 守卫;STREAM_INVOKE_FAILED 机器哨兵由组件映射为 i18n 文案
- **TranscriptionResult**:流式期间逐字渲染(displayText 接 streamText)+ 取消按钮(transcription.cancelPolish 双语);非流式回退保留(stub 无 chunk 通道时 2 参 invoke)
- **useFileTranscription**:文件导入 polish 窗口消费流式,progress chunk 累计为块字节进度(polishChunkBytes/isPolishStreaming 暴露给 UI)
- **契约**:processText +requestId 第 4 参(preload+d.ts),preload 转发有 bridge-contract 断言钉住;stale 的 POLISH_ABORT 渲染端黄名单条目按 orphans 测试自强制移除

## 评审修复(REJECT→复验)

HIGH-1 preload requestId 转发 hunk 漏提交(流式失活+取消死亡)→ 入库 + 转发断言;HIGH-2 错误路径残留截断流文本 → settle 全路径清空 + 2 例回归;MED unmount abort/abort rejection 处理/i18n 哨兵;LOW 守卫位置(修掉守卫在 ref 赋值后恒真的自锁 bug)、randomUUID jsdom 回退、degraded 忽略成文。

## 验证

ci:check 11/11;2265 unit 全绿;lint 0 警告;tsc 零错误。

## 关联

- T9 ② INSERT→UPDATE:#322 独立票
- T9 ④ race 移除:已合入(#323)
