### PR TITLE
feat: T10 流式降级探测与记忆（Spec #193, closes #237）

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -87,6 +87,12 @@ export const preloadApi: ElectronAPI = {
   deleteVocabCorrection: (wrong: string) =>
     ipcRenderer.invoke(C.AI.VOCAB_DELETE, wrong),
   clearVocabCorrections: () => ipcRenderer.invoke(C.AI.VOCAB_CLEAR),
+  // [20260910_Feat_237_StreamDegradation] T10 degradation-memory view/reset.
+  listStreamDegradations: () =>
+    ipcRenderer.invoke(C.AI.STREAM_DEGRADATION_LIST),
+  resetStreamDegradations: () =>
+    ipcRenderer.invoke(C.AI.STREAM_DEGRADATION_RESET),
+  // [20260910_Feat_237_StreamDegradation] END
   onPolishChunk: (
     callback: (chunk: import("./src/types/ipc").PolishChunk) => void,
   ) =>

--- a/src/electronAPI.d.ts
+++ b/src/electronAPI.d.ts
@@ -87,6 +87,18 @@ export interface ElectronAPI {
   ) => Promise<OperationResult>;
   deleteVocabCorrection: (wrong: string) => Promise<OperationResult>;
   clearVocabCorrections: () => Promise<OperationResult>;
+  // [20260910_Feat_237_StreamDegradation] T10 degradation-memory view/reset.
+  listStreamDegradations: () => Promise<{
+    success: boolean;
+    entries: Array<{ baseUrl: string; at: number }>;
+    error?: string;
+  }>;
+  resetStreamDegradations: () => Promise<
+    OperationResult & {
+      removed?: number;
+    }
+  >;
+  // [20260910_Feat_237_StreamDegradation] END
   onPolishChunk: (callback: (chunk: PolishChunk) => void) => () => void;
   getAIModes: () => Promise<AIMode[]>;
   getAIProviderPresets: () => Promise<AIProviderPreset[]>;

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -525,6 +525,16 @@ class DatabaseManager {
     return runStmt(stmt, key, serialized);
   }
 
+  // [20260910_Feat_237_StreamDegradation] Per-key delete for the T10
+  // degradation memory (reset + oldest-first eviction). The settings table
+  // previously only had a delete-ALL; deleting by key keeps tombstones out
+  // of the store.
+  deleteSetting(key: string): RunResult {
+    const stmt = this.db!.prepare("DELETE FROM settings WHERE key = ?");
+    return runStmt(stmt, key);
+  }
+  // [20260910_Feat_237_StreamDegradation] END
+
   getSetting(key: string, defaultValue: unknown = null): unknown {
     const stmt = this.db!.prepare("SELECT value FROM settings WHERE key = ?");
     // [20260726_TechDebt_TypedRows] Using getRow helper instead of cast

--- a/src/helpers/ipc-contracts.ts
+++ b/src/helpers/ipc-contracts.ts
@@ -74,6 +74,10 @@ export const AI = {
   VOCAB_ADD: "vocab-add",
   VOCAB_DELETE: "vocab-delete",
   VOCAB_CLEAR: "vocab-clear",
+  // [20260910_Feat_237_StreamDegradation] T10: settings-page view/reset of
+  // the stream-degradation memory (server-side read path is internal).
+  STREAM_DEGRADATION_LIST: "stream-degradation-list",
+  STREAM_DEGRADATION_RESET: "stream-degradation-reset",
   GET_MODES: "get-ai-modes",
   GET_PROVIDER_PRESETS: "get-ai-provider-presets",
   DETECT_LOCAL_MODELS: "detect-local-models",

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -918,7 +918,13 @@ export async function runPolishOrchestrator(
     }
 
     const timeoutMs = request.timeout || (isLocal ? 180_000 : 150_000);
+    // [20260910_Feat_237_StreamDegradation] T10: one deadline shared by the
+    // streaming attempt AND its degradation retry — a slow-then-4xx gateway
+    // must not double the user's wait. (Also serves the tagged retry below:
+    // `response` is reassigned there.)
+    const deadlineMs = Date.now() + timeoutMs;
     const timeoutMessage = `AI请求超时（${Math.round(timeoutMs / 1000)}秒），请尝试缩短文本或检查网络`;
+    // [20260910_Feat_237_StreamDegradation] END
     let response = await postChatCompletion(
       baseUrl,
       apiKey,
@@ -940,13 +946,20 @@ export async function runPolishOrchestrator(
     // IMMEDIATE 4xx to the streaming attempt means the gateway rejected the
     // stream itself — retry ONCE without stream:true. The retry rides the
     // same run signal, so a user cancel aborts it identically; generation
-    // gates bracket it like the first attempt.
+    // gates bracket it like the first attempt. Auth/quota statuses
+    // (401/403/429) are EXCLUDED: they fail identically non-streaming, and
+    // retrying them would double pressure on an already-limiting gateway.
+    const retryBudgetMs = deadlineMs - Date.now();
     if (
       useStream &&
       request.stream &&
       !response.ok &&
       response.status >= 400 &&
-      response.status < 500
+      response.status < 500 &&
+      response.status !== 401 &&
+      response.status !== 403 &&
+      response.status !== 429 &&
+      retryBudgetMs > 0
     ) {
       request.stream.notify({
         type: "degraded",
@@ -958,7 +971,7 @@ export async function runPolishOrchestrator(
         baseUrl,
         apiKey,
         { ...requestData, stream: false },
-        timeoutMs,
+        retryBudgetMs,
         timeoutMessage,
         runHandle?.controller.signal,
       );

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -17,6 +17,11 @@ import {
 } from "../polish-stream";
 // [20260908_Feat_333_VocabInjection] Corrections-table injection (T13→#333).
 import { filterVocabForInjection } from "../vocab";
+// [20260910_Feat_237_StreamDegradation] T10: degradation memory read/write.
+import {
+  isStreamDegradationRemembered,
+  rememberStreamDegradation,
+} from "../streamDegradation";
 
 interface Logger {
   info?(message: string, ...args: unknown[]): void;
@@ -28,6 +33,13 @@ interface DatabaseManager {
   getSetting(key: string): Promise<unknown>;
   // [20260908_Feat_333_VocabInjection] Corrections-table read for injection.
   listVocabCorrections?(): Array<{ wrong: string; right: string }>;
+  // [20260910_Feat_237_StreamDegradation] T10 store surface (optional so
+  // legacy test doubles that only stub getSetting keep compiling; the
+  // degradation paths run only for streaming requests, and a store without
+  // write/enumeration simply cannot remember).
+  setSetting?(key: string, value: unknown): unknown;
+  getAllSettings?(): Record<string, unknown>;
+  deleteSetting?(key: string): unknown;
 }
 
 interface AIMode {
@@ -759,6 +771,22 @@ export async function runPolishOrchestrator(
   // invalidates this one before it even reaches the provider). Null when the
   // request opts out — the legacy path below is untouched.
   const runHandle = beginPolishRun(request);
+  // [20260910_Feat_237_StreamDegradation] T10: settle-aside exits that
+  // bypass consumePolishStream (pre-fetch gate, post-response gates, the
+  // degraded retry, the outer catch) never emitted the abort chunk — a
+  // cancel landing there surfaced "已取消" as an ERROR in the UI, breaking
+  // the silent-cancel contract. Emit it centrally for streaming runs.
+  // Declared before try{} so the catch can reach it.
+  const settleAside = (outcome: AIResult): AIResult => {
+    if (request.stream) {
+      request.stream.notify({
+        type: "abort",
+        requestId: request.stream.requestId,
+      });
+    }
+    return outcome;
+  };
+  // [20260910_Feat_237_StreamDegradation] END
   try {
     const apiKey = (await databaseManager.getSetting("ai_api_key")) as
       | string
@@ -837,6 +865,28 @@ export async function runPolishOrchestrator(
       }));
     }
 
+    // [20260910_Feat_237_StreamDegradation] T10: a gateway REMEMBERED as
+    // stream-incapable skips the doomed streaming attempt entirely — one
+    // plain request, and the UI learns why via a degraded chunk. The memory
+    // read stays behind request.stream so legacy non-streaming callers
+    // never touch the settings store here.
+    const wantsStream = request.stream !== undefined;
+    const rememberedGateway = wantsStream
+      ? await isStreamDegradationRemembered(databaseManager, baseUrl)
+      : false;
+    if (rememberedGateway && request.stream) {
+      request.stream.notify({
+        type: "degraded",
+        requestId: request.stream.requestId,
+        reason: "remembered",
+      });
+    }
+    const useStream = wantsStream && !rememberedGateway;
+    // True once this run proved the gateway cannot stream (any signature);
+    // a successful fallback then persists the memory.
+    let degradedFallback = rememberedGateway;
+    // [20260910_Feat_237_StreamDegradation] END
+
     const requestData = {
       model: model,
       messages: [
@@ -847,7 +897,9 @@ export async function runPolishOrchestrator(
       max_tokens: effectiveMaxTokens,
       // [20260907_Feat_235_StreamPipeline] T8: stream the response body when
       // the caller requested it; chunk events flow through request.stream.
-      stream: request.stream !== undefined,
+      // [20260910_Feat_237_StreamDegradation] T10: ...unless the gateway is
+      // remembered as stream-incapable.
+      stream: useStream,
     };
 
     logger.info?.("AI文本处理请求:", {
@@ -862,16 +914,17 @@ export async function runPolishOrchestrator(
     // while settings/prompt were being resolved.
     const pendingOutcome = polishRunOutcomeIfSettledAside(runHandle);
     if (pendingOutcome) {
-      return pendingOutcome;
+      return settleAside(pendingOutcome);
     }
 
     const timeoutMs = request.timeout || (isLocal ? 180_000 : 150_000);
-    const response = await postChatCompletion(
+    const timeoutMessage = `AI请求超时（${Math.round(timeoutMs / 1000)}秒），请尝试缩短文本或检查网络`;
+    let response = await postChatCompletion(
       baseUrl,
       apiKey,
       requestData,
       timeoutMs,
-      `AI请求超时（${Math.round(timeoutMs / 1000)}秒），请尝试缩短文本或检查网络`,
+      timeoutMessage,
       runHandle?.controller.signal,
     );
 
@@ -880,13 +933,48 @@ export async function runPolishOrchestrator(
     // never overwrite the newer run's result.
     const staleOutcome = polishRunOutcomeIfSettledAside(runHandle);
     if (staleOutcome) {
-      return staleOutcome;
+      return settleAside(staleOutcome);
     }
+
+    // [20260910_Feat_237_StreamDegradation] T10 second signature: an
+    // IMMEDIATE 4xx to the streaming attempt means the gateway rejected the
+    // stream itself — retry ONCE without stream:true. The retry rides the
+    // same run signal, so a user cancel aborts it identically; generation
+    // gates bracket it like the first attempt.
+    if (
+      useStream &&
+      request.stream &&
+      !response.ok &&
+      response.status >= 400 &&
+      response.status < 500
+    ) {
+      request.stream.notify({
+        type: "degraded",
+        requestId: request.stream.requestId,
+        reason: "http_4xx",
+      });
+      degradedFallback = true;
+      response = await postChatCompletion(
+        baseUrl,
+        apiKey,
+        { ...requestData, stream: false },
+        timeoutMs,
+        timeoutMessage,
+        runHandle?.controller.signal,
+      );
+      const retryOutcome = polishRunOutcomeIfSettledAside(runHandle);
+      if (retryOutcome) {
+        return settleAside(retryOutcome);
+      }
+    }
+    // [20260910_Feat_237_StreamDegradation] END
 
     // [20260907_Feat_235_StreamPipeline] T8: consume the SSE body via the
     // merger + deadline matrix. A gateway that ignored stream:true (200 with
     // a non-SSE content-type) degrades to the non-stream JSON path below.
-    if (request.stream) {
+    // [20260910_Feat_237_StreamDegradation] T10: skipped when the run already
+    // degraded (remembered gateway or a completed 4xx retry).
+    if (useStream && !degradedFallback && request.stream) {
       const contentType = response.headers.get("content-type") ?? "";
       if (contentType.includes("text/event-stream")) {
         return await consumePolishStream(
@@ -902,6 +990,9 @@ export async function runPolishOrchestrator(
         requestId: request.stream.requestId,
         reason: "non_sse_response",
       });
+      // [20260910_Feat_237_StreamDegradation] T10: non-SSE 200 is the third
+      // degradation signature — the JSON path below IS the fallback.
+      degradedFallback = true;
     }
 
     // [20260908_Fix_BatchReview_M1] The response-headers timer cleared on
@@ -1001,6 +1092,19 @@ export async function runPolishOrchestrator(
         usage: result.usage,
       });
 
+      // [20260910_Feat_237_StreamDegradation] T10: the fallback SUCCEEDED —
+      // persist "this gateway cannot stream" so later runs skip straight
+      // to the JSON path. Local gateways are excluded inside remember
+      // (their streaming quirks get fixed, not memorized); a memory write
+      // failure must never fail the polish the user already has in hand.
+      if (degradedFallback && !rememberedGateway) {
+        try {
+          await rememberStreamDegradation(databaseManager, baseUrl);
+        } catch (memoryError) {
+          logger?.warn?.("流式降级记忆写入失败:", memoryError);
+        }
+      }
+      // [20260910_Feat_237_StreamDegradation] END
       return result;
     } else {
       logger.error?.("AI API返回数据格式错误:", undefined);
@@ -1013,7 +1117,7 @@ export async function runPolishOrchestrator(
     // shaped outcome — so it never drives an error UI.
     const abortOutcome = polishRunOutcomeIfSettledAside(runHandle);
     if (abortOutcome) {
-      return abortOutcome;
+      return settleAside(abortOutcome);
     }
 
     logger.error?.("AI文本处理失败:", error);

--- a/src/helpers/ipc/index.ts
+++ b/src/helpers/ipc/index.ts
@@ -50,6 +50,9 @@ function wrapWithRateLimits(ipcMain: Electron.IpcMain): Electron.IpcMain {
     [C.AI.VOCAB_ADD]: { maxCalls: 30, windowMs: 60_000 },
     [C.AI.VOCAB_DELETE]: { maxCalls: 30, windowMs: 60_000 },
     [C.AI.VOCAB_CLEAR]: { maxCalls: 5, windowMs: 60_000 },
+    // [20260910_Feat_237_StreamDegradation] T10 settings-page view/reset.
+    [C.AI.STREAM_DEGRADATION_LIST]: { maxCalls: 30, windowMs: 60_000 },
+    [C.AI.STREAM_DEGRADATION_RESET]: { maxCalls: 5, windowMs: 60_000 },
     [C.TRANSCRIPTION.SAVE]: { maxCalls: 30, windowMs: 60_000 },
     // [20260906_Feat_TranscriptionUpdate] Manual polish write-back (spec #193
     // T1, ticket #228): fires once per polish action, so it carries the same

--- a/src/helpers/ipc/settingsHandlers.ts
+++ b/src/helpers/ipc/settingsHandlers.ts
@@ -1,5 +1,10 @@
 // [20260724_TS_BigBang_SettingsHandlers] Migrated from .js to .ts (ADR-010).
 import * as C from "../ipc-contracts";
+// [20260910_Feat_237_StreamDegradation] T10 memory list/reset handlers.
+import {
+  listStreamDegradations,
+  resetStreamDegradations,
+} from "../streamDegradation";
 
 interface DatabaseManager {
   getSetting(key: string, defaultValue?: unknown): unknown;
@@ -176,6 +181,34 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
       return { success: false, error: (error as Error).message };
     }
   });
+
+  // [20260910_Feat_237_StreamDegradation] T10: view/reset the
+  // stream-degradation memory from the settings page. Read-only list is
+  // safe to show (normalized base_url + timestamp, no secrets).
+  ipcMain.handle(C.AI.STREAM_DEGRADATION_LIST, async () => {
+    try {
+      return {
+        success: true,
+        entries: await listStreamDegradations(databaseManager),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        entries: [],
+        error: (error as Error).message,
+      };
+    }
+  });
+
+  ipcMain.handle(C.AI.STREAM_DEGRADATION_RESET, async () => {
+    try {
+      const removed = await resetStreamDegradations(databaseManager);
+      return { success: true, removed };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  });
+  // [20260910_Feat_237_StreamDegradation] END
 
   // [20260906_Refactor_DeadChannelCleanup] Ticket #250: the SETTINGS.SAVE and
   // SETTINGS.RESET handlers were removed — zero renderer callers (orphans

--- a/src/helpers/streamDegradation.ts
+++ b/src/helpers/streamDegradation.ts
@@ -1,0 +1,177 @@
+// [20260910_Feat_237_StreamDegradation] Spec #193 T10 (ticket #237):
+// stream-degradation memory. When a gateway fails a STREAMING polish
+// request with a non-SSE content-type or an immediate 4xx, the fallback
+// (a single non-streaming retry) succeeding means "this gateway cannot
+// stream" — that fact is remembered under a NORMALIZED base_url hash so
+// later runs skip the doomed streaming attempt entirely.
+//
+// Storage decision (ticket constraint #3): the existing settings table
+// holds one `stream_degraded.<sha256-16>` key per gateway — no schema
+// migration, enumeration via getAllSettings, eviction by the stored `at`
+// timestamp. The hash bounds the key length regardless of how long the
+// configured base_url grows; the entry count is hard-capped so the table
+// cannot bloat.
+//
+// Local gateways are NEVER remembered: their streaming quirks are ours to
+// fix, not to bypass permanently.
+import crypto from "crypto";
+
+export const STREAM_DEGRADATION_MAX_ENTRIES = 50;
+const KEY_PREFIX = "stream_degraded.";
+const KEY_HASH_HEX_CHARS = 16;
+
+export interface StreamDegradationEntry {
+  baseUrl: string;
+  at: number;
+}
+
+/** Minimal settings-store seam — satisfied by DatabaseManager and mocks. */
+export interface StreamDegradationStore {
+  getSetting(key: string, defaultValue?: unknown): unknown | Promise<unknown>;
+  // Optional so partial test doubles keep compiling: a store without write
+  // capability simply cannot remember, and without enumeration it cannot
+  // list, evict, or reset (those degrade to no-ops/empty).
+  setSetting?(key: string, value: unknown): unknown | Promise<unknown>;
+  getAllSettings?(): Record<string, unknown> | Promise<Record<string, unknown>>;
+  deleteSetting?(key: string): unknown | Promise<unknown>;
+}
+
+/** Lowercase origin + path with trailing slashes stripped; null if invalid. */
+export function normalizeDegradationBaseUrl(baseUrl: string): string | null {
+  try {
+    const url = new URL(baseUrl);
+    return `${url.origin.toLowerCase()}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return null;
+  }
+}
+
+function degradationKey(normalizedBaseUrl: string): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(normalizedBaseUrl)
+    .digest("hex")
+    .slice(0, KEY_HASH_HEX_CHARS);
+  return `${KEY_PREFIX}${hash}`;
+}
+
+/**
+ * Conservative loopback check for the memory-write gate. Kept local to
+ * this module (rather than importing aiHandlers' SSRF predicates) to keep
+ * the dependency one-directional: aiHandlers imports THIS module.
+ */
+export function isLocalDegradationBaseUrl(baseUrl: string): boolean {
+  try {
+    let host = new URL(baseUrl).hostname.toLowerCase();
+    // URL keeps the brackets on IPv6 literals.
+    if (host.startsWith("[") && host.endsWith("]")) {
+      host = host.slice(1, -1);
+    }
+    if (host === "localhost" || host.endsWith(".localhost")) return true;
+    if (host === "0.0.0.0" || host === "::" || host === "::1") return true;
+    if (/^127\./.test(host)) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function parseEntry(value: unknown): StreamDegradationEntry | null {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as StreamDegradationEntry).baseUrl === "string" &&
+    typeof (value as StreamDegradationEntry).at === "number"
+  ) {
+    return value as StreamDegradationEntry;
+  }
+  return null;
+}
+
+async function readEntries(
+  store: StreamDegradationStore,
+): Promise<Array<{ key: string; entry: StreamDegradationEntry }>> {
+  if (!store.getAllSettings) return [];
+  const all = await store.getAllSettings();
+  const entries: Array<{ key: string; entry: StreamDegradationEntry }> = [];
+  for (const [key, value] of Object.entries(all)) {
+    if (!key.startsWith(KEY_PREFIX)) continue;
+    const entry = parseEntry(value);
+    if (entry) entries.push({ key, entry });
+  }
+  return entries;
+}
+
+async function removeKey(
+  store: StreamDegradationStore,
+  key: string,
+): Promise<void> {
+  if (store.deleteSetting) {
+    await store.deleteSetting(key);
+  } else if (store.setSetting) {
+    // Stores without a delete primitive tombstone the key; readEntries
+    // filters the null out, and a later remember overwrites it.
+    await store.setSetting(key, null);
+  }
+}
+
+export async function isStreamDegradationRemembered(
+  store: StreamDegradationStore,
+  baseUrl: string,
+): Promise<boolean> {
+  const normalized = normalizeDegradationBaseUrl(baseUrl);
+  if (!normalized) return false;
+  const value = await store.getSetting(degradationKey(normalized), null);
+  return parseEntry(value) !== null;
+}
+
+/**
+ * Remember a gateway as stream-incapable. Returns false (and writes
+ * nothing) for local addresses and unparseable base_urls. Re-remembering
+ * refreshes the timestamp. Beyond the cap, the OLDEST entries are evicted.
+ */
+export async function rememberStreamDegradation(
+  store: StreamDegradationStore,
+  baseUrl: string,
+  at: number = Date.now(),
+): Promise<boolean> {
+  const normalized = normalizeDegradationBaseUrl(baseUrl);
+  if (!normalized || isLocalDegradationBaseUrl(baseUrl)) return false;
+  if (!store.setSetting) return false;
+  await store.setSetting(degradationKey(normalized), {
+    baseUrl: normalized,
+    at,
+  });
+
+  const entries = await readEntries(store);
+  if (entries.length > STREAM_DEGRADATION_MAX_ENTRIES) {
+    entries.sort((a, b) => a.entry.at - b.entry.at);
+    const evictCount = entries.length - STREAM_DEGRADATION_MAX_ENTRIES;
+    for (const { key } of entries.slice(0, evictCount)) {
+      await removeKey(store, key);
+    }
+  }
+  return true;
+}
+
+/** Newest first. */
+export async function listStreamDegradations(
+  store: StreamDegradationStore,
+): Promise<StreamDegradationEntry[]> {
+  const entries = await readEntries(store);
+  return entries
+    .sort((a, b) => b.entry.at - a.entry.at)
+    .map(({ entry }) => entry);
+}
+
+/** Remove every remembered gateway; returns how many were removed. */
+export async function resetStreamDegradations(
+  store: StreamDegradationStore,
+): Promise<number> {
+  const entries = await readEntries(store);
+  for (const { key } of entries) {
+    await removeKey(store, key);
+  }
+  return entries.length;
+}
+// [20260910_Feat_237_StreamDegradation] END

--- a/src/helpers/streamDegradation.ts
+++ b/src/helpers/streamDegradation.ts
@@ -40,6 +40,9 @@ export interface StreamDegradationStore {
 export function normalizeDegradationBaseUrl(baseUrl: string): string | null {
   try {
     const url = new URL(baseUrl);
+    // Deliberately a SUBSET of the URL: query strings (e.g. Azure-style
+    // ?api-version=) and userinfo do not distinguish a gateway's streaming
+    // capability, so they share one memory entry.
     return `${url.origin.toLowerCase()}${url.pathname.replace(/\/+$/, "")}`;
   } catch {
     return null;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -120,7 +120,14 @@
       "vocabCount": "{{count}} pairs",
       "vocabAddFailed": "Add failed",
       "vocabClearConfirm": "Clear ALL correction pairs?",
-      "vocabDelete": "Delete"
+      "vocabDelete": "Delete",
+      "streamDegradationTitle": "Streaming fallback memory",
+      "streamDegradationHint": "When an AI gateway cannot serve streaming responses, Murmur remembers it and sends plain whole-message requests from then on, instead of failing once first. Local addresses are never remembered.",
+      "streamDegradationEmpty": "Nothing remembered",
+      "streamDegradationCount": "{{count}} gateways",
+      "streamDegradationReset": "Reset",
+      "streamDegradationResetConfirm": "Reset ALL streaming fallback memory?",
+      "streamDegradationResetFailed": "Reset failed"
     },
     "quickStart": {
       "title": "Quick Start",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -120,7 +120,14 @@
       "vocabCount": "{{count}} 条词对",
       "vocabAddFailed": "添加失败",
       "vocabClearConfirm": "确定清空全部修正词对吗？",
-      "vocabDelete": "删除"
+      "vocabDelete": "删除",
+      "streamDegradationTitle": "流式降级记忆",
+      "streamDegradationHint": "当某个 AI 网关不支持流式响应时，Murmur 会记住它，之后直接发送整段请求，不再每次先失败一次。本地地址不会被记录。",
+      "streamDegradationEmpty": "暂无记录",
+      "streamDegradationCount": "{{count}} 个网关",
+      "streamDegradationReset": "重置",
+      "streamDegradationResetConfirm": "确定重置全部流式降级记忆吗？",
+      "streamDegradationResetFailed": "重置失败"
     },
     "quickStart": {
       "title": "快速开始",

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -7,6 +7,8 @@ import type { SettingsState } from "../useSettings";
 import { buildAccelerator, formatAccelerator } from "../hotkeyRecorder";
 // [20260908_Feat_240_VocabCorrections] T13: corrections-table management.
 import { VocabManager } from "./VocabManager";
+// [20260910_Feat_237_StreamDegradation] T10 degradation-memory panel.
+import { StreamDegradationManager } from "./StreamDegradationManager";
 
 interface GeneralSectionProps {
   settings: SettingsState;
@@ -330,6 +332,8 @@ export const GeneralSection: React.FC<GeneralSectionProps> = ({
       </div>
       {/* [20260908_Feat_240_VocabCorrections] T13 corrections management. */}
       <VocabManager />
+      {/* [20260910_Feat_237_StreamDegradation] T10 degradation memory. */}
+      <StreamDegradationManager />
     </div>
   );
 };

--- a/src/settings/sections/StreamDegradationManager.tsx
+++ b/src/settings/sections/StreamDegradationManager.tsx
@@ -1,0 +1,114 @@
+// [20260910_Feat_237_StreamDegradation] Spec #193 T10 (ticket #237):
+// settings-page view of the stream-degradation memory — gateways that
+// proved unable to stream are listed (normalized base_url + when), and the
+// whole memory can be reset. Read-only otherwise: entries are written by
+// the polish pipeline, never edited by hand.
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+interface DegradationEntry {
+  baseUrl: string;
+  at: number;
+}
+
+export const StreamDegradationManager: React.FC = () => {
+  const { t } = useTranslation();
+  const [entries, setEntries] = React.useState<DegradationEntry[]>([]);
+
+  const reload = React.useCallback(async () => {
+    if (!window.electronAPI?.listStreamDegradations) return;
+    try {
+      const result = await window.electronAPI.listStreamDegradations();
+      if (result.success) setEntries(result.entries);
+    } catch {
+      // Bridge failure leaves the current list; the next mount retries.
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const reset = async () => {
+    if (
+      !window.confirm(
+        t(
+          "settings.general.streamDegradationResetConfirm",
+          "确定重置全部流式降级记忆吗？",
+        ),
+      )
+    ) {
+      return;
+    }
+    try {
+      const result = await window.electronAPI?.resetStreamDegradations?.();
+      if (!result?.success) {
+        toast.error(
+          t("settings.general.streamDegradationResetFailed", "重置失败"),
+        );
+        return;
+      }
+    } catch {
+      toast.error(
+        t("settings.general.streamDegradationResetFailed", "重置失败"),
+      );
+      return;
+    }
+    await reload();
+  };
+
+  return (
+    <div data-testid="stream-degradation-manager" className="space-y-3">
+      <h3 className="text-sm font-medium text-[#1d1d1f] dark:text-[#f5f5f7]">
+        {t("settings.general.streamDegradationTitle", "流式降级记忆")}
+      </h3>
+      <p className="text-xs text-[#86868b]">
+        {t(
+          "settings.general.streamDegradationHint",
+          "当某个 AI 网关不支持流式响应时，Murmur 会记住它，之后直接发送整段请求，不再每次先失败一次。本地地址不会被记录。",
+        )}
+      </p>
+      <div className="flex items-center gap-2">
+        <p className="text-xs text-[#86868b]">
+          {t("settings.general.streamDegradationCount", "{{count}} 个网关", {
+            count: entries.length,
+          })}
+        </p>
+        {entries.length > 0 && (
+          <button
+            type="button"
+            data-testid="stream-degradation-reset"
+            onClick={() => void reset()}
+            className="px-2 py-1 text-xs rounded-md border border-[#d2d2d7] dark:border-[#3a3a3c] text-[#ff5f57]"
+          >
+            {t("settings.general.streamDegradationReset", "重置")}
+          </button>
+        )}
+      </div>
+      {entries.length === 0 ? (
+        <p
+          data-testid="stream-degradation-empty"
+          className="text-xs text-[#86868b]"
+        >
+          {t("settings.general.streamDegradationEmpty", "暂无记录")}
+        </p>
+      ) : (
+        <ul className="space-y-1 max-h-48 overflow-y-auto">
+          {entries.map((entry) => (
+            <li
+              key={entry.baseUrl}
+              className="flex items-center gap-2 text-sm text-[#1d1d1f] dark:text-[#f5f5f7]"
+            >
+              <span className="font-mono text-xs">{entry.baseUrl}</span>
+              <span className="text-xs text-[#86868b]">
+                {new Date(entry.at).toLocaleString()}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+// [20260910_Feat_237_StreamDegradation] END

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -2095,3 +2095,297 @@ describe("[20260909_Fix_333_Review] injection placement regressions", () => {
     expect(result.user.match(/<\/transcript>/g)).toHaveLength(1);
   });
 });
+
+// [20260910_Feat_237_StreamDegradation] Spec #193 T10 (ticket #237):
+// degradation detection + memory at the orchestrator level. Fetch is
+// mocked three ways (healthy SSE / non-SSE 200 / immediate 4xx); the
+// databaseManager mock is a Map-backed settings store so the memory
+// module's real key/normalization logic runs unmodified. Self-contained
+// harness mirroring the T8 describe above (sender-scoped chunk capture).
+describe("[20260910_Feat_237_StreamDegradation] T10 degradation + memory", () => {
+  let registeredHandlers: Record<string, (...args: unknown[]) => unknown>;
+  let sendBySender: Map<number, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    sendBySender = new Map([[1, vi.fn()]]);
+  });
+
+  function senderEvent(id: number) {
+    return {
+      sender: {
+        id,
+        isDestroyed: vi.fn(() => false),
+        send: sendBySender.get(id) ?? vi.fn(),
+      },
+    };
+  }
+
+  function chunksFor(id: number): Array<{ type: string; reason?: string }> {
+    return sendBySender
+      .get(id)!
+      .mock.calls.map((call) => call[1] as { type: string; reason?: string });
+  }
+
+  function setupDbMock(baseUrl: string) {
+    const store = new Map<string, unknown>([
+      ["ai_api_key", "sk"],
+      ["ai_base_url", baseUrl],
+      ["ai_model", "gpt-x"],
+    ]);
+    return {
+      getSetting: vi.fn(async (key: string) => store.get(key) ?? null),
+      setSetting: vi.fn((key: string, value: unknown) => {
+        store.set(key, value);
+      }),
+      getAllSettings: vi.fn(() => Object.fromEntries(store)),
+      listVocabCorrections: vi.fn(() => []),
+    };
+  }
+
+  function setup(baseUrl = "https://api.example.com/v1") {
+    registeredHandlers = {};
+    const ipcMain = {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        registeredHandlers[channel] = fn;
+      }),
+    };
+    const db = setupDbMock(baseUrl);
+    aiHandlersNS.register(
+      ipcMain as never,
+      {
+        databaseManager: db,
+        funasrManager: null,
+        processTextWithAI: vi.fn(),
+        windowManager: { mainWindow: null },
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      } as never,
+    );
+    return db;
+  }
+
+  // Response stubs — narrowest shape the pipeline reads.
+  function jsonOk(content: string) {
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ choices: [{ message: { content } }] }),
+      text: async () => JSON.stringify({ choices: [{ message: { content } }] }),
+    };
+  }
+
+  function httpError(status: number) {
+    return {
+      ok: false,
+      status,
+      statusText: `HTTP ${status}`,
+      text: async () => "gateway error",
+    };
+  }
+
+  function sseOk(content: string) {
+    const frames = [
+      `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].map((frame) => new TextEncoder().encode(frame));
+    let index = 0;
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "text/event-stream" }),
+      body: {
+        getReader: () => ({
+          read: async () =>
+            index < frames.length
+              ? { done: false, value: frames[index++] }
+              : { done: true, value: undefined },
+        }),
+      },
+    };
+  }
+
+  function pendingUntilAbort(initSignal?: AbortSignal): Promise<never> {
+    return new Promise((_resolve, reject) => {
+      const onAbort = () => reject(new DOMException("aborted", "AbortError"));
+      if (initSignal?.aborted) onAbort();
+      else initSignal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  /** Parsed JSON body of the Nth mocked fetch call. */
+  function requestBodyOf(
+    fetchMock: FetchMock,
+    index: number,
+  ): { stream?: boolean } {
+    const init = fetchMock.mock.calls[index]![1] as { body: string };
+    return JSON.parse(init.body) as { stream?: boolean };
+  }
+
+  function degradationWrites(db: ReturnType<typeof setupDbMock>) {
+    return db.setSetting.mock.calls.filter((call) =>
+      String(call[0]).startsWith("stream_degraded."),
+    );
+  }
+
+  it("healthy SSE streams deltas and writes NO memory", async () => {
+    const db = setup();
+    global.fetch = vi.fn(async () => sseOk("流式结果")) as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-sse",
+    )) as { success: boolean; text?: string };
+
+    expect(result).toMatchObject({ success: true, text: "流式结果" });
+    const types = chunksFor(1).map((c) => c.type);
+    expect(types).toContain("delta");
+    expect(types).toContain("finish");
+    expect(types).not.toContain("degraded");
+    expect(degradationWrites(db)).toHaveLength(0);
+  });
+
+  it("non-SSE 200 degrades to the JSON path, notifies UI, remembers", async () => {
+    const db = setup();
+    global.fetch = vi.fn(async () => jsonOk("降级结果")) as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-nonsse",
+    )) as { success: boolean; text?: string };
+
+    expect(result).toMatchObject({ success: true, text: "降级结果" });
+    expect(chunksFor(1)).toContainEqual(
+      expect.objectContaining({ type: "degraded", reason: "non_sse_response" }),
+    );
+    expect(degradationWrites(db)).toHaveLength(1);
+  });
+
+  it("immediate 4xx on a streaming request retries once non-streaming", async () => {
+    const db = setup();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => httpError(400))
+      .mockImplementationOnce(async () =>
+        jsonOk("重试成功"),
+      ) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-4xx",
+    )) as { success: boolean; text?: string };
+
+    expect(result).toMatchObject({ success: true, text: "重试成功" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // First attempt streamed, the retry did not.
+    expect(requestBodyOf(fetchMock, 0).stream).toBe(true);
+    expect(requestBodyOf(fetchMock, 1).stream).toBe(false);
+    expect(chunksFor(1)).toContainEqual(
+      expect.objectContaining({ type: "degraded", reason: "http_4xx" }),
+    );
+    expect(degradationWrites(db)).toHaveLength(1);
+  });
+
+  it("a REMEMBERED gateway skips streaming entirely (single non-stream fetch)", async () => {
+    const db = setup();
+    const { rememberStreamDegradation } =
+      await import("../../src/helpers/streamDegradation");
+    await rememberStreamDegradation(db, "https://api.example.com/v1");
+    const fetchMock = vi.fn(async () =>
+      jsonOk("直连结果"),
+    ) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-remembered",
+    )) as { success: boolean; text?: string };
+
+    expect(result).toMatchObject({ success: true, text: "直连结果" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestBodyOf(fetchMock, 0).stream).toBe(false);
+    expect(chunksFor(1)).toContainEqual(
+      expect.objectContaining({ type: "degraded", reason: "remembered" }),
+    );
+  });
+
+  it("local gateways are retried but NEVER remembered", async () => {
+    const db = setup("http://127.0.0.1:8317/v1");
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => httpError(400))
+      .mockImplementationOnce(async () =>
+        jsonOk("本地结果"),
+      ) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-local",
+    )) as { success: boolean; text?: string };
+
+    expect(result).toMatchObject({ success: true, text: "本地结果" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(degradationWrites(db)).toHaveLength(0);
+  });
+
+  it("the degradation retry is cancellable via POLISH_ABORT", async () => {
+    setup();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => httpError(400))
+      .mockImplementationOnce(
+        (_url: unknown, init?: { signal?: AbortSignal }) =>
+          pendingUntilAbort(init?.signal),
+      ) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const processPromise = registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-cancel",
+    ) as Promise<unknown>;
+
+    // Wait until the retry fetch is in flight, then abort as the owner.
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const abortResult = (await registeredHandlers[C.AI.POLISH_ABORT]!(
+      senderEvent(1),
+      "sd-cancel",
+    )) as { success: boolean };
+    expect(abortResult).toEqual({ success: true });
+
+    const result = (await processPromise) as {
+      success: boolean;
+      code?: string;
+    };
+    expect(result.success).toBe(false);
+    expect(result.code).toBe("CANCELLED");
+    expect(chunksFor(1)).toContainEqual(
+      expect.objectContaining({ type: "abort" }),
+    );
+  });
+});

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -2384,8 +2384,96 @@ describe("[20260910_Feat_237_StreamDegradation] T10 degradation + memory", () =>
     };
     expect(result.success).toBe(false);
     expect(result.code).toBe("CANCELLED");
-    expect(chunksFor(1)).toContainEqual(
-      expect.objectContaining({ type: "abort" }),
-    );
+    // Pin SINGLE emission: one abort chunk per cancelled run, never two
+    // (settleAside vs consumePolishStream double-notify guard).
+    expect(chunksFor(1).filter((c) => c.type === "abort")).toHaveLength(1);
   });
+
+  // [20260910_Feat_237_ReviewFixes] Review MINOR #1: auth/quota 4xx statuses
+  // fail identically without streaming — retrying them doubles pressure on
+  // an already-limiting gateway and could memorialize a transient failure.
+  it("401/429 are NOT retried and never remembered", async () => {
+    for (const status of [401, 403, 429]) {
+      const db = setup();
+      const fetchMock = vi.fn(async () =>
+        httpError(status),
+      ) as unknown as FetchMock;
+      global.fetch = fetchMock as never;
+      const C = await import("../../src/helpers/ipc-contracts");
+
+      const result = (await registeredHandlers[C.AI.PROCESS]!(
+        senderEvent(1),
+        "原文",
+        "optimize",
+        10_000,
+        `sd-no-retry-${status}`,
+      )) as { success: boolean };
+
+      expect(result.success).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(degradationWrites(db)).toHaveLength(0);
+    }
+  });
+
+  // [20260910_Feat_237_ReviewFixes] Review MINOR #3: failure halves.
+  it("a FAILED retry surfaces the error and writes no memory", async () => {
+    const db = setup();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => httpError(400))
+      .mockImplementationOnce(async () =>
+        httpError(500),
+      ) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-retry-fail",
+    )) as { success: boolean };
+
+    expect(result.success).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(degradationWrites(db)).toHaveLength(0);
+  });
+
+  it("a degraded fallback with EMPTY content writes no memory", async () => {
+    const db = setup();
+    global.fetch = vi.fn(async () => jsonOk("")) as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-empty",
+    )) as { success: boolean };
+
+    expect(result.success).toBe(false);
+    expect(degradationWrites(db)).toHaveLength(0);
+  });
+
+  it("a memory-WRITE failure never fails the polish in hand", async () => {
+    const db = setup();
+    db.setSetting.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    global.fetch = vi.fn(async () => jsonOk("照样成功")) as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "原文",
+      "optimize",
+      10_000,
+      "sd-write-fail",
+    )) as { success: boolean; text?: string };
+
+    expect(result).toMatchObject({ success: true, text: "照样成功" });
+  });
+  // [20260910_Feat_237_ReviewFixes] END
 });

