### PR TITLE
feat: T14 长文分块润色 — 增量累积链 / map-reduce（Spec #193, closes #241）

### DIFF
--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -367,6 +367,29 @@ export default function TranscriptionResult({
               <p className="text-sm text-[#1d1d1d] dark:text-[#f5f5f7]/80 whitespace-pre-wrap">
                 {displayText}
               </p>
+              {/* [20260911_Feat_241_LongTextChunking] T14: block progress
+                  (第几块/共几块 + 已耗时) while the chunked chain runs —
+                  the ticket's cost-transparency note for the super-linear
+                  token spend. */}
+              {polishStream.chunkProgress && (
+                <p
+                  data-testid="polish-chunk-progress"
+                  className="text-xs text-[#86868b]"
+                >
+                  {t(
+                    "transcription.chunkProgress",
+                    "第 {{current}}/{{total}} 块 · 已耗时 {{seconds}} 秒",
+                    {
+                      current: polishStream.chunkProgress.index,
+                      total: polishStream.chunkProgress.count,
+                      seconds: Math.round(
+                        polishStream.chunkProgress.elapsedMs / 1000,
+                      ),
+                    },
+                  )}
+                </p>
+              )}
+              {/* [20260911_Feat_241_LongTextChunking] END */}
               <button
                 type="button"
                 onClick={handleCancelPolish}

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -860,12 +860,12 @@ async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
     ctx.logger?.warn?.("修正表读取失败,跳过注入:", vocabError);
   }
 
-  const notifyProgress = (chunkIndex: number): void => {
+  const notifyProgress = (chunkIndex: number, count = chunks.length): void => {
     stream?.notify({
       type: "progress",
       requestId: stream.requestId,
       chunkIndex,
-      chunkCount: chunks.length,
+      chunkCount: count,
       elapsedMs: Date.now() - startedAt,
     });
   };
@@ -876,8 +876,23 @@ async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
       vocabCorrections: filterVocabForInjection(chunk, allVocab),
     });
 
+  /** One merge call over a batch of summaries (shared by all reduce rounds). */
+  const mergeOnce = async (batch: string[]): Promise<string> => {
+    const joined = joinChunkOutputs(batch);
+    const mergeBase = buildChunkPrompt(joined);
+    return await callChunkOnce(
+      ctx,
+      mergeBase.system,
+      `${mergeBase.user}\n【合并约束】以上为多段分块摘要，请合并为一份连贯的最终结果：去除重复、保留全部要点、输出一份而非逐段罗列。`,
+      joined.length,
+    );
+  };
+
   if (chunkStrategyForMode(mode) === "map-reduce") {
-    // 摘要类: per-chunk summaries, then ONE merge call over their join.
+    // 摘要类: per-chunk summaries, then merge. The merge input can itself
+    // exceed the budget on very long inputs (N × per-chunk summary), so the
+    // reduce runs in ROUNDS: group summaries to fit the budget, merge each
+    // group, and repeat until one text remains (multi-level map-reduce).
     const summaries: string[] = [];
     for (let i = 0; i < chunks.length; i++) {
       const aside = polishRunOutcomeIfSettledAside(ctx.runHandle);
@@ -886,21 +901,55 @@ async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
       summaries.push(await callChunkOnce(ctx, system, user, chunks[i]!.length));
       notifyProgress(i + 1);
     }
-    const mergeAside = polishRunOutcomeIfSettledAside(ctx.runHandle);
-    if (mergeAside) return ctx.settleAside(mergeAside);
-    const mergeBase = buildChunkPrompt(joinChunkOutputs(summaries));
-    const merged = await callChunkOnce(
-      ctx,
-      mergeBase.system,
-      `${mergeBase.user}\n【合并约束】以上为多段分块摘要，请合并为一份连贯的最终结果：去除重复、保留全部要点、输出一份而非逐段罗列。`,
-      summaries.join("").length,
-    );
-    return { success: true, text: clampJoinedOutput(merged), model: ctx.model };
+    // [20260911_Fix_241_Review] Progress counts the merge work too (N+1
+    // ticks): the UI must not sit at "第 N/N 块" while the merge runs.
+    let level = summaries;
+    let tick = chunks.length;
+    while (level.length > 1) {
+      const mergeAside = polishRunOutcomeIfSettledAside(ctx.runHandle);
+      if (mergeAside) return ctx.settleAside(mergeAside);
+      // Group so each group's join fits the chunk budget.
+      const groups: string[][] = [];
+      let bucket: string[] = [];
+      for (const summary of level) {
+        if (
+          bucket.length > 0 &&
+          joinChunkOutputs([...bucket, summary]).length > POLISH_CHUNK_MAX_CHARS
+        ) {
+          groups.push(bucket);
+          bucket = [];
+        }
+        bucket.push(summary);
+      }
+      if (bucket.length > 0) groups.push(bucket);
+      // Termination guard: if EVERY summary alone already exceeds the
+      // budget, grouping cannot shrink the level — merge the whole level in
+      // one best-effort call instead of looping forever.
+      if (groups.length === 1 || groups.length >= level.length) {
+        level = [await mergeOnce(level)];
+        tick += 1;
+        notifyProgress(tick, chunks.length + 1);
+        break;
+      }
+      const mergedGroups: string[] = [];
+      for (const group of groups) {
+        const groupAside = polishRunOutcomeIfSettledAside(ctx.runHandle);
+        if (groupAside) return ctx.settleAside(groupAside);
+        mergedGroups.push(await mergeOnce(group));
+        tick += 1;
+        notifyProgress(tick, chunks.length + groups.length);
+      }
+      level = mergedGroups;
+    }
+    return {
+      success: true,
+      text: clampJoinedOutput(level[0] ?? "", ctx.logger),
+      model: ctx.model,
+    };
   }
 
   // 整理/改写类: append-only accumulation chain.
   let accumulated = "";
