### PR TITLE
feat: diff/rewrite 面板挂载 + 修正表注入编排器(#333 集成票)

### DIFF
--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -10,6 +10,8 @@ import { usePolishStream } from "../hooks/usePolishStream";
 // comparison with correction annotation.
 import { DiffReviewPanel } from "./DiffReviewPanel";
 import { RewriteReviewPanel } from "./RewriteReviewPanel";
+// [20260909_Fix_333_Review] Shared minimal-edit mode set.
+import { MINIMAL_EDIT_MODES } from "../helpers/polish-diff";
 import { LoadingDots } from "./ui/loading-dots";
 import ExportPanel from "./ExportPanel";
 import ProcessingPanel from "./ProcessingPanel";
@@ -80,8 +82,9 @@ export default function TranscriptionResult({
     original: string;
     revised: string;
   } | null>(null);
+  // [20260909_Fix_333_Review] Shared set — see polish-diff.ts.
   const isMinimalEditMode = (modeName: string): boolean =>
-    ["optimize", "optimize_long", "format", "correct"].includes(modeName);
+    MINIMAL_EDIT_MODES.has(modeName);
   const [expandedSegment, setExpandedSegment] = React.useState<
     string | number | null
   >(null);
@@ -278,7 +281,9 @@ export default function TranscriptionResult({
         polishedText = result;
         setOptimizedText(result);
         setPendingReview({
-          modeClass: "rewrite",
+          modeClass: isMinimalEditMode(currentMode)
+            ? "minimal-edit"
+            : "rewrite",
           original: text,
           revised: result,
         });
@@ -535,10 +540,9 @@ export default function TranscriptionResult({
               onApply={(merged) => {
                 setOptimizedText(merged);
                 if (id != null) {
-                  void window.electronAPI?.updateTranscription?.(id, {
-                    processed_text: merged,
-                    text: merged,
-                  });
+                  // [20260909_Fix_333_Review] Route through the hardened
+                  // writer — void-discard regressed #314's toast on failure.
+                  void persistPolishedText(id, merged);
                 }
                 setPendingReview(null);
               }}
@@ -551,25 +555,28 @@ export default function TranscriptionResult({
               original={pendingReview.original}
               rewritten={pendingReview.revised}
               onAddCorrection={(wrong, right) => {
-                void window.electronAPI?.addVocabCorrection?.(wrong, right);
+                // [20260909_Fix_333_Review] Surface IPC failures, never
+                // discard them silently.
+                window.electronAPI
+                  ?.addVocabCorrection?.(wrong, right)
+                  .catch((error: unknown) => {
+                    console.warn("修正表写入失败:", error);
+                    toast.warning(
+                      t("transcription.vocabSaveFailed", "修正词对保存失败"),
+                    );
+                  });
               }}
               onAccept={(finalText) => {
                 setOptimizedText(finalText);
                 if (id != null) {
-                  void window.electronAPI?.updateTranscription?.(id, {
-                    processed_text: finalText,
-                    text: finalText,
-                  });
+                  void persistPolishedText(id, finalText);
                 }
                 setPendingReview(null);
               }}
               onRevert={() => {
                 setOptimizedText(null);
                 if (id != null) {
-                  void window.electronAPI?.updateTranscription?.(id, {
-                    processed_text: pendingReview.original,
-                    text: pendingReview.original,
-                  });
+                  void persistPolishedText(id, pendingReview.original);
                 }
                 setPendingReview(null);
               }}

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -5,6 +5,11 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 // [20260907_Feat_236_StreamingUi] T9 ①: streaming polish coordinator.
 import { usePolishStream } from "../hooks/usePolishStream";
+// [20260908_Feat_333_PanelIntegration] Post-polish review panels (#333):
+// minimal-edit modes get the diff review; rewrite modes get the whole-text
+// comparison with correction annotation.
+import { DiffReviewPanel } from "./DiffReviewPanel";
+import { RewriteReviewPanel } from "./RewriteReviewPanel";
 import { LoadingDots } from "./ui/loading-dots";
 import ExportPanel from "./ExportPanel";
 import ProcessingPanel from "./ProcessingPanel";
@@ -67,6 +72,16 @@ export default function TranscriptionResult({
   // [20260907_Feat_236_StreamingUi] T9 ①: streaming polish coordinator —
   // owns chunk subscription, incremental delta state and the cancel channel.
   const polishStream = usePolishStream();
+  // [20260908_Feat_333_PanelIntegration] Pending post-polish review (spec
+  // #193 S4): after a successful polish the accepted text is staged here
+  // with its mode class until the user accepts/reverts in the panel.
+  const [pendingReview, setPendingReview] = React.useState<{
+    modeClass: "minimal-edit" | "rewrite";
+    original: string;
+    revised: string;
+  } | null>(null);
+  const isMinimalEditMode = (modeName: string): boolean =>
+    ["optimize", "optimize_long", "format", "correct"].includes(modeName);
   const [expandedSegment, setExpandedSegment] = React.useState<
     string | number | null
   >(null);
@@ -196,6 +211,13 @@ export default function TranscriptionResult({
         // (file import's aiReviewTranscription review-by-id).
         polishedText = await onAIOptimize(text);
         setOptimizedText(polishedText);
+        setPendingReview({
+          modeClass: isMinimalEditMode(currentMode)
+            ? "minimal-edit"
+            : "rewrite",
+          original: text,
+          revised: polishedText,
+        });
       } else if (typeof window.electronAPI?.processText === "function") {
         // [20260907_Feat_236_StreamingUi] T9 ①: streaming when the chunk
         // channel exists; timeout semantics live in the orchestrator's
@@ -225,6 +247,13 @@ export default function TranscriptionResult({
         if (result?.success && result?.text) {
           polishedText = result.text;
           setOptimizedText(result.text);
+          setPendingReview({
+            modeClass: isMinimalEditMode(currentMode)
+              ? "minimal-edit"
+              : "rewrite",
+            original: text,
+            revised: polishedText,
+          });
         } else {
           // [20260815_Fix_AiEmptyContent] Surface the main-process error
           // (e.g. max_tokens exhausted by model reasoning) instead of a
@@ -248,6 +277,11 @@ export default function TranscriptionResult({
         const result = await onAIOptimize(text);
         polishedText = result;
         setOptimizedText(result);
+        setPendingReview({
+          modeClass: "rewrite",
+          original: text,
+          revised: result,
+        });
       } else {
         setOptimizeError("AI功能不可用");
       }
@@ -484,6 +518,62 @@ export default function TranscriptionResult({
                 );
               })}
             </div>
+          )}
+        </div>
+      )}
+
+      {/* [20260908_Feat_333_PanelIntegration] Post-polish review: minimal-edit
+          modes -> diff hunks with per-hunk accept/reject; rewrite modes ->
+          whole-text comparison with correction annotation. Accept writes back
+          through the T1 UPDATE channel; revert restores the original. */}
+      {pendingReview && !showOptimizing && (
+        <div data-testid="polish-review">
+          {pendingReview.modeClass === "minimal-edit" ? (
+            <DiffReviewPanel
+              original={pendingReview.original}
+              revised={pendingReview.revised}
+              onApply={(merged) => {
+                setOptimizedText(merged);
+                if (id != null) {
+                  void window.electronAPI?.updateTranscription?.(id, {
+                    processed_text: merged,
+                    text: merged,
+                  });
+                }
+                setPendingReview(null);
+              }}
+              onCancel={() => {
+                setPendingReview(null);
+              }}
+            />
+          ) : (
+            <RewriteReviewPanel
+              original={pendingReview.original}
+              rewritten={pendingReview.revised}
+              onAddCorrection={(wrong, right) => {
+                void window.electronAPI?.addVocabCorrection?.(wrong, right);
+              }}
+              onAccept={(finalText) => {
+                setOptimizedText(finalText);
+                if (id != null) {
+                  void window.electronAPI?.updateTranscription?.(id, {
+                    processed_text: finalText,
+                    text: finalText,
+                  });
+                }
+                setPendingReview(null);
+              }}
+              onRevert={() => {
+                setOptimizedText(null);
+                if (id != null) {
+                  void window.electronAPI?.updateTranscription?.(id, {
+                    processed_text: pendingReview.original,
+                    text: pendingReview.original,
+                  });
+                }
+                setPendingReview(null);
+              }}
+            />
           )}
         </div>
       )}

--- a/src/helpers/aiPrompts.ts
+++ b/src/helpers/aiPrompts.ts
@@ -11,6 +11,9 @@ export interface PromptTemplate {
   user: string;
 }
 
+// [20260908_Feat_333_VocabInjection] Directive lives inside the envelope.
+import { buildVocabDirective } from "./vocab";
+
 /** Result of buildPrompt: system + user prompt pair. */
 export interface PromptResult {
   system: string;
@@ -42,6 +45,13 @@ const TRANSCRIPT_CLOSE_TAG = "</transcript>";
 /** Options for buildPrompt. */
 export interface BuildPromptOptions {
   customTemplates?: PromptTemplate[];
+  /**
+   * [20260908_Feat_333_VocabInjection] Pre-filtered correction entries
+   * (spec #193 T13): the caller resolves the vocabulary table and filters
+   * by occurrence; the directive is appended INSIDE the transcript envelope
+   * so the injection guard covers it. Empty/absent -> no directive.
+   */
+  vocabCorrections?: Array<{ wrong: string; right: string }>;
   /**
    * Diarized segments for the current request. When non-empty, the built-in
    * body is assembled as "[说话人N]: line" per segment; when absent the raw
@@ -155,6 +165,7 @@ export function buildPrompt(
     customTemplates = [],
     speakerSegments,
     outputLang,
+    vocabCorrections,
   }: BuildPromptOptions = {},
 ): PromptResult {
   const custom = customTemplates.find((t) => t.name === mode);
@@ -189,6 +200,11 @@ export function buildPrompt(
     // orchestrator's absolute char cap; the token-budget clamp intentionally
     // does not apply to rewrite-class template outputs.
     user = `${user}\n${INJECTION_GUARD}`;
+    // [20260908_Feat_333_VocabInjection] Corrections ride inside the
+    // envelope after the guard (custom-template arm).
+    if (vocabCorrections && vocabCorrections.length > 0) {
+      user = `${user}\n${buildVocabDirective(vocabCorrections)}`;
+    }
     return { system: custom.system, user };
   }
 
@@ -568,8 +584,20 @@ export function buildPrompt(
   // can forget it, and the user body always comes from buildTranscriptBody so
   // the XML wrap format has exactly one definition.
   const selectedSystem = modes[mode] ?? modes.optimize!;
-  return {
+  const result: PromptResult = {
     system: `${ANTI_SLOP_PREFIX}\n${INJECTION_GUARD}\n\n${selectedSystem}`,
     user: buildTranscriptBody(text, speakerSegments),
   };
+  // [20260908_Feat_333_VocabInjection] For built-in modes the directive
+  // goes INSIDE the envelope (before the close tag) so the T4 injection
+  // guard's "transcript content is data" framing covers the corrections
+  // block too.
+  if (vocabCorrections && vocabCorrections.length > 0) {
+    const directive = buildVocabDirective(vocabCorrections);
+    result.user = result.user.replace(
+      new RegExp(`${TRANSCRIPT_CLOSE_TAG}$`),
+      `${directive}\n${TRANSCRIPT_CLOSE_TAG}`,
+    );
+  }
+  return result;
 }

--- a/src/helpers/aiPrompts.ts
+++ b/src/helpers/aiPrompts.ts
@@ -200,10 +200,19 @@ export function buildPrompt(
     // orchestrator's absolute char cap; the token-budget clamp intentionally
     // does not apply to rewrite-class template outputs.
     user = `${user}\n${INJECTION_GUARD}`;
-    // [20260908_Feat_333_VocabInjection] Corrections ride inside the
-    // envelope after the guard (custom-template arm).
+    // [20260909_Fix_333_Review] Corrections ride INSIDE the envelope in the
+    // custom arm too: inject before the LAST close tag when the rendered
+    // template has one; a template without an envelope keeps the directive
+    // appended after the guard (nothing to be inside of).
     if (vocabCorrections && vocabCorrections.length > 0) {
-      user = `${user}\n${buildVocabDirective(vocabCorrections)}`;
+      const directive = buildVocabDirective(vocabCorrections);
+      const lastClose = user.lastIndexOf(TRANSCRIPT_CLOSE_TAG);
+      if (lastClose !== -1) {
+        user =
+          user.slice(0, lastClose) + `${directive}\n` + user.slice(lastClose);
+      } else {
+        user = `${user}\n${directive}`;
+      }
     }
     return { system: custom.system, user };
   }
@@ -594,9 +603,11 @@ export function buildPrompt(
   // block too.
   if (vocabCorrections && vocabCorrections.length > 0) {
     const directive = buildVocabDirective(vocabCorrections);
+    // [20260909_Fix_333_Review] Function-form replacer: vocab terms may
+    // contain "$&"-family sequences that a string replacement would expand.
     result.user = result.user.replace(
       new RegExp(`${TRANSCRIPT_CLOSE_TAG}$`),
-      `${directive}\n${TRANSCRIPT_CLOSE_TAG}`,
+      () => `${directive}\n${TRANSCRIPT_CLOSE_TAG}`,
     );
   }
   return result;

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -598,14 +598,9 @@ const POLISH_SUPERSEDED_MESSAGE = "已发起新的AI处理，本次结果已丢�
 const POLISH_CLAMP_MIN_TOKENS = 4096;
 const POLISH_CLAMP_INPUT_LENGTH_FACTOR = 2;
 export { POLISH_CLAMP_MIN_TOKENS, POLISH_CLAMP_INPUT_LENGTH_FACTOR };
-// Minimal-edit modes (最小修改类) whose output is expected to track the input
-// length; everything else (rewrite-class + custom templates) is never clamped.
-const MINIMAL_EDIT_MODES: ReadonlySet<string> = new Set([
-  "optimize",
-  "optimize_long",
-  "format",
-  "correct",
-]);
+// [20260909_Fix_333_Review] Single shared source in polish-diff.ts.
+export { MINIMAL_EDIT_MODES } from "../polish-diff";
+import { MINIMAL_EDIT_MODES as MINIMAL_MODES_FOR_CLAMP } from "../polish-diff";
 // Absolute response guard (Spec #193 超时与总量上限矩阵: 绝对上限 200 万字符):
 // a provider (or malicious gateway) response longer than this is truncated
 // before mapping, so oversized/absurd output never flows to the renderer.
@@ -743,7 +738,7 @@ function resolvePolishMaxTokens(
   userMaxTokens: number,
   clampEnabled: boolean,
 ): number {
-  if (!clampEnabled || !MINIMAL_EDIT_MODES.has(mode)) {
+  if (!clampEnabled || !MINIMAL_MODES_FOR_CLAMP.has(mode)) {
     return userMaxTokens;
   }
   return Math.max(
@@ -1291,7 +1286,7 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
             mode,
             templatesDir,
             timeout,
-            clampOutputTokens: MINIMAL_EDIT_MODES.has(mode),
+            clampOutputTokens: MINIMAL_MODES_FOR_CLAMP.has(mode),
             generationScope: requestId,
             signal: streamAbortTargets.get(requestId ?? "")?.controller.signal,
             stream,

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -15,6 +15,8 @@ import {
   STREAM_MAX_CHUNKS,
   streamDeadlineViolation,
 } from "../polish-stream";
+// [20260908_Feat_333_VocabInjection] Corrections-table injection (T13→#333).
+import { filterVocabForInjection } from "../vocab";
 
 interface Logger {
   info?(message: string, ...args: unknown[]): void;
@@ -24,6 +26,8 @@ interface Logger {
 
 interface DatabaseManager {
   getSetting(key: string): Promise<unknown>;
+  // [20260908_Feat_333_VocabInjection] Corrections-table read for injection.
+  listVocabCorrections?(): Array<{ wrong: string; right: string }>;
 }
 
 interface AIMode {
@@ -818,7 +822,24 @@ export async function runPolishOrchestrator(
       const customTemplates = request.templatesDir
         ? getCachedTemplates(request.templatesDir)
         : [];
-      ({ system, user } = buildPrompt(mode, text, { customTemplates }));
+      // [20260908_Feat_333_VocabInjection] Resolve the corrections table
+      // and keep ONLY entries whose wrong word appears in this text (T13
+      // discipline: ≤20 by recency; the directive rides inside the XML
+      // envelope via buildPrompt). A table read failure degrades to no
+      // injection — polish must never fail on the optional corrections.
+      let vocabCorrections: Array<{ wrong: string; right: string }> = [];
+      try {
+        vocabCorrections = filterVocabForInjection(
+          text,
+          databaseManager.listVocabCorrections?.() ?? [],
+        );
+      } catch (vocabError) {
+        logger?.warn?.("修正表读取失败,跳过注入:", vocabError);
+      }
+      ({ system, user } = buildPrompt(mode, text, {
+        customTemplates,
+        vocabCorrections,
+      }));
     }
 
     const requestData = {

--- a/src/helpers/polish-diff.ts
+++ b/src/helpers/polish-diff.ts
@@ -21,6 +21,16 @@
 // (transcript-length texts).
 import DiffMatchPatch from "diff-match-patch";
 
+// [20260909_Fix_333_Review] Single source for the minimal-edit mode set —
+// consumed by the orchestrator's token clamp AND the renderer's panel
+// routing, so a new mode cannot drift between the two.
+export const MINIMAL_EDIT_MODES: ReadonlySet<string> = new Set([
+  "optimize",
+  "optimize_long",
+  "format",
+  "correct",
+]);
+
 /** Above this input size the diff degrades to a single whole-text hunk. */
 export const DIFF_MAX_INPUT_CHARS = 200_000;
 /** Diff computation budget in seconds (dmp's Diff_Timeout unit). */

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -375,7 +375,8 @@
     "polishSaveFailed": "Couldn't save the polished text — it will revert after restart",
     "cancelPolish": "Cancel",
     "polishInvokeFailed": "AI processing failed, please retry",
-    "polishFailed": "AI processing failed, please retry"
+    "polishFailed": "AI processing failed, please retry",
+    "vocabSaveFailed": "Failed to save the correction pair"
   },
   "diff": {
     "noChanges": "No changes",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -375,7 +375,8 @@
     "polishSaveFailed": "润色结果保存失败，重启后将显示原文本",
     "cancelPolish": "取消",
     "polishInvokeFailed": "AI处理失败，请重试",
-    "polishFailed": "AI处理失败，请重试"
+    "polishFailed": "AI处理失败，请重试",
+    "vocabSaveFailed": "修正词对保存失败"
   },
   "diff": {
     "noChanges": "无改动",

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -1851,3 +1851,173 @@ describe("[20260908_Fix_BatchReview_M1] non-streaming body deadline", () => {
 function senderEvent(id: number): { sender: { id: number } } {
   return { sender: { id } };
 }
+
+// [20260908_Feat_333_VocabInjection] End-to-end injection: the orchestrator
+// resolves the corrections table, filters by occurrence, and the directive
+// rides INSIDE the transcript envelope. No match / read failure → no
+// directive (polish never fails on the optional table).
+describe("[20260908_Feat_333_VocabInjection] corrections injection", () => {
+  function makeDb(entries: Array<{ wrong: string; right: string }>) {
+    return {
+      getSetting: vi.fn(async (key: string) =>
+        key === "ai_base_url"
+          ? "https://api.example.com/v1"
+          : key === "ai_api_key"
+            ? "sk"
+            : key === "ai_model"
+              ? "gpt-x"
+              : null,
+      ),
+      listVocabCorrections: vi.fn(() => entries),
+    };
+  }
+  function makeDbNoVocab() {
+    return {
+      getSetting: vi.fn(async (key: string) =>
+        key === "ai_base_url"
+          ? "https://api.example.com/v1"
+          : key === "ai_api_key"
+            ? "sk"
+            : key === "ai_model"
+              ? "gpt-x"
+              : null,
+      ),
+    };
+  }
+  function captureBody(): Record<string, unknown> {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    return JSON.parse(
+      (fetchMock.mock.calls[0]![1] as { body: string }).body,
+    ) as Record<string, unknown>;
+  }
+  // [20260908_Feat_333_VocabInjection] handlers map values are possibly
+  // undefined under noUncheckedIndexedAccess — non-null helper.
+  const processHandler = (
+    map: Record<string, (...args: unknown[]) => unknown>,
+  ): ((...args: unknown[]) => Promise<unknown>) =>
+    map[C.AI.PROCESS]! as (...args: unknown[]) => Promise<unknown>;
+  function messagesOf(body: Record<string, unknown>): string {
+    return (body.messages as Array<{ role: string; content: string }>)
+      .map((m) => m.content)
+      .join("\n---\n");
+  }
+
+  it("injects matching corrections inside the transcript envelope", async () => {
+    const handlers: Record<string, (...args: unknown[]) => unknown> = {};
+    const ipcMain = {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        handlers[channel] = fn;
+      }),
+    };
+    const prevFetch = global.fetch;
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({
+        choices: [{ message: { content: "润色结果" }, finish_reason: "stop" }],
+      }),
+    })) as unknown as typeof fetch;
+    const db = makeDb([
+      { wrong: "会义室", right: "会议室" },
+      { wrong: "不出现的词", right: "某词" },
+    ]);
+    aiHandlersNS.register(
+      ipcMain as never,
+      {
+        databaseManager: db,
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      } as never,
+    );
+
+    await processHandler(handlers)(
+      { sender: { id: 1 } },
+      "我们明天在会义室开会",
+      "optimize",
+    );
+    // Capture BEFORE restoring the real fetch.
+    const userMsg = messagesOf(captureBody());
+    global.fetch = prevFetch;
+    expect(userMsg).toContain("会义室");
+    expect(userMsg).toContain("会议室");
+    expect(userMsg).not.toContain("不出现的词");
+    // Inside the envelope: directive appears BEFORE the close tag.
+    const closeIdx = userMsg.indexOf("</transcript>");
+    const dirIdx = userMsg.indexOf("修正表");
+    expect(closeIdx).toBeGreaterThan(-1);
+    expect(dirIdx).toBeGreaterThan(-1);
+    expect(dirIdx).toBeLessThan(closeIdx);
+  });
+
+  it("no matching corrections → no directive in the prompt", async () => {
+    const handlers: Record<string, (...args: unknown[]) => unknown> = {};
+    const ipcMain = {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        handlers[channel] = fn;
+      }),
+    };
+    const prevFetch = global.fetch;
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({
+        choices: [{ message: { content: "润色结果" }, finish_reason: "stop" }],
+      }),
+    })) as unknown as typeof fetch;
+    aiHandlersNS.register(
+      ipcMain as never,
+      {
+        databaseManager: makeDb([{ wrong: "无关词", right: "x" }]),
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      } as never,
+    );
+
+    await processHandler(handlers)(
+      { sender: { id: 1 } },
+      "完全无关的文本",
+      "optimize",
+    );
+    const noMatchMsg = messagesOf(captureBody());
+    global.fetch = prevFetch;
+    expect(noMatchMsg).not.toContain("修正表");
+  });
+
+  it("missing vocab surface on the manager → polish proceeds without injection", async () => {
+    const handlers: Record<string, (...args: unknown[]) => unknown> = {};
+    const ipcMain = {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        handlers[channel] = fn;
+      }),
+    };
+    const prevFetch = global.fetch;
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({
+        choices: [{ message: { content: "润色结果" }, finish_reason: "stop" }],
+      }),
+    })) as unknown as typeof fetch;
+    aiHandlersNS.register(
+      ipcMain as never,
+      {
+        databaseManager: makeDbNoVocab(),
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      } as never,
+    );
+
+    const result = (await processHandler(handlers)(
+      { sender: { id: 1 } },
+      "普通文本",
+      "optimize",
+    )) as { success: boolean };
+    const noVocabMsg = messagesOf(captureBody());
+    global.fetch = prevFetch;
+    expect(result.success).toBe(true);
+    expect(noVocabMsg).not.toContain("修正表");
+  });
+});

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -2021,3 +2021,77 @@ describe("[20260908_Feat_333_VocabInjection] corrections injection", () => {
     expect(noVocabMsg).not.toContain("修正表");
   });
 });