--- a/tests/unit/stream-degradation-manager.test.tsx
+++ b/tests/unit/stream-degradation-manager.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+// [20260910_Feat_237_StreamDegradation] TDD for the T10 settings-page
+// degradation-memory panel: list rendering, empty state, and the reset
+// round-trip (reset → reload). The bridge is stubbed per test.
+import "../setup/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { StreamDegradationManager } from "../../src/settings/sections/StreamDegradationManager";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+function bridgeWith(
+  entries: Array<{ baseUrl: string; at: number }>,
+  resetImpl?: () => Promise<{ success: boolean; removed: number }>,
+) {
+  const list = vi.fn(async () => ({ success: true, entries }));
+  const reset = vi.fn(
+    resetImpl ?? (async () => ({ success: true, removed: entries.length })),
+  );
+  (window as { electronAPI?: unknown }).electronAPI = {
+    listStreamDegradations: list,
+    resetStreamDegradations: reset,
+  };
+  return { list, reset };
+}
+
+describe("[20260910_Feat_237_StreamDegradation] StreamDegradationManager", () => {
+  beforeEach(() => {
+    delete (window as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it("lists remembered gateways", async () => {
+    bridgeWith([
+      { baseUrl: "https://gw-a.example.com/v1", at: 1_757_000_000_000 },
+      { baseUrl: "https://gw-b.example.com/v1", at: 1_757_000_100_000 },
+    ]);
+    render(<StreamDegradationManager />);
+    await screen.findByText("https://gw-a.example.com/v1");
+    expect(screen.getByText("https://gw-b.example.com/v1")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when nothing is remembered", async () => {
+    bridgeWith([]);
+    const { container } = render(<StreamDegradationManager />);
+    await waitFor(() =>
+      expect(
+        container.querySelector("[data-testid='stream-degradation-empty']"),
+      ).not.toBeNull(),
+    );
+  });
+
+  it("reset clears the memory and reloads the list", async () => {
+    let entries = [{ baseUrl: "https://gw.example.com/v1", at: 1 }];
+    const { reset, list } = bridgeWith(entries, async () => {
+      entries = [];
+      return { success: true, removed: 1 };
+    });
+    // The list stub closes over the initial array; re-point it per call.
+    list.mockImplementation(async () => ({ success: true, entries }));
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<StreamDegradationManager />);
+    await screen.findByText("https://gw.example.com/v1");
+    fireEvent.click(screen.getByTestId("stream-degradation-reset"));
+
+    await waitFor(() => expect(reset).toHaveBeenCalledTimes(1));
+    await screen.findByTestId("stream-degradation-empty");
+  });
+
+  it("surfaces a reset failure instead of clearing silently", async () => {
+    bridgeWith([{ baseUrl: "https://gw.example.com/v1", at: 1 }], async () => {
+      throw new Error("ipc down");
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<StreamDegradationManager />);
+    await screen.findByText("https://gw.example.com/v1");
+    fireEvent.click(screen.getByTestId("stream-degradation-reset"));
+
+    // The entry stays — no silent clear.
+    await waitFor(() =>
+      expect(screen.getByText("https://gw.example.com/v1")).toBeInTheDocument(),
+    );
+  });
+});

--- a/tests/unit/stream-degradation-manager.test.tsx
+++ b/tests/unit/stream-degradation-manager.test.tsx
@@ -78,14 +78,14 @@ describe("[20260910_Feat_237_StreamDegradation] StreamDegradationManager", () =>
       throw new Error("ipc down");
     });
     vi.spyOn(window, "confirm").mockReturnValue(true);
+    const { toast } = await import("sonner");
 
     render(<StreamDegradationManager />);
     await screen.findByText("https://gw.example.com/v1");
     fireEvent.click(screen.getByTestId("stream-degradation-reset"));
 
-    // The entry stays — no silent clear.
-    await waitFor(() =>
-      expect(screen.getByText("https://gw.example.com/v1")).toBeInTheDocument(),
-    );
+    // The failure is surfaced AND the entry stays — no silent clear.
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(screen.getByText("https://gw.example.com/v1")).toBeInTheDocument();
   });
 });