-  const outputs: string[] = [];
   for (let i = 0; i < chunks.length; i++) {
     const aside = polishRunOutcomeIfSettledAside(ctx.runHandle);
     if (aside) return ctx.settleAside(aside);
@@ -909,25 +958,39 @@ async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
     const chainedUser = accumulated
       ? `${user}\n【增量累积约束】前文已整理出以下要点，本次输出必须完整保留这些要点（只增不减），在此基础上继续处理当前内容：\n${accumulated}`
       : user;
-    const output = await callChunkOnce(ctx, system, chainedUser, chunk.length);
-    outputs.push(output);
+    // [20260911_Fix_241_Review] MAJOR #2: the chain output is CUMULATIVE —
+    // from chunk 2 the provider must re-emit the accumulated points plus the
+    // new chunk, so the token budget keys to chunk + accumulated, not the
+    // chunk alone (else truncation silently drops earlier points).
+    const output = await callChunkOnce(
+      ctx,
+      system,
+      chainedUser,
+      chunk.length + accumulated.length,
+    );
     // The append-only output carries every point so far — it IS the next
-    // chunk's context.
+    // chunk's context AND (being the last one) the final result. Joining
+    // all per-chunk outputs would duplicate content N-fold (review MAJOR #1).
     accumulated = output;
     notifyProgress(i + 1);
   }
   return {
     success: true,
-    text: clampJoinedOutput(joinChunkOutputs(outputs)),
+    text: clampJoinedOutput(accumulated, ctx.logger),
     model: ctx.model,
   };
 }
 
 /** Absolute output guard, shared by the chunked path's final text. */
-function clampJoinedOutput(text: string): string {
-  return text.length > POLISH_OUTPUT_MAX_CHARS
-    ? text.slice(0, POLISH_OUTPUT_MAX_CHARS)
-    : text;
+function clampJoinedOutput(text: string, logger: Logger): string {
+  if (text.length <= POLISH_OUTPUT_MAX_CHARS) return text;
+  // [20260911_Fix_241_Review] Truncation is a robustness action worth a log
+  // line, same as the single-shot clamp.
+  logger.info?.("AI输出超出字符上限，已截断:", {
+    originalLength: text.length,
+    cap: POLISH_OUTPUT_MAX_CHARS,
+  });
+  return text.slice(0, POLISH_OUTPUT_MAX_CHARS);
 }
 // [20260911_Feat_241_LongTextChunking] END
 

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -928,7 +928,10 @@ async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
       if (groups.length === 1 || groups.length >= level.length) {
         level = [await mergeOnce(level)];
         tick += 1;
-        notifyProgress(tick, chunks.length + 1);
+        // [20260911_Fix_241_Review2] The final tick IS the total — after a
+        // grouped round the running tick can exceed chunks.length+1, and
+        // the UI must never show 第 10/7 块.
+        notifyProgress(tick, Math.max(tick, chunks.length + 1));
         break;
       }
       const mergedGroups: string[] = [];
@@ -937,7 +940,9 @@ async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
         if (groupAside) return ctx.settleAside(groupAside);
         mergedGroups.push(await mergeOnce(group));
         tick += 1;
-        notifyProgress(tick, chunks.length + groups.length);
+        // [20260911_Fix_241_Review2] Count never shrinks below the running
+        // index across rounds.
+        notifyProgress(tick, Math.max(tick, chunks.length + groups.length));
       }
       level = mergedGroups;
     }
@@ -961,7 +966,10 @@ async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
     // [20260911_Fix_241_Review] MAJOR #2: the chain output is CUMULATIVE —
     // from chunk 2 the provider must re-emit the accumulated points plus the
     // new chunk, so the token budget keys to chunk + accumulated, not the