+
+// [20260909_Fix_333_Review] Custom-arm directive placement + $&-safe replacer.
+describe("[20260909_Fix_333_Review] injection placement regressions", () => {
+  it("custom-template arm injects the directive INSIDE the envelope", async () => {
+    const handlers: Record<string, (...args: unknown[]) => unknown> = {};
+    const ipcMain = {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        handlers[channel] = fn;
+      }),
+    };
+    const prevFetch = global.fetch;
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({
+        choices: [{ message: { content: "润色结果" }, finish_reason: "stop" }],
+      }),
+    })) as unknown as typeof fetch;
+    const db = {
+      getSetting: vi.fn(async (key: string) =>
+        key === "ai_base_url"
+          ? "https://api.example.com/v1"
+          : key === "ai_api_key"
+            ? "sk"
+            : key === "ai_model"
+              ? "gpt-x"
+              : null,
+      ),
+      listVocabCorrections: vi.fn(() => [{ wrong: "会义室", right: "会议室" }]),
+    };
+    aiHandlersNS.register(
+      ipcMain as never,
+      {
+        databaseManager: db,
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/tpl-333",
+      } as never,
+    );
+
+    // Stub a custom template via the templatesDir cache: register() reads
+    // the dir; simplest reliable route is monkeypatching getCachedTemplates
+    // behavior via fs — instead exercise buildPrompt directly for placement
+    // (the orchestrator wiring is covered above).
+    global.fetch = prevFetch;
+    const { buildPrompt } = await import("../../src/helpers/aiPrompts");
+    const result = buildPrompt("custom-with-envelope", "我们在会义室开会", {
+      customTemplates: [
+        {
+          name: "custom-with-envelope",
+          label: "模板",
+          system: "系统",
+          user: "整理：<transcript>\n{text}\n</transcript>",
+        },
+      ],
+      vocabCorrections: [{ wrong: "会义室", right: "会议室" }],
+    });
+    const closeIdx = result.user.lastIndexOf("</transcript>");
+    const dirIdx = result.user.indexOf("修正表");
+    expect(closeIdx).toBeGreaterThan(-1);
+    expect(dirIdx).toBeGreaterThan(-1);
+    expect(dirIdx).toBeLessThan(closeIdx);
+  });
+
+  it("built-in arm directive survives $&-family sequences in vocab terms", async () => {
+    const { buildPrompt } = await import("../../src/helpers/aiPrompts");
+    const result = buildPrompt("optimize", "文本", {
+      vocabCorrections: [{ wrong: "X", right: "cost is $& total" }],
+    });
+    // The $& must appear literally — no expansion into the matched close tag.
+    expect(result.user).toContain("cost is $& total");
+    expect(result.user.match(/<\/transcript>/g)).toHaveLength(1);
+  });
+});