--- a/tests/unit/stream-degradation.test.ts
+++ b/tests/unit/stream-degradation.test.ts
@@ -1,0 +1,110 @@
+// [20260910_Feat_237_StreamDegradation] TDD for Spec #193 T10 (ticket #237):
+// the stream-degradation memory. A gateway that fails a streaming request
+// (non-SSE content-type or immediate 4xx) is remembered by NORMALIZED
+// base_url hash so later runs skip the doomed streaming attempt; local
+// addresses are never remembered (their streaming quirks get fixed, not
+// bypassed); the table is capped (see STREAM_DEGRADATION_MAX_ENTRIES in the
+// module) with oldest-first eviction.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import DatabaseManager from "../../src/helpers/database";
+import {
+  isStreamDegradationRemembered,
+  listStreamDegradations,
+  rememberStreamDegradation,
+  resetStreamDegradations,
+} from "../../src/helpers/streamDegradation";
+
+let db: InstanceType<typeof DatabaseManager>;
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stream-degradation-test-"));
+  db = new DatabaseManager();
+  db.initialize(tmpDir);
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("[20260910_Feat_237_StreamDegradation] memory store", () => {
+  it("remembers a gateway and reports it remembered", async () => {
+    const written = await rememberStreamDegradation(
+      db,
+      "https://gateway.example.com/v1",
+    );
+    expect(written).toBe(true);
+    await expect(
+      isStreamDegradationRemembered(db, "https://gateway.example.com/v1"),
+    ).resolves.toBe(true);
+    const entries = await listStreamDegradations(db);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.baseUrl).toBe("https://gateway.example.com/v1");
+    expect(typeof entries[0]!.at).toBe("number");
+  });
+
+  it("normalizes base_url before keying (scheme/host case, trailing slash)", async () => {
+    await rememberStreamDegradation(db, "HTTPS://GATEWAY.EXAMPLE.COM/v1/");
+    await expect(
+      isStreamDegradationRemembered(db, "https://gateway.example.com/v1"),
+    ).resolves.toBe(true);
+    // A DIFFERENT path is a different gateway.
+    await expect(
+      isStreamDegradationRemembered(db, "https://gateway.example.com/v2"),
+    ).resolves.toBe(false);
+  });
+
+  it("never remembers local addresses", async () => {
+    for (const local of [
+      "http://localhost:8317/v1",
+      "http://127.0.0.1:8317/v1",
+      "http://[::1]:8317/v1",
+    ]) {
+      await expect(rememberStreamDegradation(db, local)).resolves.toBe(false);
+      await expect(isStreamDegradationRemembered(db, local)).resolves.toBe(
+        false,
+      );
+    }
+    await expect(listStreamDegradations(db)).resolves.toHaveLength(0);
+  });
+
+  it("caps the memory at 50 entries, evicting the oldest first", async () => {
+    for (let i = 0; i < 55; i++) {
+      await rememberStreamDegradation(
+        db,
+        `https://gw-${i}.example.com/v1`,
+        1_000 + i,
+      );
+    }
+    const entries = await listStreamDegradations(db);
+    expect(entries).toHaveLength(50);
+    // The first five gateways were evicted; the newest survived.
+    await expect(
+      isStreamDegradationRemembered(db, "https://gw-0.example.com/v1"),
+    ).resolves.toBe(false);
+    await expect(
+      isStreamDegradationRemembered(db, "https://gw-54.example.com/v1"),
+    ).resolves.toBe(true);
+  });
+
+  it("reset clears every remembered gateway and reports the count", async () => {
+    await rememberStreamDegradation(db, "https://a.example.com/v1");
+    await rememberStreamDegradation(db, "https://b.example.com/v1");
+    await expect(resetStreamDegradations(db)).resolves.toBe(2);
+    await expect(listStreamDegradations(db)).resolves.toHaveLength(0);
+    // A second reset is a clean no-op.
+    await expect(resetStreamDegradations(db)).resolves.toBe(0);
+  });
+
+  it("re-remembering the same gateway refreshes it without duplicating", async () => {
+    await rememberStreamDegradation(db, "https://gw.example.com/v1", 1_000);
+    await rememberStreamDegradation(db, "https://gw.example.com/v1", 2_000);
+    const entries = await listStreamDegradations(db);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.at).toBe(2_000);
+  });
+});