-    // chunk alone (else truncation silently drops earlier points).
+    // chunk alone (else truncation silently drops earlier points). The
+    // budget still saturates at the user's max_tokens ceiling on very long
+    // chains — the same accepted tradeoff as the single-shot path
+    // (review-2 residual observation, not a defect).
     const output = await callChunkOnce(
       ctx,
       system,

--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -22,6 +22,13 @@ import {
   isStreamDegradationRemembered,
   rememberStreamDegradation,
 } from "../streamDegradation";
+// [20260911_Feat_241_LongTextChunking] T14: chunker + strategy classifier.
+import {
+  POLISH_CHUNK_MAX_CHARS,
+  chunkStrategyForMode,
+  joinChunkOutputs,
+  splitIntoChunks,
+} from "../polish-chunking";
 
 interface Logger {
   info?(message: string, ...args: unknown[]): void;
@@ -760,6 +767,170 @@ function resolvePolishMaxTokens(
 }
 // [20260906_Feat_OrchestratorGenCancel] END
 
+// [20260911_Feat_241_LongTextChunking] Spec #193 T14 (ticket #241): chunked
+// polish for over-threshold text. Sequential per-chunk provider calls (块间
+// 顺序执行); two strategies — 整理/改写类 walk an append-only accumulation
+// chain (each chunk carries the previous accumulated output with a
+// 只增不减 constraint), summarize maps to per-chunk summaries + one merge
+// call. Progress rides the existing progress chunk as 第几块/共几块/已耗时
+// so the renderer stays strategy-agnostic. Chunks are NON-streaming
+// provider calls: the degradation memory (T10) neither reads nor writes
+// here, and each chunk gets the full per-request timeout (the user watches
+// elapsed time in the UI — the ticket's explicit cost tradeoff, since the
+// accumulation chain's total token spend grows super-linearly).
+interface ChunkedPolishContext {
+  chunks: string[];
+  mode: string;
+  baseUrl: string;
+  apiKey: string | undefined;
+  model: string;
+  temperature: number;
+  maxTokens: number;
+  clampOutputTokens: boolean;
+  templatesDir: string | undefined;
+  databaseManager: DatabaseManager;
+  timeoutMs: number;
+  timeoutMessage: string;
+  runHandle: PolishRunHandle | null;
+  stream: PolishRequest["stream"];
+  logger: Logger;
+  settleAside: (outcome: AIResult) => AIResult;
+}
+
+/** One non-streaming provider call returning the trimmed content text. */
+async function callChunkOnce(
+  ctx: ChunkedPolishContext,
+  system: string,
+  user: string,
+  chunkInputLength: number,
+): Promise<string> {
+  const response = await postChatCompletion(
+    ctx.baseUrl,
+    ctx.apiKey,
+    {
+      model: ctx.model,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+      temperature: ctx.temperature,
+      // Per-chunk budget follows the same clamp semantics as single-shot,
+      // keyed to the CHUNK's input length.
+      max_tokens: resolvePolishMaxTokens(
+        ctx.mode,
+        chunkInputLength,
+        ctx.maxTokens,
+        ctx.clampOutputTokens,
+      ),
+      stream: false,
+    },
+    ctx.timeoutMs,
+    ctx.timeoutMessage,
+    ctx.runHandle?.controller.signal,
+  );
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      extractAIErrorMessage(response, errorText, ctx.logger) ||
+        `AI服务请求失败 (${response.status})`,
+    );
+  }
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = data.choices?.[0]?.message?.content?.trim() || "";
+  if (!content) {
+    throw new Error("AI返回了空内容，请重试或更换模型");
+  }
+  return content;
+}
+
+async function runChunkedPolish(ctx: ChunkedPolishContext): Promise<AIResult> {
+  const { chunks, mode, stream } = ctx;
+  const startedAt = Date.now();
+  const customTemplates = ctx.templatesDir
+    ? getCachedTemplates(ctx.templatesDir)
+    : [];
+  // Corrections read once, re-filtered per chunk (same discipline as the
+  // single-shot path: a table read failure degrades to no injection).
+  let allVocab: Array<{ wrong: string; right: string }> = [];
+  try {
+    allVocab = ctx.databaseManager.listVocabCorrections?.() ?? [];
+  } catch (vocabError) {
+    ctx.logger?.warn?.("修正表读取失败,跳过注入:", vocabError);
+  }
+
+  const notifyProgress = (chunkIndex: number): void => {
+    stream?.notify({
+      type: "progress",
+      requestId: stream.requestId,
+      chunkIndex,
+      chunkCount: chunks.length,
+      elapsedMs: Date.now() - startedAt,
+    });
+  };
+
+  const buildChunkPrompt = (chunk: string): { system: string; user: string } =>
+    buildPrompt(mode, chunk, {
+      customTemplates,
+      vocabCorrections: filterVocabForInjection(chunk, allVocab),
+    });
+
+  if (chunkStrategyForMode(mode) === "map-reduce") {
+    // 摘要类: per-chunk summaries, then ONE merge call over their join.
+    const summaries: string[] = [];
+    for (let i = 0; i < chunks.length; i++) {
+      const aside = polishRunOutcomeIfSettledAside(ctx.runHandle);
+      if (aside) return ctx.settleAside(aside);
+      const { system, user } = buildChunkPrompt(chunks[i]!);
+      summaries.push(await callChunkOnce(ctx, system, user, chunks[i]!.length));
+      notifyProgress(i + 1);
+    }
+    const mergeAside = polishRunOutcomeIfSettledAside(ctx.runHandle);
+    if (mergeAside) return ctx.settleAside(mergeAside);
+    const mergeBase = buildChunkPrompt(joinChunkOutputs(summaries));
+    const merged = await callChunkOnce(
+      ctx,
+      mergeBase.system,
+      `${mergeBase.user}\n【合并约束】以上为多段分块摘要，请合并为一份连贯的最终结果：去除重复、保留全部要点、输出一份而非逐段罗列。`,
+      summaries.join("").length,
+    );
+    return { success: true, text: clampJoinedOutput(merged), model: ctx.model };
+  }
+
+  // 整理/改写类: append-only accumulation chain.
+  let accumulated = "";
+  const outputs: string[] = [];
+  for (let i = 0; i < chunks.length; i++) {
+    const aside = polishRunOutcomeIfSettledAside(ctx.runHandle);
+    if (aside) return ctx.settleAside(aside);
+    const chunk = chunks[i]!;
+    const { system, user } = buildChunkPrompt(chunk);
+    const chainedUser = accumulated
+      ? `${user}\n【增量累积约束】前文已整理出以下要点，本次输出必须完整保留这些要点（只增不减），在此基础上继续处理当前内容：\n${accumulated}`
+      : user;
+    const output = await callChunkOnce(ctx, system, chainedUser, chunk.length);
+    outputs.push(output);
+    // The append-only output carries every point so far — it IS the next
+    // chunk's context.
+    accumulated = output;
+    notifyProgress(i + 1);
+  }
+  return {
+    success: true,
+    text: clampJoinedOutput(joinChunkOutputs(outputs)),
+    model: ctx.model,
+  };
+}
+
+/** Absolute output guard, shared by the chunked path's final text. */
+function clampJoinedOutput(text: string): string {
+  return text.length > POLISH_OUTPUT_MAX_CHARS
+    ? text.slice(0, POLISH_OUTPUT_MAX_CHARS)
+    : text;
+}
+// [20260911_Feat_241_LongTextChunking] END
+
 export async function runPolishOrchestrator(
   deps: PolishDeps,
   request: PolishRequest,
@@ -925,6 +1096,40 @@ export async function runPolishOrchestrator(
     const deadlineMs = Date.now() + timeoutMs;
     const timeoutMessage = `AI请求超时（${Math.round(timeoutMs / 1000)}秒），请尝试缩短文本或检查网络`;
     // [20260910_Feat_237_StreamDegradation] END
+
+    // [20260911_Feat_241_LongTextChunking] T14: over-threshold text takes the
+    // chunked path — sequential per-chunk calls with progress chunks; the
+    // single-shot pipeline below is untouched for normal-length input (单块
+    // 直通 = 现状行为). Explicit whole-prompt overrides (AI_REVIEW) keep the
+    // single-shot path too: their prompt contract is caller-owned.
+    if (
+      text.length > POLISH_CHUNK_MAX_CHARS &&
+      !(request.systemPrompt && request.userPrompt)
+    ) {
+      const chunks = splitIntoChunks(text);
+      if (chunks.length > 1) {
+        return await runChunkedPolish({
+          chunks,
+          mode,
+          baseUrl,
+          apiKey,
+          model,
+          temperature,
+          maxTokens,
+          clampOutputTokens: request.clampOutputTokens === true,
+          templatesDir: request.templatesDir,
+          databaseManager,
+          timeoutMs,
+          timeoutMessage,
+          runHandle,
+          stream: request.stream,
+          logger,
+          settleAside,
+        });
+      }
+    }
+    // [20260911_Feat_241_LongTextChunking] END
+
     let response = await postChatCompletion(
       baseUrl,
       apiKey,

--- a/src/helpers/polish-chunking.ts
+++ b/src/helpers/polish-chunking.ts
@@ -1,0 +1,63 @@
+// [20260911_Feat_241_LongTextChunking] Spec #193 T14 (ticket #241): the
+// long-text chunker + chunk-strategy classification for polish.
+//
+// The budget is a plain CHARACTER count — deliberately no tokenizer
+// dependency (ticket constraint); for mixed zh/en transcripts chars are a
+// good enough proxy for the provider's context window. Splitting priority
+// is paragraph (double newline) → line (single newline) → hard cut at the
+// budget, and the split is LOSSLESS: chunks.join("") === input.
+//
+// Strategies: 整理/改写类 modes walk an incremental accumulation chain
+// (each chunk carries the key points so far with an append-only
+// constraint); summarize maps to per-chunk summaries → merge.
+
+/** Activation threshold AND per-chunk budget, in characters. */
+export const POLISH_CHUNK_MAX_CHARS = 4000;
+
+export type ChunkStrategy = "accumulate" | "map-reduce";
+
+/** summarize 类 → 分块摘要再合并；其余（含自定义模板）→ 增量累积链。 */
+export function chunkStrategyForMode(mode: string): ChunkStrategy {
+  return mode === "summarize" ? "map-reduce" : "accumulate";
+}
+
+/**
+ * Lossless chunker. Breaks at the LAST paragraph boundary inside the
+ * budget window, else the last line boundary, else a hard cut. Delimiters
+ * stay at the end of the preceding chunk so no content is lost.
+ */
+export function splitIntoChunks(
+  text: string,
+  maxChars: number = POLISH_CHUNK_MAX_CHARS,
+): string[] {
+  if (text.length <= maxChars) return [text];
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > maxChars) {
+    const window = rest.slice(0, maxChars);
+    const paragraphBreak = window.lastIndexOf("\n\n");
+    const lineBreak = window.lastIndexOf("\n");
+    let cut: number;
+    if (paragraphBreak > 0) {
+      cut = paragraphBreak + 2; // keep the delimiter on the left chunk
+    } else if (lineBreak > 0) {
+      cut = lineBreak + 1;
+    } else {
+      cut = maxChars;
+    }
+    chunks.push(rest.slice(0, cut));
+    rest = rest.slice(cut);
+  }
+  if (rest.length > 0) chunks.push(rest);
+  return chunks;
+}
+
+/**
+ * Concatenate per-chunk outputs into the final text. Paragraph-joined;
+ * single-chunk output passes through byte-identical (现状行为).
+ */
+export function joinChunkOutputs(outputs: string[]): string {
+  if (outputs.length === 1) return outputs[0]!;
+  return outputs.join("\n\n");
+}
+// [20260911_Feat_241_LongTextChunking] END

--- a/src/hooks/usePolishStream.ts
+++ b/src/hooks/usePolishStream.ts
@@ -112,9 +112,9 @@ export function usePolishStream() {
           } else if (chunk.type === "progress") {
             // [20260907_Feat_236_StreamingUi] T9 ③: block progress (bytes)
             // for consumers without per-word rendering (file import).
-            setStreamBytes(
-              (prev) => prev + ((chunk as { bytes?: number }).bytes ?? 0),
-            );
+            // [20260911_Fix_241_Review] The vestigial cast went away with
+            // the typed-optional bytes field.
+            setStreamBytes((prev) => prev + (chunk.bytes ?? 0));
             // [20260911_Feat_241_LongTextChunking] T14: the block triplet is
             // the chunked-polish dimension; byte-only progress chunks leave
             // it untouched.

--- a/src/hooks/usePolishStream.ts
+++ b/src/hooks/usePolishStream.ts
@@ -28,6 +28,13 @@ type StreamingApi = {
 export function usePolishStream() {
   const [streamText, setStreamText] = React.useState<string | null>(null);
   const [streamBytes, setStreamBytes] = React.useState(0);
+  // [20260911_Feat_241_LongTextChunking] T14: block progress for chunked
+  // polish (第几块/共几块 + 已耗时), driven by the progress chunk triplet.
+  const [chunkProgress, setChunkProgress] = React.useState<{
+    index: number;
+    count: number;
+    elapsedMs: number;
+  } | null>(null);
   const [isStreaming, setIsStreaming] = React.useState(false);
   const requestIdRef = React.useRef<string | null>(null);
   const abortRef = React.useRef<StreamingApi["abortPolish"] | null>(null);
@@ -70,6 +77,7 @@ export function usePolishStream() {
       setIsStreaming(true);
       setStreamText("");
       setStreamBytes(0);
+      setChunkProgress(null);
 
       return await new Promise<PolishResult>((resolve) => {
         let settled = false;
@@ -86,6 +94,9 @@ export function usePolishStream() {
           // partial rendered as the user's transcription. Success hands
           // over to optimizedText; cancel/error restore the original.
           setStreamText(null);
+          // [20260911_Feat_241_LongTextChunking] Clear block progress on
+          // EVERY terminal outcome alongside the stream text.
+          setChunkProgress(null);
           resolve(result);
         };
         const unsubscribe = api.onPolishChunk((chunk) => {
@@ -104,6 +115,16 @@ export function usePolishStream() {
             setStreamBytes(
               (prev) => prev + ((chunk as { bytes?: number }).bytes ?? 0),
             );
+            // [20260911_Feat_241_LongTextChunking] T14: the block triplet is
+            // the chunked-polish dimension; byte-only progress chunks leave
+            // it untouched.
+            if (chunk.chunkIndex !== undefined) {
+              setChunkProgress({
+                index: chunk.chunkIndex,
+                count: chunk.chunkCount ?? 0,
+                elapsedMs: chunk.elapsedMs ?? 0,
+              });
+            }
           } else if (chunk.type === "finish") {
             settle({ success: true, text: chunk.text });
           } else if (chunk.type === "error") {
@@ -144,5 +165,5 @@ export function usePolishStream() {
     };
   }, []);
 
-  return { streamText, streamBytes, isStreaming, start, cancel };
+  return { streamText, streamBytes, chunkProgress, isStreaming, start, cancel };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -381,6 +381,7 @@
   "transcription": {
     "polishSaveFailed": "Couldn't save the polished text — it will revert after restart",
     "cancelPolish": "Cancel",
+    "chunkProgress": "Chunk {{current}}/{{total}} · {{seconds}}s elapsed",
     "polishInvokeFailed": "AI processing failed, please retry",
     "polishFailed": "AI processing failed, please retry",
     "vocabSaveFailed": "Failed to save the correction pair"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -381,6 +381,7 @@
   "transcription": {
     "polishSaveFailed": "润色结果保存失败，重启后将显示原文本",
     "cancelPolish": "取消",
+    "chunkProgress": "第 {{current}}/{{total}} 块 · 已耗时 {{seconds}} 秒",
     "polishInvokeFailed": "AI处理失败，请重试",
     "polishFailed": "AI处理失败，请重试",
     "vocabSaveFailed": "修正词对保存失败"

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -149,7 +149,18 @@ export interface ExportResult {
 export type PolishChunk =
   | { type: "start"; requestId: string }
   | { type: "delta"; requestId: string; text: string }
-  | { type: "progress"; requestId: string; bytes: number }
+  | {
+      type: "progress";
+      requestId: string;
+      // [20260911_Feat_241_LongTextChunking] T14: bytes stays for the
+      // file-import byte counter (T9 ③); the block triplet carries the
+      // chunked-polish "第几块/共几块 + 已耗时" progress. Both optional —
+      // producers send whichever dimension they own.
+      bytes?: number;
+      chunkIndex?: number;
+      chunkCount?: number;
+      elapsedMs?: number;
+    }
   | { type: "degraded"; requestId: string; reason: string }
   | { type: "finish"; requestId: string; text: string; reasoningChars: number }
   | { type: "abort"; requestId: string }

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -2541,10 +2541,10 @@ describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
     );
   }
 
-  // Five ~1500-char paragraphs → 3 chunks at the 4000-char budget
-  // (p1+p2 | p3+p4 | p5, split on paragraph boundaries).
+  // Six ~1500-char paragraphs → 3 equal chunks at the 4000-char budget
+  // (p1+p2 | p3+p4 | p5+p6, split on paragraph boundaries).
   function longText(): { text: string; markers: string[] } {
-    const markers = ["甲块", "乙块", "丙块", "丁块", "戊块"];
+    const markers = ["甲块", "乙块", "丙块", "丁块", "戊块", "己块"];
     const paragraphs = markers.map(
       (m, i) => `${m}段落${i}。${"展开细节。".repeat(300)}`,
     );
@@ -2565,11 +2565,18 @@ describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
     }) as unknown as FetchMock;
   }
 
-  it("accumulate chain: N fetches, 只增不减 constraint present from chunk 2, joined golden", async () => {
+  it("accumulate chain: N fetches, 只增不减 constraint present from chunk 2, cumulative golden", async () => {
     setup();
     const { text } = longText();
     let call = 0;
-    const fetchMock = chunkWiseFetch(() => `输出${"一二三"[call++]!}。`);
+    // [20260911_Fix_241_Review] The mock mirrors the REAL provider contract
+    // the 只增不减 constraint creates: each chunk's output is CUMULATIVE
+    // (contains every previous point). The final text is the last output —
+    // joining all outputs would duplicate content N-fold.
+    const fetchMock = chunkWiseFetch(() => {
+      call += 1;
+      return "输出一。输出二。输出三。".slice(0, call * 4);
+    });
     global.fetch = fetchMock as never;
     const C = await import("../../src/helpers/ipc-contracts");
 
@@ -2583,8 +2590,8 @@ describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
 
     expect(result.success).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    // Golden: 首末句存在、句集合 = 逐块输出并集。
-    expect(result.text).toBe("输出一。\n\n输出二。\n\n输出三。");
+    // Golden: final = the last (cumulative) output; 首末句都在其中。
+    expect(result.text).toBe("输出一。输出二。输出三。");
     // From chunk 2 on, the prompt carries the accumulation constraint AND
     // the previous output as context.
     const secondBody = JSON.parse(
@@ -2606,6 +2613,38 @@ describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
       [3, 3],
     ]);
     for (const p of progress) expect(p.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // [20260911_Fix_241_Review] MAJOR #2: with the token clamp active
+  // (minimal-edit modes via the PROCESS entry), the per-chunk budget must
+  // grow with the CUMULATIVE input (chunk + accumulated context) — else the
+  // provider truncates the accumulated points mid-chain.
+  it("accumulate chain grows the token budget along the chain (clamp on)", async () => {
+    setup();
+    const { text } = longText();
+    let call = 0;
+    const fetchMock = chunkWiseFetch(() => {
+      call += 1;
+      return "输出一。输出二。输出三。".slice(0, call * 4);
+    });
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "optimize", // minimal-edit mode → clampOutputTokens active at this entry
+      60_000,
+      "ck-clamp",
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const budgets = fetchMock.mock.calls.map(
+      (c) => JSON.parse((c[1] as { body: string }).body).max_tokens as number,
+    );
+    expect(budgets).toHaveLength(3);
+    expect(budgets[1]!).toBeGreaterThan(budgets[0]!);
+    expect(budgets[2]!).toBeGreaterThan(budgets[1]!);
   });
 
   it("map-reduce: summarize chunks then merge once", async () => {
@@ -2744,4 +2783,139 @@ describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
     expect(result.success).toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  // [20260911_Fix_241_Review] MINOR #5 failure halves for map-reduce.
+  it("merge-call failure surfaces the error after all chunks succeed", async () => {
+    setup();
+    const { text } = longText();
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      if (call <= 3) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({
+            choices: [{ message: { content: `分块摘要${call}` } }],
+          }),
+          text: async (): Promise<string> => "",
+        };
+      }
+      return {
+        ok: false,
+        status: 500,
+        statusText: "HTTP 500",
+        text: async (): Promise<string> => "merge boom",
+      };
+    }) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "summarize",
+      60_000,
+      "ck-merge-fail",
+    )) as { success: boolean };
+
+    expect(result.success).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("cancel after the last chunk settles before the merge call fires", async () => {
+    setup();
+    const { text } = longText();
+    let call = 0;
+    const fetchMock = vi.fn(
+      async (_url: unknown, init?: { signal?: AbortSignal }) => {
+        call += 1;
+        if (call <= 3) {
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers({ "content-type": "application/json" }),
+            json: async () => ({
+              choices: [{ message: { content: `分块摘要${call}` } }],
+            }),
+            text: async () => "",
+          };
+        }
+        // The merge call pends until aborted — it must never resolve.
+        return new Promise((_resolve, reject) => {
+          const onAbort = () =>
+            reject(new DOMException("aborted", "AbortError"));
+          if (init?.signal?.aborted) onAbort();
+          else init?.signal?.addEventListener("abort", onAbort, { once: true });
+        });
+      },
+    ) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const processPromise = registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "summarize",
+      60_000,
+      "ck-merge-cancel",
+    ) as Promise<unknown>;
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    await registeredHandlers[C.AI.POLISH_ABORT]!(
+      senderEvent(1),
+      "ck-merge-cancel",
+    );
+
+    const result = (await processPromise) as {
+      success: boolean;
+      code?: string;
+    };
+    expect(result.success).toBe(false);
+    expect(result.code).toBe("CANCELLED");
+    // Exactly 4 calls: 3 chunks + the in-flight merge; nothing further.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("oversized merge input reduces in ROUNDS before the final merge", async () => {
+    setup();
+    // 12 paragraphs → 6 chunks; each summary is 1500 chars so the first
+    // merge join (~9010) exceeds the budget and must split into groups.
+    const markers = Array.from({ length: 12 }, (_, i) => `段${i}`);
+    const paragraphs = markers.map(
+      (m) => `${m}内容。${"展开细节。".repeat(300)}`,
+    );
+    const text = paragraphs.join("\n\n");
+    let call = 0;
+    const fetchMock = chunkWiseFetch(() => {
+      call += 1;
+      if (call <= 6) return `摘要${call}。${"填".repeat(1490)}`;
+      if (call <= 9) return `合并轮次二${call}。`; // grouped merges
+      return "终稿";
+    });
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "summarize",
+      60_000,
+      "ck-rounds",
+    )) as { success: boolean; text?: string };
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("终稿");
+    // 6 chunk summaries + 3 grouped merges + 1 final merge.
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+    // Every merge call carries the merge constraint.
+    for (let i = 6; i < 10; i++) {
+      const body = JSON.parse(
+        (fetchMock.mock.calls[i]![1] as { body: string }).body,
+      );
+      expect(body.messages[1].content).toContain("合并约束");
+    }
+  });
+  // [20260911_Fix_241_Review] END
 });

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -2824,7 +2824,9 @@ describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
-  it("cancel after the last chunk settles before the merge call fires", async () => {
+  // [20260911_Fix_241_Review2] Retitled: the abort lands DURING the
+  // in-flight merge call (the deterministic timing point), not before it.
+  it("cancel during the in-flight merge call settles the whole chain", async () => {
     setup();
     const { text } = longText();
     let call = 0;
@@ -2915,6 +2917,11 @@ describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
         (fetchMock.mock.calls[i]![1] as { body: string }).body,
       );
       expect(body.messages[1].content).toContain("合并约束");
+    }
+    // [20260911_Fix_241_Review2] Progress never shows index > count, across
+    // every map phase tick and every reduce round.
+    for (const p of chunksFor(1).filter((c) => c.type === "progress")) {
+      expect(p.chunkIndex).toBeLessThanOrEqual(p.chunkCount!);
     }
   });
   // [20260911_Fix_241_Review] END

--- a/tests/unit/aiHandlers.test.ts
+++ b/tests/unit/aiHandlers.test.ts
@@ -2477,3 +2477,271 @@ describe("[20260910_Feat_237_StreamDegradation] T10 degradation + memory", () =>
   });
   // [20260910_Feat_237_ReviewFixes] END
 });
+
+// [20260911_Feat_241_LongTextChunking] Spec #193 T14 (ticket #241):
+// long-text chunked polish at the orchestrator level. Text fixtures are
+// sized against the real POLISH_CHUNK_MAX_CHARS so the split counts are
+// deterministic; fetch answers per chunk by inspecting the request body.
+describe("[20260911_Feat_241_LongTextChunking] T14 chunked polish", () => {
+  let registeredHandlers: Record<string, (...args: unknown[]) => unknown>;
+  let sendBySender: Map<number, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    sendBySender = new Map([[1, vi.fn()]]);
+  });
+
+  function senderEvent(id: number) {
+    return {
+      sender: {
+        id,
+        isDestroyed: vi.fn(() => false),
+        send: sendBySender.get(id) ?? vi.fn(),
+      },
+    };
+  }
+
+  function chunksFor(id: number): Array<{
+    type: string;
+    chunkIndex?: number;
+    chunkCount?: number;
+    elapsedMs?: number;
+  }> {
+    return sendBySender.get(id)!.mock.calls.map((call) => call[1]);
+  }
+
+  function setup() {
+    registeredHandlers = {};
+    const ipcMain = {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        registeredHandlers[channel] = fn;
+      }),
+    };
+    const db = {
+      getSetting: vi.fn(async (key: string) =>
+        key === "ai_base_url"
+          ? "https://api.example.com/v1"
+          : key === "ai_api_key"
+            ? "sk"
+            : key === "ai_model"
+              ? "gpt-x"
+              : null,
+      ),
+      listVocabCorrections: vi.fn(() => []),
+    };
+    aiHandlersNS.register(
+      ipcMain as never,
+      {
+        databaseManager: db,
+        funasrManager: null,
+        processTextWithAI: vi.fn(),
+        windowManager: { mainWindow: null },
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        templatesDir: "/tmp/test-templates",
+      } as never,
+    );
+  }
+
+  // Five ~1500-char paragraphs → 3 chunks at the 4000-char budget
+  // (p1+p2 | p3+p4 | p5, split on paragraph boundaries).
+  function longText(): { text: string; markers: string[] } {
+    const markers = ["甲块", "乙块", "丙块", "丁块", "戊块"];
+    const paragraphs = markers.map(
+      (m, i) => `${m}段落${i}。${"展开细节。".repeat(300)}`,
+    );
+    return { text: paragraphs.join("\n\n"), markers };
+  }
+
+  /** fetch stub: answers each chunk with a marker-derived output. */
+  function chunkWiseFetch(outputFor: (body: string) => string) {
+    return vi.fn(async (_url: unknown, init?: { body?: string }) => {
+      const content = outputFor(init?.body ?? "");
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ choices: [{ message: { content } }] }),
+        text: async () => "",
+      };
+    }) as unknown as FetchMock;
+  }
+
+  it("accumulate chain: N fetches, 只增不减 constraint present from chunk 2, joined golden", async () => {
+    setup();
+    const { text } = longText();
+    let call = 0;
+    const fetchMock = chunkWiseFetch(() => `输出${"一二三"[call++]!}。`);
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "optimize",
+      60_000,
+      "ck-acc",
+    )) as { success: boolean; text?: string };
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // Golden: 首末句存在、句集合 = 逐块输出并集。
+    expect(result.text).toBe("输出一。\n\n输出二。\n\n输出三。");
+    // From chunk 2 on, the prompt carries the accumulation constraint AND
+    // the previous output as context.
+    const secondBody = JSON.parse(
+      (fetchMock.mock.calls[1]![1] as { body: string }).body,
+    );
+    const secondUser = secondBody.messages[1].content as string;
+    expect(secondUser).toContain("只增不减");
+    expect(secondUser).toContain("输出一。");
+    // First chunk carries no chain constraint.
+    const firstBody = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as { body: string }).body,
+    );
+    expect(firstBody.messages[1].content).not.toContain("只增不减");
+    // Progress chunks: 第 i/3 块 + elapsed time, monotonic.
+    const progress = chunksFor(1).filter((c) => c.type === "progress");
+    expect(progress.map((p) => [p.chunkIndex, p.chunkCount])).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+    for (const p of progress) expect(p.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("map-reduce: summarize chunks then merge once", async () => {
+    setup();
+    const { text } = longText();
+    let call = 0;
+    const fetchMock = chunkWiseFetch(() =>
+      call++ < 3 ? `分块摘要${call}` : "合并终稿",
+    );
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "summarize",
+      60_000,
+      "ck-mr",
+    )) as { success: boolean; text?: string };
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("合并终稿");
+    // 3 chunk summaries + 1 merge call.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const mergeBody = JSON.parse(
+      (fetchMock.mock.calls[3]![1] as { body: string }).body,
+    );
+    const mergeUser = mergeBody.messages[1].content as string;
+    expect(mergeUser).toContain("合并");
+    expect(mergeUser).toContain("分块摘要1");
+    expect(mergeUser).toContain("分块摘要3");
+    // Chunk prompts carry NO accumulation constraint.
+    const chunkBody = JSON.parse(
+      (fetchMock.mock.calls[1]![1] as { body: string }).body,
+    );
+    expect(chunkBody.messages[1].content).not.toContain("只增不减");
+  });
+
+  it("short text takes the single-shot path untouched (直通不回归)", async () => {
+    setup();
+    const fetchMock = chunkWiseFetch(() => "单次输出");
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      "短文本",
+      "optimize",
+      60_000,
+      "ck-short",
+    )) as { success: boolean; text?: string };
+
+    expect(result).toMatchObject({ success: true, text: "单次输出" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(chunksFor(1).filter((c) => c.chunkIndex !== undefined)).toHaveLength(
+      0,
+    );
+  });
+
+  it("cancel between chunks settles the run and never sends later chunks", async () => {
+    setup();
+    const { text } = longText();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ choices: [{ message: { content: "输出一。" } }] }),
+        text: async () => "",
+      }))
+      .mockImplementationOnce(
+        (_url: unknown, init?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            const onAbort = () =>
+              reject(new DOMException("aborted", "AbortError"));
+            if (init?.signal?.aborted) onAbort();
+            else
+              init?.signal?.addEventListener("abort", onAbort, { once: true });
+          }),
+      ) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const processPromise = registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "optimize",
+      60_000,
+      "ck-cancel",
+    ) as Promise<unknown>;
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await registeredHandlers[C.AI.POLISH_ABORT]!(senderEvent(1), "ck-cancel");
+
+    const result = (await processPromise) as {
+      success: boolean;
+      code?: string;
+    };
+    expect(result.success).toBe(false);
+    expect(result.code).toBe("CANCELLED");
+    // Chunk 3 was never sent.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(chunksFor(1).filter((c) => c.type === "abort")).toHaveLength(1);
+  });
+
+  it("a chunk failure aborts the chain and surfaces the error", async () => {
+    setup();
+    const { text } = longText();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ choices: [{ message: { content: "输出一。" } }] }),
+        text: async () => "",
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: false,
+        status: 500,
+        statusText: "HTTP 500",
+        text: async () => "boom",
+      })) as unknown as FetchMock;
+    global.fetch = fetchMock as never;
+    const C = await import("../../src/helpers/ipc-contracts");
+
+    const result = (await registeredHandlers[C.AI.PROCESS]!(
+      senderEvent(1),
+      text,
+      "optimize",
+      60_000,
+      "ck-fail",
+    )) as { success: boolean };
+
+    expect(result.success).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/polish-chunking.test.ts
+++ b/tests/unit/polish-chunking.test.ts
@@ -1,0 +1,126 @@
+// [20260911_Feat_241_LongTextChunking] TDD for Spec #193 T14 (ticket #241):
+// the long-text chunker. Pure function, no tokenizer dependency — splitting
+// priority is paragraph (double newline) → line (single newline) → hard cut
+// at the char budget. Goldens pin completeness: no content is ever lost or
+// reordered, and a sub-threshold text passes through untouched (单块 = 现状).
+import { describe, it, expect } from "vitest";
+import {
+  POLISH_CHUNK_MAX_CHARS,
+  chunkStrategyForMode,
+  joinChunkOutputs,
+  splitIntoChunks,
+} from "../../src/helpers/polish-chunking";
+
+/** Build N paragraphs of roughly equal size. */
+function paragraphs(count: number, sentencePrefix = "第"): string[] {
+  return Array.from(
+    { length: count },
+    (_, i) => `${sentencePrefix}${i + 1}段内容。${"补充细节。".repeat(20)}`,
+  );
+}
+
+describe("[20260911_Feat_241_LongTextChunking] splitIntoChunks", () => {
+  it("passes sub-threshold text through as a single chunk (直通不回归)", () => {
+    const text = "一段不长的转写文本。";
+    expect(splitIntoChunks(text)).toEqual([text]);
+    expect(splitIntoChunks("x".repeat(POLISH_CHUNK_MAX_CHARS))).toEqual([
+      "x".repeat(POLISH_CHUNK_MAX_CHARS),
+    ]);
+  });
+
+  it("prefers paragraph boundaries (double newline) over line breaks", () => {
+    const paras = paragraphs(8);
+    const text = paras.join("\n\n");
+    const chunks = splitIntoChunks(text, paras[0]!.length * 3);
+    expect(chunks.length).toBeGreaterThan(1);
+    // No chunk ends mid-paragraph: every chunk boundary sits on "\n\n".
+    for (const chunk of chunks.slice(0, -1)) {
+      expect(chunk.endsWith("\n\n")).toBe(true);
+    }
+  });
+
+  it("falls back to single newlines when no paragraph break fits", () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `行${i}`.repeat(30));
+    const text = lines.join("\n");
+    const chunks = splitIntoChunks(text, 400);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks.slice(0, -1)) {
+      expect(chunk.endsWith("\n")).toBe(true);
+      expect(chunk.endsWith("\n\n")).toBe(false);
+    }
+  });
+
+  it("hard-cuts text with no break points at exactly the budget", () => {
+    const text = "密".repeat(1000);
+    const chunks = splitIntoChunks(text, 300);
+    expect(chunks).toHaveLength(4);
+    expect(chunks[0]).toHaveLength(300);
+    expect(chunks[3]).toHaveLength(100);
+  });
+
+  it("GOLDEN: N× threshold text loses nothing and reorders nothing", () => {
+    const sentences = Array.from(
+      { length: 500 },
+      (_, i) => `句子编号${i}。${"展开论述。".repeat(6)}`,
+    );
+    // Mix paragraphs and lines so both break priorities engage.
+    const text = sentences
+      .map((s, i) => (i % 7 === 0 ? `${s}\n\n` : `${s}\n`))
+      .join("");
+    expect(text.length).toBeGreaterThan(POLISH_CHUNK_MAX_CHARS * 3);
+
+    const chunks = splitIntoChunks(text);
+    expect(chunks.length).toBeGreaterThan(3);
+    // No loss, no reorder: concatenation reproduces the input exactly.
+    expect(chunks.join("")).toBe(text);
+    // First and last sentences survive in their original positions.
+    expect(chunks[0]!.startsWith("句子编号0。")).toBe(true);
+    expect(chunks[chunks.length - 1]!).toContain("句子编号499。");
+    // Every chunk respects the budget (hard-cut guarantee).
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(POLISH_CHUNK_MAX_CHARS);
+    }
+  });
+});
+
+describe("[20260911_Feat_241_LongTextChunking] joinChunkOutputs", () => {
+  it("GOLDEN: first/last sentence present, sentence set = union of outputs", () => {
+    const outputs = ["要点甲。要点乙。", "要点丙。要点丁。", "要点戊。"];
+    const joined = joinChunkOutputs(outputs);
+    expect(joined.startsWith("要点甲。")).toBe(true);
+    expect(joined.endsWith("要点戊。")).toBe(true);
+    const joinedSentences = new Set(
+      joined
+        .split(/(?<=。)/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+    for (const output of outputs) {
+      for (const sentence of output.split(/(?<=。)/)) {
+        if (sentence) expect(joinedSentences.has(sentence.trim())).toBe(true);
+      }
+    }
+  });
+
+  it("single output passes through unchanged (单块 = 现状行为)", () => {
+    expect(joinChunkOutputs(["唯一块输出。"])).toBe("唯一块输出。");
+  });
+});
+
+describe("[20260911_Feat_241_LongTextChunking] chunkStrategyForMode", () => {
+  it("summarize maps to map-reduce; everything else to the accumulation chain", () => {
+    expect(chunkStrategyForMode("summarize")).toBe("map-reduce");
+    for (const mode of [
+      "optimize",
+      "optimize_long",
+      "format",
+      "correct",
+      "enhance",
+      "de-ai",
+    ]) {
+      expect(chunkStrategyForMode(mode)).toBe("accumulate");
+    }
+    // Unknown/custom modes default to the accumulation chain.
+    expect(chunkStrategyForMode("my-custom-template")).toBe("accumulate");
+  });
+});

--- a/tests/unit/transcription-result.test.tsx
+++ b/tests/unit/transcription-result.test.tsx
@@ -675,6 +675,11 @@ describe("TranscriptionResult — streaming manual polish (#236 ①)", () => {
     reason?: string;
     error?: string;
     reasoningChars?: number;
+    // [20260911_Feat_241_LongTextChunking] T14 progress-chunk dimensions.
+    bytes?: number;
+    chunkIndex?: number;
+    chunkCount?: number;
+    elapsedMs?: number;
   };
   type TestWindow = Omit<Window, "electronAPI"> & {
     electronAPI?: {
@@ -807,6 +812,45 @@ describe("TranscriptionResult — streaming manual polish (#236 ①)", () => {
     await vi.waitFor(() => expect(unsubSpy).toHaveBeenCalled());
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
+
+  // [20260911_Feat_241_LongTextChunking] T14: block progress (第几块/共几
+  // 块 + 已耗时) renders in the streaming card, driven purely by progress
+  // chunks — the renderer never learns the chunking strategy itself.
+  it("renders block progress and elapsed time from progress chunks", async () => {
+    renderManual();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "应用 AI 处理" }),
+    );
+    await vi.waitFor(() => expect(chunkListener).not.toBeNull());
+    const api = (globalThis.window as unknown as TestWindow).electronAPI!;
+    const requestId = (api.processText as ReturnType<typeof vi.fn>).mock
+      .calls[0]![3] as string;
+
+    chunkListener!({ type: "start", requestId });
+    // A byte-only progress chunk (file-import dimension) must NOT render
+    // block progress.
+    chunkListener!({ type: "progress", requestId, bytes: 2048 });
+    expect(
+      screen.queryByTestId("polish-chunk-progress"),
+    ).not.toBeInTheDocument();
+
+    chunkListener!({
+      type: "progress",
+      requestId,
+      chunkIndex: 2,
+      chunkCount: 3,
+      elapsedMs: 4200,
+    });
+    // i18next is not initialized in this harness, so t() echoes the zh
+    // fallback template raw; the structural pin is the element + template
+    // shape (interpolation is i18next's contract, covered by the locale
+    // files' zh/en parity checks).
+    const progress = await screen.findByTestId("polish-chunk-progress");
+    expect(progress.textContent).toContain("第");
+    expect(progress.textContent).toContain("块");
+    expect(progress.textContent).toContain("已耗时");
+  });
+  // [20260911_Feat_241_LongTextChunking] END
 });
 
 // [20260907_Fix_236_Review] Regression: a mid-stream ERROR must not leave


### PR DESCRIPTION
## 概要

实现 #241（Spec #193 T14）：超长文本自动分块润色。

- **分块器**（`polish-chunking.ts` 纯函数）：字符预算具名常量（4000，不引入分词器）；切块优先级段落双换行 → 单换行 → 硬切；无损 golden（`chunks.join("") === 原文`，首末句原位）
- **两类策略**：整理/改写类走增量累积链（第 2 块起携带前文累积输出 + 只增不减约束，终稿 = 末块累积输出）；摘要类走分块摘要 → 多轮分组归并（合并输入超预算时自动降轮，含终止守卫）
- **块间顺序执行、可取消**（settleAside 门禁 + 同 run 信号），块失败即中止并报错
- **进度透明**：progress chunk 三元组驱动 UI「第 X/N 块 · 已耗时 Y 秒」（含合并调用 tick；index 永不超过 count）；渲染端不感知切分策略；与文件导入的 bytes 进度共存
- **零回归**：短文本/单块直通现状路径；AI_REVIEW 显式 prompt 覆盖保持单发；i18n 中英完整

## Review 发现并修复的问题（两轮独立 review，非实现者）

- **MAJOR：累积链拼接自我重复** —— 初审发现「只增不减」约束下每块输出是累积式的，join 全部输出会把早期内容重复 N 倍；终稿改为末块输出，golden mock 改为遵守真实 provider 契约
- **MAJOR：clamp 预算没随链增长** —— 最小修改类模式下按单块长度给预算会在链中段截断丢要点；现按 chunk+accumulated 计算，测试钉死预算严格增长
- 初审 MINOR×5 + 复验 MINOR×1（进度显示错乱）全部修复并有测试钉住

## 验证

- TDD 红→绿：分块器 8 + 编排器 9 + 渲染端 1 + 既有全套（总计 160+ 相关用例）
- 两轮独立 code review：FIX-FIRST → 修复 → SHIP → fast-follow 落地
- `pnpm ci:check` 11/11 全绿

## 风险与注记

- 增量链 token 消耗超线性是票面确认的取舍，进度 UI 的已耗时即为知情手段
- clamp 预算在极长链上仍会顶到用户 max_tokens 上限（与单发路径同一取舍，已注释注明）
- 分块路径恒为非流式，与 T10 降级记忆无交互（记忆只描述流式能力）