--- a/tests/unit/file-import.test.tsx
+++ b/tests/unit/file-import.test.tsx
@@ -399,7 +399,7 @@ describe("[20260816_Test_FileImportExpanded] FileImport — remaining branches",
     });
     expect(api.aiReviewTranscription).toHaveBeenCalledWith(42);
     await waitFor(() => {
-      expect(screen.getByText("审校后的文本")).toBeInTheDocument();
+      expect(screen.getAllByText("审校后的文本").length).toBeGreaterThan(0);
     });
   });
 });

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -136,7 +136,7 @@ describe("TranscriptionResult — AI optimize paths", () => {
     render(<TranscriptionResult text="原始待优化" />);
     fireEvent.click(await findOptimizeButton());
     await waitFor(() => {
-      expect(screen.getByText("优化后文本")).toBeInTheDocument();
+      expect(screen.getAllByText("优化后文本").length).toBeGreaterThan(0);
     });
     // [20260907_Feat_236_StreamingUi] no chunk channel in this stub →
     // non-streaming fallback: the classic two-argument invoke.
@@ -162,7 +162,7 @@ describe("TranscriptionResult — AI optimize paths", () => {
     render(<TranscriptionResult text="走属性" onAIOptimize={onAIOptimize} />);
     fireEvent.click(await findOptimizeButton());
     await waitFor(() => {
-      expect(screen.getByText("属性优化结果")).toBeInTheDocument();
+      expect(screen.getAllByText("属性优化结果").length).toBeGreaterThan(0);
     });
     expect(onAIOptimize).toHaveBeenCalledWith("走属性");
   });
@@ -514,7 +514,7 @@ describe("TranscriptionResult — preferOnAIOptimize (#316)", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("评审通道的文本")).toBeInTheDocument();
+      expect(screen.getAllByText("评审通道的文本").length).toBeGreaterThan(0);
     });
     expect(processText).not.toHaveBeenCalled();
   });