### PR DESCRIPTION
## 概要

实现 #237（Spec #193 T10）：流式降级探测与记忆。

- **三种降级签名**：非 SSE content-type（200，走既有 JSON 降级路径）、立即 4xx（新增：自动非流式重试一次）、已记忆网关（直接跳过流式，零浪费）
- **降级成功才记忆**：按规范化 base_url 的 sha256 哈希存进既有 settings 表（`stream_degraded.<hash>`，免 schema 迁移），上限 50 条最旧淘汰；**本地地址永不记忆**（本地流式问题另行修复而非绕过）
- **重试可取消**：复用 run 信号；流式尝试与重试共享同一条截止线（重试只拿剩余预算）
- **401/403/429 不重试**：认证/配额错误非流式同样失败，重试只会给限流网关加倍压力
- **degraded chunk 通知 UI**：reason = non_sse_response / http_4xx / remembered
- **设置页**新增「流式降级记忆 / Streaming fallback memory」查看 + 重置面板，i18n 中英完整；IPC 走既有 settingsHandlers + 限速边界

## 附带修复（review 发现的既有问题）

- **静默取消契约漏洞**：settle-aside 退出路径（预检门禁、响应后门禁、降级重试、外层 catch）从不发 abort chunk，渲染端只靠 chunk 识别取消 → 在这些时点取消会把「已取消」当成错误弹出来。现由 `settleAside` 统一补发 abort chunk，对流式全程成立（含 T7 supersede 路径——行为变化：被取代的旧运行现在也静默收尾，与 mid-stream 路径一致，属有意为之）

## 验证

- TDD 红→绿：记忆模块 6 用例（规范化/本地不记/50 上限淘汰/重置/刷新）、管线 10 用例（SSE 正常 / 非 SSE 降级 / 4xx 重试成功 / 已记忆直连 / 本地不记 / 重试可取消 / 401+403+429 不重试 / 重试失败不写记忆 / 空内容不写记忆 / 写记忆失败不影响结果）、设置面板 4 用例
- **独立 code review（非实现者）两轮**：初审 SHIP + 5 MINOR + 2 NIT → 全部修复 → 复验 SHIP
- `pnpm ci:check` 11/11 全绿

## 风险

- 存储走 settings 表新增前缀键，无 schema 迁移；`deleteSetting` 是新增 per-key 删除（原只有全清），有测试覆盖
- 记住降级的网关将永远走非流式直到用户在设置页重置——面板里可见可重置，符合票设计