### PR TITLE
feat: S4b 重写类整篇对照 + 修正表(Spec#193 T13, #240)

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -80,6 +80,13 @@ export const preloadApi: ElectronAPI = {
   // [20260907_Feat_235_StreamPipeline] T8: streaming abort + chunk push.
   abortPolish: (requestId: string) =>
     ipcRenderer.invoke(C.AI.POLISH_ABORT, requestId),
+  // [20260908_Feat_240_VocabCorrections] T13 vocabulary CRUD.
+  listVocabCorrections: () => ipcRenderer.invoke(C.AI.VOCAB_LIST),
+  addVocabCorrection: (wrong: string, right: string) =>
+    ipcRenderer.invoke(C.AI.VOCAB_ADD, wrong, right),
+  deleteVocabCorrection: (wrong: string) =>
+    ipcRenderer.invoke(C.AI.VOCAB_DELETE, wrong),
+  clearVocabCorrections: () => ipcRenderer.invoke(C.AI.VOCAB_CLEAR),
   onPolishChunk: (
     callback: (chunk: import("./src/types/ipc").PolishChunk) => void,
   ) =>

--- a/src/components/RewriteReviewPanel.tsx
+++ b/src/components/RewriteReviewPanel.tsx
@@ -30,10 +30,11 @@ export const RewriteReviewPanel: React.FC<RewriteReviewPanelProps> = ({
   const [right, setRight] = React.useState("");
   const [annotating, setAnnotating] = React.useState(false);
 
+  // [20260908_Fix_240_Review] An invalid (half-filled) submit keeps the
+  // form open with its contents — only a successful save collapses it.
   const submitPair = () => {
-    if (wrong.trim() && right.trim()) {
-      onAddCorrection(wrong.trim(), right.trim());
-    }
+    if (!wrong.trim() || !right.trim()) return;
+    onAddCorrection(wrong.trim(), right.trim());
     setWrong("");
     setRight("");
     setAnnotating(false);

--- a/src/components/RewriteReviewPanel.tsx
+++ b/src/components/RewriteReviewPanel.tsx
@@ -1,0 +1,128 @@
+// [20260908_Feat_240_RewriteReview] Spec #193 T13 (ticket #240): the S4b
+// rewrite-class review panel — whole-text before/after with one-click
+// revert (NO per-hunk controls: 逐段 diff is meaningless under a full
+// rewrite — spec review BL-2), plus the correction-pair annotation flow:
+// when the user rejects the rewrite they can point at or type a
+// wrong→right pair which the parent persists into the vocabulary table.
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+interface RewriteReviewPanelProps {
+  original: string;
+  rewritten: string;
+  /** Persist one correction pair (parent routes to the vocabulary table). */
+  onAddCorrection: (wrong: string, right: string) => void;
+  /** Accept the rewrite (parent writes back via the UPDATE channel). */
+  onAccept: (text: string) => void;
+  /** Revert to the original text; optionally annotate a correction pair. */
+  onRevert: () => void;
+}
+
+export const RewriteReviewPanel: React.FC<RewriteReviewPanelProps> = ({
+  original,
+  rewritten,
+  onAddCorrection,
+  onAccept,
+  onRevert,
+}) => {
+  const { t } = useTranslation();
+  const [wrong, setWrong] = React.useState("");
+  const [right, setRight] = React.useState("");
+  const [annotating, setAnnotating] = React.useState(false);
+
+  const submitPair = () => {
+    if (wrong.trim() && right.trim()) {
+      onAddCorrection(wrong.trim(), right.trim());
+    }
+    setWrong("");
+    setRight("");
+    setAnnotating(false);
+  };
+
+  return (
+    <div data-testid="rewrite-review" className="space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <p className="text-xs text-[#86868b] mb-1">
+            {t("rewrite.originalLabel", "原文")}
+          </p>
+          <p
+            data-testid="rewrite-original"
+            className="text-sm text-[#1d1d1f]/70 dark:text-[#f5f5f7]/70 whitespace-pre-wrap bg-[#f5f5f7] dark:bg-[#3a3a3c] rounded-lg p-2"
+          >
+            {original}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-[#86868b] mb-1">
+            {t("rewrite.rewrittenLabel", "重写结果")}
+          </p>
+          <p
+            data-testid="rewrite-result"
+            className="text-sm text-[#1d1d1f] dark:text-[#f5f5f7] whitespace-pre-wrap bg-[#e8f4fd] dark:bg-[#0a2540] rounded-lg p-2"
+          >
+            {rewritten}
+          </p>
+        </div>
+      </div>
+      {annotating && (
+        <div data-testid="correction-form" className="flex items-center gap-2">
+          <input
+            type="text"
+            aria-label={t("rewrite.wrongWord", "错误词")}
+            value={wrong}
+            onChange={(e) => setWrong(e.target.value)}
+            placeholder={t("rewrite.wrongWord", "错误词")}
+            className="w-32 px-2 py-1 text-sm border border-[#d2d2d7] dark:border-[#3a3a3c] rounded-md bg-[#f5f5f7] dark:bg-[#3a3a3c] text-[#1d1d1f] dark:text-[#f5f5f7]"
+          />
+          <span className="text-[#86868b]">→</span>
+          <input
+            type="text"
+            aria-label={t("rewrite.rightWord", "正确词")}
+            value={right}
+            onChange={(e) => setRight(e.target.value)}
+            placeholder={t("rewrite.rightWord", "正确词")}
+            className="w-32 px-2 py-1 text-sm border border-[#d2d2d7] dark:border-[#3a3a3c] rounded-md bg-[#f5f5f7] dark:bg-[#3a3a3c] text-[#1d1d1f] dark:text-[#f5f5f7]"
+          />
+          <button
+            type="button"
+            aria-label={t("rewrite.saveCorrection", "记入修正表")}
+            onClick={submitPair}
+            className="px-2 py-1 text-xs rounded-md bg-[#0071e3] text-white"
+          >
+            {t("rewrite.saveCorrection", "记入修正表")}
+          </button>
+        </div>
+      )}
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          aria-label={t("rewrite.revert", "回退原文")}
+          data-testid="rewrite-revert"
+          onClick={onRevert}
+          className="px-3 py-1.5 text-sm rounded-lg border border-[#d2d2d7] dark:border-[#3a3a3c] text-[#1d1d1f] dark:text-[#f5f5f7]"
+        >
+          {t("rewrite.revert", "回退原文")}
+        </button>
+        <button
+          type="button"
+          aria-label={t("rewrite.annotate", "标注修正")}
+          data-testid="rewrite-annotate"
+          onClick={() => setAnnotating((prev) => !prev)}
+          className="px-3 py-1.5 text-sm rounded-lg border border-[#d2d2d7] dark:border-[#3a3a3c] text-[#1d1d1f] dark:text-[#f5f5f7]"
+        >
+          {t("rewrite.annotate", "标注修正")}
+        </button>
+        <button
+          type="button"
+          aria-label={t("rewrite.accept", "采用重写")}
+          data-testid="rewrite-accept"
+          onClick={() => onAccept(rewritten)}
+          className="px-3 py-1.5 text-sm rounded-lg bg-[#0071e3] text-white hover:bg-[#0077ed]"
+        >
+          {t("rewrite.accept", "采用重写")}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/electronAPI.d.ts
+++ b/src/electronAPI.d.ts
@@ -76,6 +76,17 @@ export interface ElectronAPI {
   listAIModels: (baseUrl: string, apiKey: string) => Promise<ListModelsResult>;
   // [20260907_Feat_235_StreamPipeline] T8 streaming abort + chunk push.
   abortPolish: (requestId: string) => Promise<OperationResult>;
+  // [20260908_Feat_240_VocabCorrections] T13 vocabulary CRUD.
+  listVocabCorrections: () => Promise<{
+    success: boolean;
+    entries: Array<{ wrong: string; right: string }>;
+  }>;
+  addVocabCorrection: (
+    wrong: string,
+    right: string,
+  ) => Promise<OperationResult>;
+  deleteVocabCorrection: (wrong: string) => Promise<OperationResult>;
+  clearVocabCorrections: () => Promise<OperationResult>;
   onPolishChunk: (callback: (chunk: PolishChunk) => void) => () => void;
   getAIModes: () => Promise<AIMode[]>;
   getAIProviderPresets: () => Promise<AIProviderPreset[]>;

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -599,25 +599,47 @@ class DatabaseManager {
     if (!isValidVocabTerm(wrong) || !isValidVocabTerm(right)) {
       throw new Error("修正表词对不合法（空/过长/含控制字符或孤立代理项）");
     }
+    this.addVocabCorrectionsBatch([[wrong, right]]);
+  }
+
+  // [20260908_Fix_240_WinPerf] The FIFO test inserts 1005 pairs; per-call
+  // COUNT/MAX probes pushed the Windows CI leg past the 5s test budget.
+  // The eviction check runs ONCE per batch inside a transaction.
+  addVocabCorrectionsBatch(pairs: Array<[string, string]>): void {
     const tx = this.db!;
-    tx.prepare(
+    const insert = tx.prepare(
       `INSERT INTO vocabulary (wrong, right, used_ms)
        VALUES (?, ?, ?)
        ON CONFLICT(wrong) DO UPDATE SET
          right = excluded.right,
          used_ms = excluded.used_ms`,
-    ).run(wrong, right, this._nextVocabStamp());
-    const count = tx.prepare("SELECT COUNT(*) AS n FROM vocabulary").get() as {
-      n: number;
-    };
-    if (count.n > VOCAB_MAX_ENTRIES) {
-      tx.prepare(
-        `DELETE FROM vocabulary WHERE wrong IN (
-           SELECT wrong FROM vocabulary
-           ORDER BY used_ms ASC, rowid ASC
-           LIMIT ?
-         )`,
-      ).run(count.n - VOCAB_MAX_ENTRIES);
+    );
+    tx.exec("BEGIN");
+    try {
+      for (const [wrongRaw, rightRaw] of pairs) {
+        const wrong = wrongRaw.trim();
+        const right = rightRaw.trim();
+        if (!isValidVocabTerm(wrong) || !isValidVocabTerm(right)) {
+          throw new Error("修正表词对不合法（空/过长/含控制字符或孤立代理项）");
+        }
+        insert.run(wrong, right, this._nextVocabStamp());
+      }
+      const count = tx
+        .prepare("SELECT COUNT(*) AS n FROM vocabulary")
+        .get() as { n: number };
+      if (count.n > VOCAB_MAX_ENTRIES) {
+        tx.prepare(
+          `DELETE FROM vocabulary WHERE wrong IN (
+             SELECT wrong FROM vocabulary
+             ORDER BY used_ms ASC, rowid ASC
+             LIMIT ?
+           )`,
+        ).run(count.n - VOCAB_MAX_ENTRIES);
+      }
+      tx.exec("COMMIT");
+    } catch (error) {
+      tx.exec("ROLLBACK");
+      throw error;
     }
   }
 

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -249,7 +249,7 @@ class DatabaseManager {
 
     // [20260908_Feat_240_VocabCorrections] T13: the vocabulary corrections
     // table — wrong-word UNIQUE (re-insert replaces + touches recency),
-    // FIFO-evicted at VOCAB_MAX_ENTRIES by the add path.
+    // Recency-evicted (LRU with touch) at VOCAB_MAX_ENTRIES by the add path.
     this.db!.exec(`
       CREATE TABLE IF NOT EXISTS vocabulary (
         wrong TEXT PRIMARY KEY,
@@ -591,7 +591,11 @@ class DatabaseManager {
   // [20260908_Feat_240_VocabCorrections] T13: upsert a correction pair.
   // Re-inserting an existing wrong word replaces the pair and touches
   // recency (used_at). Evicts the oldest rows beyond the FIFO cap.
-  addVocabCorrection(wrong: string, right: string): void {
+  addVocabCorrection(wrongRaw: string, rightRaw: string): void {
+    // [20260908_Fix_240_Review] Trim at the write boundary — whitespace-only
+    // terms would pass length checks but match nothing meaningful.
+    const wrong = wrongRaw.trim();
+    const right = rightRaw.trim();
     if (!isValidVocabTerm(wrong) || !isValidVocabTerm(right)) {
       throw new Error("修正表词对不合法（空/过长/含控制字符或孤立代理项）");
     }

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -15,6 +15,8 @@ import path from "path";
 import fs from "fs";
 import { loadFileConfig } from "./fileConfig";
 import { saveFileConfig, FILE_CONFIGURABLE_KEYS } from "./fileConfig";
+// [20260908_Feat_240_VocabCorrections] T13 correction-table contracts.
+import { VOCAB_MAX_ENTRIES, isValidVocabTerm } from "./vocab";
 
 /** A transcription record as stored in SQLite. */
 export interface TranscriptionRecord {
@@ -242,6 +244,17 @@ class DatabaseManager {
         key TEXT PRIMARY KEY,
         value TEXT,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    // [20260908_Feat_240_VocabCorrections] T13: the vocabulary corrections
+    // table — wrong-word UNIQUE (re-insert replaces + touches recency),
+    // FIFO-evicted at VOCAB_MAX_ENTRIES by the add path.
+    this.db!.exec(`
+      CREATE TABLE IF NOT EXISTS vocabulary (
+        wrong TEXT PRIMARY KEY,
+        right TEXT NOT NULL,
+        used_ms INTEGER NOT NULL DEFAULT 0
       )
     `);
 
@@ -573,6 +586,60 @@ class DatabaseManager {
     }
     saveFileConfig(this._fileConfigPath, filtered);
     this._fileConfigCache = loadFileConfig(this._fileConfigPath);
+  }
+
+  // [20260908_Feat_240_VocabCorrections] T13: upsert a correction pair.
+  // Re-inserting an existing wrong word replaces the pair and touches
+  // recency (used_at). Evicts the oldest rows beyond the FIFO cap.
+  addVocabCorrection(wrong: string, right: string): void {
+    if (!isValidVocabTerm(wrong) || !isValidVocabTerm(right)) {
+      throw new Error("修正表词对不合法（空/过长/含控制字符或孤立代理项）");
+    }
+    const tx = this.db!;
+    tx.prepare(
+      `INSERT INTO vocabulary (wrong, right, used_ms)
+       VALUES (?, ?, ?)
+       ON CONFLICT(wrong) DO UPDATE SET
+         right = excluded.right,
+         used_ms = excluded.used_ms`,
+    ).run(wrong, right, this._nextVocabStamp());
+    const count = tx.prepare("SELECT COUNT(*) AS n FROM vocabulary").get() as {
+      n: number;
+    };
+    if (count.n > VOCAB_MAX_ENTRIES) {
+      tx.prepare(
+        `DELETE FROM vocabulary WHERE wrong IN (
+           SELECT wrong FROM vocabulary
+           ORDER BY used_ms ASC, rowid ASC
+           LIMIT ?
+         )`,
+      ).run(count.n - VOCAB_MAX_ENTRIES);
+    }
+  }
+
+  // [20260908_Feat_240_VocabCorrections] Monotonic stamp: Date.now() can
+  // tie within one millisecond for rapid successive calls, collapsing the
+  // recency order — always strictly greater than the stored maximum.
+  private _nextVocabStamp(): number {
+    const max = this.db!.prepare(
+      "SELECT MAX(used_ms) AS m FROM vocabulary",
+    ).get() as { m: number | null };
+    return Math.max(Date.now(), (max.m ?? 0) + 1);
+  }
+
+  // Oldest-first (injection picks the most recent from the tail).
+  listVocabCorrections(): Array<{ wrong: string; right: string }> {
+    return this.db!.prepare(
+      "SELECT wrong, right FROM vocabulary ORDER BY used_ms ASC, rowid ASC",
+    ).all() as Array<{ wrong: string; right: string }>;
+  }
+
+  deleteVocabCorrection(wrong: string): void {
+    this.db!.prepare("DELETE FROM vocabulary WHERE wrong = ?").run(wrong);
+  }
+
+  clearVocabCorrections(): void {
+    this.db!.exec("DELETE FROM vocabulary");
   }
 
   close(): void {

--- a/src/helpers/ipc-contracts.ts
+++ b/src/helpers/ipc-contracts.ts
@@ -68,6 +68,12 @@ export const AI = {
   // polish run by requestId. Rate-limit exempt by design (an abort must
   // never be throttled); ownership is checked against the initiating sender.
   POLISH_ABORT: "ai-polish-abort",
+  // [20260908_Feat_240_VocabCorrections] T13: vocabulary corrections CRUD
+  // (settings-page management; the injection read is server-side).
+  VOCAB_LIST: "vocab-list",
+  VOCAB_ADD: "vocab-add",
+  VOCAB_DELETE: "vocab-delete",
+  VOCAB_CLEAR: "vocab-clear",
   GET_MODES: "get-ai-modes",
   GET_PROVIDER_PRESETS: "get-ai-provider-presets",
   DETECT_LOCAL_MODELS: "detect-local-models",

--- a/src/helpers/ipc/index.ts
+++ b/src/helpers/ipc/index.ts
@@ -45,6 +45,11 @@ function wrapWithRateLimits(ipcMain: Electron.IpcMain): Electron.IpcMain {
     // [20260907_Feat_233_ListModels] Model-list derivation (T6): small
     // quota — it fires on base_url edits, not per keystroke.
     [C.AI.LIST_MODELS]: { maxCalls: 10, windowMs: 60_000 },
+    // [20260908_Feat_240_VocabCorrections] T13 settings-page CRUD.
+    [C.AI.VOCAB_LIST]: { maxCalls: 30, windowMs: 60_000 },
+    [C.AI.VOCAB_ADD]: { maxCalls: 30, windowMs: 60_000 },
+    [C.AI.VOCAB_DELETE]: { maxCalls: 30, windowMs: 60_000 },
+    [C.AI.VOCAB_CLEAR]: { maxCalls: 5, windowMs: 60_000 },
     [C.TRANSCRIPTION.SAVE]: { maxCalls: 30, windowMs: 60_000 },
     // [20260906_Feat_TranscriptionUpdate] Manual polish write-back (spec #193
     // T1, ticket #228): fires once per polish action, so it carries the same

--- a/src/helpers/ipc/settingsHandlers.ts
+++ b/src/helpers/ipc/settingsHandlers.ts
@@ -141,8 +141,12 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
         success: true,
         entries: databaseManager.listVocabCorrections(),
       };
-    } catch {
-      return { success: false, entries: [] };
+    } catch (error) {
+      return {
+        success: false,
+        entries: [],
+        error: (error as Error).message,
+      };
     }
   });
 

--- a/src/helpers/ipc/settingsHandlers.ts
+++ b/src/helpers/ipc/settingsHandlers.ts
@@ -6,6 +6,11 @@ interface DatabaseManager {
   setSetting(key: string, value: unknown): unknown;
   getAllSettings(): Record<string, unknown>;
   syncToFileConfig(): void;
+  // [20260908_Feat_240_VocabCorrections] T13 corrections-table CRUD.
+  listVocabCorrections(): Array<{ wrong: string; right: string }>;
+  addVocabCorrection(wrong: string, right: string): void;
+  deleteVocabCorrection(wrong: string): void;
+  clearVocabCorrections(): void;
 }
 
 interface WindowManager {
@@ -127,6 +132,46 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   // [20260816_Refactor_DeadChannels] The GET_LEGACY alias and the IMPORT/
   // EXPORT handlers (dialog-backed but with no UI entry point anywhere) were
   // removed with their contract constants.
+
+  // [20260908_Feat_240_VocabCorrections] T13: vocabulary CRUD for the
+  // settings page. Small quotas — the settings page edits, not polls.
+  ipcMain.handle(C.AI.VOCAB_LIST, () => {
+    try {
+      return {
+        success: true,
+        entries: databaseManager.listVocabCorrections(),
+      };
+    } catch {
+      return { success: false, entries: [] };
+    }
+  });
+
+  ipcMain.handle(C.AI.VOCAB_ADD, (_event, wrong: string, right: string) => {
+    try {
+      databaseManager.addVocabCorrection(wrong, right);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  });
+
+  ipcMain.handle(C.AI.VOCAB_DELETE, (_event, wrong: string) => {
+    try {
+      databaseManager.deleteVocabCorrection(wrong);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  });
+
+  ipcMain.handle(C.AI.VOCAB_CLEAR, () => {
+    try {
+      databaseManager.clearVocabCorrections();
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  });
 
   // [20260906_Refactor_DeadChannelCleanup] Ticket #250: the SETTINGS.SAVE and
   // SETTINGS.RESET handlers were removed — zero renderer callers (orphans

--- a/src/helpers/vocab.ts
+++ b/src/helpers/vocab.ts
@@ -47,7 +47,12 @@ export function filterVocabForInjection(
   pendingText: string,
   entries: VocabEntry[],
 ): VocabEntry[] {
-  const matching = entries.filter((e) => pendingText.includes(e.wrong));
+  // [20260908_Fix_240_Review] Defense-in-depth per the hotwords doctrine:
+  // re-validate at the injection read — a corrupted DB row with an empty
+  // wrong word would otherwise match EVERY text ("".includes semantics).
+  const matching = entries.filter(
+    (e) => e.wrong.length > 0 && pendingText.includes(e.wrong),
+  );
   if (matching.length <= VOCAB_MAX_INJECTED) return matching;
   return matching.slice(matching.length - VOCAB_MAX_INJECTED);
 }

--- a/src/helpers/vocab.ts
+++ b/src/helpers/vocab.ts
@@ -1,0 +1,63 @@
+// [20260908_Feat_240_VocabCorrections] Spec #193 T13 (ticket #240): the
+// vocabulary corrections layer — pure helpers for the injection discipline.
+// DB storage lives in database.ts (vocabulary table); this module owns the
+// filtering/directive contracts:
+//   - injection keeps ONLY entries whose wrong word appears in the pending
+//     text (no bulk shipping of the user's private table)
+//   - at most 20 entries, chosen by most-recent use
+//   - the directive is a labeled block the prompt builder places INSIDE the
+//     <transcript> envelope, so the T4 injection guard covers it
+export const VOCAB_MAX_ENTRIES = 1000;
+export const VOCAB_MAX_TERM_CHARS = 200;
+export const VOCAB_MAX_INJECTED = 20;
+
+export interface VocabEntry {
+  wrong: string;
+  right: string;
+}
+
+/** Reject terms with control chars or lone surrogates (both sides). */
+export function isValidVocabTerm(term: string): boolean {
+  if (!term || term.length > VOCAB_MAX_TERM_CHARS) return false;
+
+  if (/[\u0000-\u001f\u007f-\u009f]/.test(term)) return false;
+  // Lone surrogates: any unpaired \ud800-\udfff.
+  for (let i = 0; i < term.length; i++) {
+    const code = term.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdfff) {
+      const next = i + 1 < term.length ? term.charCodeAt(i + 1) : 0;
+      const prev = i > 0 ? term.charCodeAt(i - 1) : 0;
+      const isHigh = code <= 0xdbff;
+      const paired = isHigh
+        ? next >= 0xdc00 && next <= 0xdfff
+        : prev >= 0xd800 && prev <= 0xdbff;
+      if (!paired) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Entries eligible for one polish run: wrong word present in the text,
+ * capped at VOCAB_MAX_INJECTED most-recent entries. `entries` arrives
+// oldest-first from the DB; recency = later position (touched entries
+ * surface at the end).
+ */
+export function filterVocabForInjection(
+  pendingText: string,
+  entries: VocabEntry[],
+): VocabEntry[] {
+  const matching = entries.filter((e) => pendingText.includes(e.wrong));
+  if (matching.length <= VOCAB_MAX_INJECTED) return matching;
+  return matching.slice(matching.length - VOCAB_MAX_INJECTED);
+}
+
+/**
+ * Build the corrections directive — a labeled line per entry, placed by the
+ * prompt builder inside the XML envelope (injection-guard covered).
+ */
+export function buildVocabDirective(entries: VocabEntry[]): string {
+  if (entries.length === 0) return "";
+  const lines = entries.map((e) => `- ${e.wrong} → ${e.right}`);
+  return `【修正表】以下词对为历史修正,遇到左侧错误词请按右侧写法输出:\n${lines.join("\n")}`;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -111,7 +111,16 @@
       "defaultModeCorrect": "Proofread",
       "defaultModeSummarize": "Summarize",
       "defaultModeOff": "Turn AI off",
-      "defaultModeDesc": "AI processing applied automatically after recording or file import; the per-result panel still allows a one-off switch."
+      "defaultModeDesc": "AI processing applied automatically after recording or file import; the per-result panel still allows a one-off switch.",
+      "vocabTitle": "Corrections",
+      "vocabPrivacy": "Privacy: correction entries are sent with polish requests to your configured AI provider to fix recurring mistakes — nowhere else. Edit or clear them here at any time.",
+      "vocabEmpty": "No correction pairs yet",
+      "vocabAdd": "Add pair",
+      "vocabClear": "Clear all",
+      "vocabCount": "{{count}} pairs",
+      "vocabAddFailed": "Add failed",
+      "vocabClearConfirm": "Clear ALL correction pairs?",
+      "vocabDelete": "Delete"
     },
     "quickStart": {
       "title": "Quick Start",
@@ -375,5 +384,15 @@
     "apply": "Apply changes",
     "discard": "Discard changes",
     "emptySide": "(empty)"
+  },
+  "rewrite": {
+    "originalLabel": "Original",
+    "rewrittenLabel": "Rewritten",
+    "revert": "Revert to original",
+    "annotate": "Annotate correction",
+    "accept": "Accept rewrite",
+    "wrongWord": "Wrong word",
+    "rightWord": "Right word",
+    "saveCorrection": "Save to corrections"
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -111,7 +111,16 @@
       "defaultModeCorrect": "校对纠错",
       "defaultModeSummarize": "摘要总结",
       "defaultModeOff": "关闭 AI 处理",
-      "defaultModeDesc": "录音与文件导入完成后自动应用的 AI 处理方式；单次结果面板仍可临时切换。"
+      "defaultModeDesc": "录音与文件导入完成后自动应用的 AI 处理方式；单次结果面板仍可临时切换。",
+      "vocabTitle": "修正表",
+      "vocabPrivacy": "隐私说明：修正表内容会随润色请求发送至你所配置的 AI 服务商，用于纠正惯用错词；不会发送到其他任何地方。可随时在此编辑或清空。",
+      "vocabEmpty": "暂无修正词对",
+      "vocabAdd": "添加词对",
+      "vocabClear": "清空全部",
+      "vocabCount": "{{count}} 条词对",
+      "vocabAddFailed": "添加失败",
+      "vocabClearConfirm": "确定清空全部修正词对吗？",
+      "vocabDelete": "删除"
     },
     "quickStart": {
       "title": "快速开始",
@@ -375,5 +384,15 @@
     "apply": "应用修改",
     "discard": "放弃修改",
     "emptySide": "（空）"
+  },
+  "rewrite": {
+    "originalLabel": "原文",
+    "rewrittenLabel": "重写结果",
+    "revert": "回退原文",
+    "annotate": "标注修正",
+    "accept": "采用重写",
+    "wrongWord": "错误词",
+    "rightWord": "正确词",
+    "saveCorrection": "记入修正表"
   }
 }

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -5,6 +5,8 @@ import type { SettingsState } from "../useSettings";
 // [20260905_Fix_246_HotkeySettingsUi] Hotkey recorder (issue #246: the
 // settings entry the main-window failure toast pointed at did not exist).
 import { buildAccelerator, formatAccelerator } from "../hotkeyRecorder";
+// [20260908_Feat_240_VocabCorrections] T13: corrections-table management.
+import { VocabManager } from "./VocabManager";
 
 interface GeneralSectionProps {
   settings: SettingsState;
@@ -326,6 +328,8 @@ export const GeneralSection: React.FC<GeneralSectionProps> = ({
           </div>
         )}
       </div>
+      {/* [20260908_Feat_240_VocabCorrections] T13 corrections management. */}
+      <VocabManager />
     </div>
   );
 };

--- a/src/settings/sections/VocabManager.tsx
+++ b/src/settings/sections/VocabManager.tsx
@@ -1,0 +1,144 @@
+// [20260908_Feat_240_VocabCorrections] Spec #193 T13 (ticket #240):
+// settings-page management for the vocabulary corrections table —
+// view/add/delete/clear with the privacy disclosure (entries ship with
+// polish requests to the configured provider).
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+interface VocabEntry {
+  wrong: string;
+  right: string;
+}
+
+export const VocabManager: React.FC = () => {
+  const { t } = useTranslation();
+  const [entries, setEntries] = React.useState<VocabEntry[]>([]);
+  const [wrong, setWrong] = React.useState("");
+  const [right, setRight] = React.useState("");
+
+  const reload = React.useCallback(async () => {
+    if (!window.electronAPI?.listVocabCorrections) return;
+    try {
+      const result = await window.electronAPI.listVocabCorrections();
+      if (result.success) setEntries(result.entries);
+    } catch {
+      // Bridge failure leaves the current list; the next mount retries.
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const add = async () => {
+    if (!wrong.trim() || !right.trim()) return;
+    const result = await window.electronAPI?.addVocabCorrection?.(
+      wrong.trim(),
+      right.trim(),
+    );
+    if (result?.success) {
+      setWrong("");
+      setRight("");
+      await reload();
+    } else {
+      toast.error(t("settings.general.vocabAddFailed", "添加失败"));
+    }
+  };
+
+  const remove = async (target: string) => {
+    await window.electronAPI?.deleteVocabCorrection?.(target);
+    await reload();
+  };
+
+  const clearAll = async () => {
+    if (
+      !window.confirm(
+        t("settings.general.vocabClearConfirm", "确定清空全部修正词对吗？"),
+      )
+    ) {
+      return;
+    }
+    await window.electronAPI?.clearVocabCorrections?.();
+    await reload();
+  };
+
+  return (
+    <div data-testid="vocab-manager" className="space-y-3">
+      <h3 className="text-sm font-medium text-[#1d1d1f] dark:text-[#f5f5f7]">
+        {t("settings.general.vocabTitle", "修正表")}
+      </h3>
+      {/* Privacy disclosure: entries ship with polish requests. */}
+      <p className="text-xs text-[#86868b]">
+        {t(
+          "settings.general.vocabPrivacy",
+          "隐私说明：修正表内容会随润色请求发送至你所配置的 AI 服务商，用于纠正惯用错词；不会发送到其他任何地方。可随时在此编辑或清空。",
+        )}
+      </p>
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          aria-label={t("rewrite.wrongWord", "错误词")}
+          value={wrong}
+          onChange={(e) => setWrong(e.target.value)}
+          className="w-32 px-2 py-1 text-sm border border-[#d2d2d7] dark:border-[#3a3a3c] rounded-md bg-[#f5f5f7] dark:bg-[#3a3a3c] text-[#1d1d1f] dark:text-[#f5f5f7]"
+        />
+        <span className="text-[#86868b]">→</span>
+        <input
+          type="text"
+          aria-label={t("rewrite.rightWord", "正确词")}
+          value={right}
+          onChange={(e) => setRight(e.target.value)}
+          className="w-32 px-2 py-1 text-sm border border-[#d2d2d7] dark:border-[#3a3a3c] rounded-md bg-[#f5f5f7] dark:bg-[#3a3a3c] text-[#1d1d1f] dark:text-[#f5f5f7]"
+        />
+        <button
+          type="button"
+          data-testid="vocab-add"
+          onClick={() => void add()}
+          className="px-2 py-1 text-xs rounded-md bg-[#0071e3] text-white"
+        >
+          {t("settings.general.vocabAdd", "添加词对")}
+        </button>
+        <button
+          type="button"
+          data-testid="vocab-clear"
+          onClick={() => void clearAll()}
+          className="px-2 py-1 text-xs rounded-md border border-[#d2d2d7] dark:border-[#3a3a3c] text-[#ff5f57]"
+        >
+          {t("settings.general.vocabClear", "清空全部")}
+        </button>
+      </div>
+      <p className="text-xs text-[#86868b]">
+        {t("settings.general.vocabCount", "{{count}} 条词对", {
+          count: entries.length,
+        })}
+      </p>
+      {entries.length === 0 ? (
+        <p className="text-xs text-[#86868b]">
+          {t("settings.general.vocabEmpty", "暂无修正词对")}
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {entries.map((e) => (
+            <li
+              key={e.wrong}
+              className="flex items-center gap-2 text-sm text-[#1d1d1f] dark:text-[#f5f5f7]"
+            >
+              <span className="line-through text-[#86868b]">{e.wrong}</span>
+              <span>→</span>
+              <span>{e.right}</span>
+              <button
+                type="button"
+                aria-label={t("settings.general.vocabDelete", "删除")}
+                onClick={() => void remove(e.wrong)}
+                className="ml-auto text-xs text-[#ff5f57]"
+              >
+                {t("settings.general.vocabDelete", "删除")}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/settings/sections/VocabManager.tsx
+++ b/src/settings/sections/VocabManager.tsx
@@ -46,8 +46,15 @@ export const VocabManager: React.FC = () => {
     }
   };
 
+  // [20260908_Fix_240_Review] Uniform failure surface: the rate limiter
+  // resolves {success:false} instead of rejecting, so EVERY mutation must
+  // check the envelope or fail invisibly.
   const remove = async (target: string) => {
-    await window.electronAPI?.deleteVocabCorrection?.(target);
+    const result = await window.electronAPI?.deleteVocabCorrection?.(target);
+    if (!result?.success) {
+      toast.error(t("settings.general.vocabAddFailed", "添加失败"));
+      return;
+    }
     await reload();
   };
 
@@ -59,7 +66,11 @@ export const VocabManager: React.FC = () => {
     ) {
       return;
     }
-    await window.electronAPI?.clearVocabCorrections?.();
+    const result = await window.electronAPI?.clearVocabCorrections?.();
+    if (!result?.success) {
+      toast.error(t("settings.general.vocabAddFailed", "添加失败"));
+      return;
+    }
     await reload();
   };
 
@@ -118,8 +129,8 @@ export const VocabManager: React.FC = () => {
           {t("settings.general.vocabEmpty", "暂无修正词对")}
         </p>
       ) : (
-        <ul className="space-y-1">
-          {entries.map((e) => (
+        <ul className="space-y-1 max-h-48 overflow-y-auto">
+          {[...entries].reverse().map((e) => (
             <li
               key={e.wrong}
               className="flex items-center gap-2 text-sm text-[#1d1d1f] dark:text-[#f5f5f7]"

--- a/tests/unit/vocab-corrections.test.ts
+++ b/tests/unit/vocab-corrections.test.ts
@@ -5,7 +5,7 @@
 // eviction at 1000 entries. Injection filter: ≤20 entries by most-recent
 // use, ONLY entries whose wrong word appears in the pending text, wrapped
 // inside the XML envelope so the injection guard covers it.
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -24,6 +24,12 @@ beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vocab-test-"));
   db = new DatabaseManager();
   db.initialize(tmpDir);
+});
+
+afterEach(() => {
+  // [20260908_Fix_240_Review] DB-test convention: close + rmSync per run.
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("[20260908_Feat_240_VocabCorrections] DB layer", () => {
@@ -224,7 +230,8 @@ describe("[20260908_Feat_240_RewriteReview] RewriteReviewPanel", () => {
     fireEvent.click(screen.getByTestId("rewrite-annotate"));
     fireEvent.click(screen.getByRole("button", { name: "记入修正表" }));
     expect(onAddCorrection).not.toHaveBeenCalled();
-    // The form collapsed without persisting anything.
-    expect(screen.queryByTestId("correction-form")).not.toBeInTheDocument();
+    // [20260908_Fix_240_Review] A half-filled/empty submit keeps the form
+    // open with its contents (no silent input loss).
+    expect(screen.getByTestId("correction-form")).toBeInTheDocument();
   });
 });

--- a/tests/unit/vocab-corrections.test.ts
+++ b/tests/unit/vocab-corrections.test.ts
@@ -1,0 +1,230 @@
+// [20260908_Feat_240_VocabCorrections] TDD for Spec #193 T13 (ticket #240):
+// the vocabulary corrections table — wrong-word→right-word pairs captured
+// when the user rejects a rewrite change. DB contracts: wrong-word UNIQUE,
+// length caps on both sides, control-char/lone-surrogate rejection, FIFO
+// eviction at 1000 entries. Injection filter: ≤20 entries by most-recent
+// use, ONLY entries whose wrong word appears in the pending text, wrapped
+// inside the XML envelope so the injection guard covers it.
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import DatabaseManager from "../../src/helpers/database";
+import {
+  VOCAB_MAX_ENTRIES,
+  VOCAB_MAX_TERM_CHARS,
+  filterVocabForInjection,
+  buildVocabDirective,
+} from "../../src/helpers/vocab";
+
+let db: InstanceType<typeof DatabaseManager>;
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vocab-test-"));
+  db = new DatabaseManager();
+  db.initialize(tmpDir);
+});
+
+describe("[20260908_Feat_240_VocabCorrections] DB layer", () => {
+  it("adds and lists a correction pair", () => {
+    db.addVocabCorrection("会义室", "会议室");
+    const rows = db.listVocabCorrections();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ wrong: "会义室", right: "会议室" });
+  });
+
+  it("re-inserting the same wrong word updates the pair in place (unique)", () => {
+    db.addVocabCorrection("会义室", "会议室");
+    db.addVocabCorrection("会义室", "会议室B");
+    const rows = db.listVocabCorrections();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.right).toBe("会议室B");
+  });
+
+  it("rejects terms over the length cap on either side", () => {
+    expect(() =>
+      db.addVocabCorrection("a".repeat(VOCAB_MAX_TERM_CHARS + 1), "x"),
+    ).toThrow();
+    expect(() =>
+      db.addVocabCorrection("x", "b".repeat(VOCAB_MAX_TERM_CHARS + 1)),
+    ).toThrow();
+    // At exactly the cap the term is valid.
+    expect(() =>
+      db.addVocabCorrection("a".repeat(VOCAB_MAX_TERM_CHARS), "x"),
+    ).not.toThrow();
+  });
+
+  it("rejects empty terms and control characters / lone surrogates", () => {
+    expect(() => db.addVocabCorrection("", "x")).toThrow();
+    expect(() => db.addVocabCorrection("x", "")).toThrow();
+    expect(() => db.addVocabCorrection("a\u0000b", "x")).toThrow();
+    expect(() => db.addVocabCorrection("\ud800", "x")).toThrow();
+  });
+
+  it("evicts the OLDEST entries beyond the FIFO cap", () => {
+    for (let i = 0; i < VOCAB_MAX_ENTRIES + 5; i++) {
+      db.addVocabCorrection(`词${i}`, `正${i}`);
+    }
+    const rows = db.listVocabCorrections();
+    expect(rows).toHaveLength(VOCAB_MAX_ENTRIES);
+    // The first five inserted pairs were evicted.
+    expect(rows.some((r) => r.wrong === "词0")).toBe(false);
+    expect(rows.some((r) => r.wrong === `词${VOCAB_MAX_ENTRIES + 4}`)).toBe(
+      true,
+    );
+  });
+
+  it("deletes a pair and clears all", () => {
+    db.addVocabCorrection("a", "b");
+    db.addVocabCorrection("c", "d");
+    db.deleteVocabCorrection("a");
+    expect(db.listVocabCorrections()).toHaveLength(1);
+    db.clearVocabCorrections();
+    expect(db.listVocabCorrections()).toHaveLength(0);
+  });
+
+  it("re-touching an existing wrong word moves it to most-recent", () => {
+    db.addVocabCorrection("a", "1");
+    db.addVocabCorrection("b", "2");
+    db.addVocabCorrection("a", "1"); // touch
+    const rows = db.listVocabCorrections();
+    expect(rows[0]!.wrong).toBe("b"); // oldest first
+    expect(rows[1]!.wrong).toBe("a"); // a is now most recent
+  });
+});
+
+describe("[20260908_Feat_240_VocabCorrections] injection filter", () => {
+  it("keeps only entries whose wrong word appears in the pending text, ≤20 by recency", () => {
+    // Non-overlapping keys (CJK substring semantics: 词1 ⊂ 词10 would
+    // both match, conflating the test).
+    const entries = Array.from({ length: 30 }, (_, i) => ({
+      wrong: `错${i}词`,
+      right: `正${i}词`,
+    }));
+    const filtered = filterVocabForInjection(
+      "这里出现了 错5词 和 错10词 还有 错25词",
+      entries,
+    );
+    expect(filtered.map((e) => e.wrong).sort()).toEqual(
+      ["错10词", "错25词", "错5词"].sort(),
+    );
+
+    // Over 20 matches: the 20 most RECENT entries win (highest index here).
+    const many = Array.from({ length: 30 }, (_, i) => ({
+      wrong: `w${i}`,
+      right: `r${i}`,
+    }));
+    const text = many.map((e) => e.wrong).join(" ");
+    const capped = filterVocabForInjection(text, many);
+    expect(capped).toHaveLength(20);
+    expect(capped[0]!.wrong).toBe("w10"); // oldest of the kept 20
+    expect(capped[19]!.wrong).toBe("w29");
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(
+      filterVocabForInjection("没有任何匹配", [{ wrong: "x", right: "y" }]),
+    ).toEqual([]);
+  });
+
+  it("builds the directive inside the XML envelope scope", () => {
+    const directive = buildVocabDirective([
+      { wrong: "会义室", right: "会议室" },
+    ]);
+    expect(directive).toContain("会义室");
+    expect(directive).toContain("会议室");
+    // Structure: a labeled corrections block the prompt builder places
+    // INSIDE the <transcript> envelope (injection-guard covered).
+    expect(directive).toMatch(/\[|【/);
+  });
+
+  it("empty entries build no directive", () => {
+    expect(buildVocabDirective([])).toBe("");
+  });
+});
+
+// [20260908_Feat_240_RewriteReview] T13 ①: rewrite-class modes show the
+// whole-text before/after panel with one-click revert — NO per-hunk
+// controls (spec: 逐段 diff is meaningless under full rewrite).
+// ② the correction-pair annotation flow (reject-time capture).
+// @vitest-environment jsdom
+import "../setup/react";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    i18n: { language: "zh-CN" },
+  }),
+}));
+
+import { RewriteReviewPanel } from "../../src/components/RewriteReviewPanel";
+
+describe("[20260908_Feat_240_RewriteReview] RewriteReviewPanel", () => {
+  const onAddCorrection = vi.fn();
+  beforeEach(() => vi.clearAllMocks());
+  const onAccept = vi.fn();
+  const onRevert = vi.fn();
+
+  function mount() {
+    return render(
+      React.createElement(RewriteReviewPanel, {
+        original: "原始的转写文本",
+        rewritten: "重写后的精彩文本",
+        onAddCorrection,
+        onAccept,
+        onRevert,
+      }),
+    );
+  }
+
+  it("renders the whole-text side-by-side (no per-hunk controls)", () => {
+    mount();
+    expect(screen.getByTestId("rewrite-original")).toHaveTextContent(
+      "原始的转写文本",
+    );
+    expect(screen.getByTestId("rewrite-result")).toHaveTextContent(
+      "重写后的精彩文本",
+    );
+    // NO per-hunk accept/reject buttons (rewrite-class contract).
+    expect(screen.queryAllByRole("button", { name: "接受" })).toHaveLength(0);
+    expect(screen.queryAllByRole("button", { name: "拒绝" })).toHaveLength(0);
+  });
+
+  it("revert calls onRevert (one-click back to original)", () => {
+    mount();
+    fireEvent.click(screen.getByTestId("rewrite-revert"));
+    expect(onRevert).toHaveBeenCalledTimes(1);
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+
+  it("accept sends the rewritten text", () => {
+    mount();
+    fireEvent.click(screen.getByTestId("rewrite-accept"));
+    expect(onAccept).toHaveBeenCalledWith("重写后的精彩文本");
+  });
+
+  it("annotation flow captures a wrong→right pair", () => {
+    mount();
+    fireEvent.click(screen.getByTestId("rewrite-annotate"));
+    fireEvent.change(screen.getByLabelText("错误词"), {
+      target: { value: "会义室" },
+    });
+    fireEvent.change(screen.getByLabelText("正确词"), {
+      target: { value: "会议室" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "记入修正表" }));
+    expect(onAddCorrection).toHaveBeenCalledWith("会义室", "会议室");
+  });
+
+  it("empty pairs are not submitted", () => {
+    mount();
+    fireEvent.click(screen.getByTestId("rewrite-annotate"));
+    fireEvent.click(screen.getByRole("button", { name: "记入修正表" }));
+    expect(onAddCorrection).not.toHaveBeenCalled();
+    // The form collapsed without persisting anything.
+    expect(screen.queryByTestId("correction-form")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概述

Spec #193 T13(#240)S4b 重写类整篇对照 + 修正表。评审后台运行中,结论出来前 PR 保持 open(按票面约束:评审修复复验后才关票)。

## 交付

- **RewriteReviewPanel**:整篇前后对照 + 一键回退原文(无逐段控件——spec BL-2:全文重写下逐段 diff 无意义)+ 修正词对标注流(拒绝时点选/输入 wrong→right,空词对不提交)
- **修正表 SQLite**(vocabulary 表):wrong 唯一(upsert 替换 + 触碰 recency,单调毫秒戳避免同毫秒并列)、双侧 ≤200 字符、控制字符/孤立代理项拒斥、FIFO 1000 上限淘汰
- **注入纪律纯函数**(vocab.ts):仅注入错误词在待润色文本中出现的条目、≤20 条按最近使用、修正行置于 XML 包裹内(T4 注入防护覆盖)
- **设置页管理**(VocabManager,General 标签):查看/添加/删除/清空 + 条数 + 隐私披露文案(修正表内容随润色请求发送至所配服务商)——zh/en 双语
- **IPC 链**:VOCAB_LIST/ADD/DELETE/CLEAR 契约 + 限流配额 + preload + d.ts

## 验证

ci:check 11/11;2299 unit 全绿;Python 120(floor 46);lint 0 警告;tsc 双配置零错误。

## 关联

- T12 对照基座(#325 已合)之上;修正表注入到 prompt 的编排器接线属后续集成(与 T12 面板接线同批)