@@ -549,7 +549,7 @@ describe("TranscriptionResult — preferOnAIOptimize (#316)", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("默认通道的文本")).toBeInTheDocument();
+      expect(screen.getAllByText("默认通道的文本").length).toBeGreaterThan(0);
     });
     expect(onAIOptimize).not.toHaveBeenCalled();
   });
@@ -616,7 +616,7 @@ describe("TranscriptionResult — polish write-back failure (#314)", () => {
       );
     });
     // The polished result stays on screen (documented intent).
-    expect(screen.getByText("润色后文本")).toBeInTheDocument();
+    expect(screen.getAllByText("润色后文本").length).toBeGreaterThan(0);
     consoleSpy.mockRestore();
   });
 
@@ -659,7 +659,7 @@ describe("TranscriptionResult — polish write-back failure (#314)", () => {
       );
     });
     // Not wiped: the polished text stays on screen.
-    expect(screen.getByText("润色后文本")).toBeInTheDocument();
+    expect(screen.getAllByText("润色后文本").length).toBeGreaterThan(0);
     consoleSpy2.mockRestore();
   });
 });
@@ -779,7 +779,9 @@ describe("TranscriptionResult — streaming manual polish (#236 ①)", () => {
       reasoningChars: 0,
     });
 
-    await screen.findByText("最终润色结果");
+    expect((await screen.findAllByText("最终润色结果")).length).toBeGreaterThan(
+      0,
+    );
     await vi.waitFor(() => expect(unsubSpy).toHaveBeenCalled());
   });
 
@@ -911,5 +913,128 @@ describe("TranscriptionResult — streaming error paths (#236 review)", () => {
       expect(screen.getByText("AI处理失败，请重试")).toBeInTheDocument();
     });
     expect(screen.getByText("原始转写内容")).toBeInTheDocument();
+  });
+});
+
+// [20260908_Feat_333_PanelIntegration] Mode split: after a successful
+// polish, minimal-edit modes stage the diff review panel and rewrite modes
+// stage the whole-text panel — until then neither is mounted.
+describe("TranscriptionResult — post-polish review staging (#333)", () => {
+  function makeApi(extra: Record<string, unknown> = {}) {
+    return {
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "润色完成" }),
+      getAIModes: vi.fn().mockResolvedValue([
+        { name: "optimize", label: "智能润色", description: "" },
+        { name: "summarize", label: "摘要总结", description: "" },
+      ]),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
+      addVocabCorrection: vi.fn().mockResolvedValue({ success: true }),
+      ...extra,
+    };
+  }
+  function mountWith(mode: string, api: Record<string, unknown>) {
+    (globalThis.window as unknown as { electronAPI?: unknown }).electronAPI =
+      api;
+    const onCopy = vi.fn();
+    render(
+      React.createElement(TranscriptionResult, {
+        text: "原文内容",
+        id: 42,
+        onCopy,
+      }),
+    );
+    return { onCopy };
+  }
+
+  const originalAPI = (
+    globalThis.window as unknown as { electronAPI?: unknown }
+  ).electronAPI;
+  afterEach(() => {
+    (globalThis.window as unknown as { electronAPI?: unknown }).electronAPI =
+      originalAPI;
+    vi.clearAllMocks();
+  });
+
+  it("minimal-edit mode mounts the diff review after polish", async () => {
+    const api = makeApi();
+    mountWith("optimize", api);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    expect(await screen.findByTestId("polish-review")).toBeInTheDocument();
+    expect(screen.getByTestId("diff-review")).toBeInTheDocument();
+  });
+
+  it("rewrite mode mounts the whole-text review after polish", async () => {
+    const api = makeApi();
+    mountWith("summarize", api);
+    fireEvent.change(await screen.findByDisplayValue("智能润色"), {
+      target: { value: "summarize" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    expect(await screen.findByTestId("polish-review")).toBeInTheDocument();
+    expect(screen.getByTestId("rewrite-review")).toBeInTheDocument();
+  });
+
+  it("rewrite accept persists via updateTranscription and clears the panel", async () => {
+    const api = makeApi();
+    mountWith("summarize", api);
+    fireEvent.change(await screen.findByDisplayValue("智能润色"), {
+      target: { value: "summarize" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    fireEvent.click(await screen.findByTestId("rewrite-accept"));
+    expect(api.updateTranscription).toHaveBeenCalledWith(42, {
+      processed_text: "润色完成",
+      text: "润色完成",
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("polish-review")).not.toBeInTheDocument();
+    });
+  });
+
+  it("rewrite revert restores the original and persists it", async () => {
+    const api = makeApi();
+    mountWith("summarize", api);
+    fireEvent.change(await screen.findByDisplayValue("智能润色"), {
+      target: { value: "summarize" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    fireEvent.click(await screen.findByTestId("rewrite-revert"));
+    expect(api.updateTranscription).toHaveBeenCalledWith(42, {
+      processed_text: "原文内容",
+      text: "原文内容",
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("polish-review")).not.toBeInTheDocument();
+    });
+  });
+
+  it("rewrite annotate routes to addVocabCorrection", async () => {
+    const api = makeApi();
+    mountWith("summarize", api);
+    fireEvent.change(await screen.findByDisplayValue("智能润色"), {
+      target: { value: "summarize" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    fireEvent.click(await screen.findByTestId("rewrite-annotate"));
+    fireEvent.change(screen.getByLabelText("错误词"), {
+      target: { value: "会义室" },
+    });
+    fireEvent.change(screen.getByLabelText("正确词"), {
+      target: { value: "会议室" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "记入修正表" }));
+    expect(api.addVocabCorrection).toHaveBeenCalledWith("会义室", "会议室");
   });
 });

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -934,7 +934,8 @@ describe("TranscriptionResult — post-polish review staging (#333)", () => {
       ...extra,
     };
   }
-  function mountWith(mode: string, api: Record<string, unknown>) {
+  // mode selects the panel class via the mode selector after mount.
+  function mountWith(_mode: string, api: Record<string, unknown>) {
     (globalThis.window as unknown as { electronAPI?: unknown }).electronAPI =
       api;
     const onCopy = vi.fn();


### PR DESCRIPTION
## 概述

#333 集成票:T12 diff 对照面板 + T13 重写对照/修正表接入生产路径,修正表注入编排器。独立评审后台运行中,结论前不关票。

## 交付

- **面板挂载**(TranscriptionResult):润色成功后进入评审态(pendingReview)——最小修改类(optimize/optimize_long/format/correct)挂 DiffReviewPanel(逐块接受/拒绝,归并结果经 T1 UPDATE 写回);重写类挂 RewriteReviewPanel(整篇对照,一键回退=原文写回,标注修正→VOCAB_ADD)
- **修正表注入**(编排器):prompt 构建时解析 vocabulary 表→按出现过滤(≤20 最近使用)→buildPrompt 在 XML 包裹**内**追加修正指令(内置与自定义模板两臂,注入防护覆盖);表读取失败/无表面→静默跳过注入(润色不因可选修正表失败)

## 验证

2308 unit 全绿(164 文件);lint 0;tsc 双配置零。新增:3 注入端到端 + 5 挂载分流测试;遗留文本断言因面板重复展示改为多匹配容错。

## 关联

- T12(#325)/T13(#332)面板本体;#314 写回 toast 既有
- 接线注意(评审 #334 留言):vocab 拉丁词边界、AI_REVIEW 渲染端无取消(预存)——前者本轮未处理(注入过滤用 substring,CJK 语义正确)
