### PR TITLE
fix: v1.5.0 macOS 四个现场 bug — 模型路径门禁/Dock 卡死/拖放导入/已损坏密封 (#336 #337 #338 #339)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,38 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # [20260911_Gate_MacSignature] Issue #337: with CSC_IDENTITY_AUTO_DISCOVERY=false
+      # and no Developer ID in the keychain, electron-builder skipped signing
+      # entirely, so the shipped .app kept Electron's linker ad-hoc signature
+      # with NO resource seal ("code has no resources but signature indicates
+      # they must be present"). On Apple Silicon a quarantined app in that
+      # state is rejected by Gatekeeper as "已损坏 / damaged" — right-click →
+      # Open cannot bypass it. Two-part fix:
+      #   1) package.json build.mac.identity="-" forces electron-builder's
+      #      ad-hoc signing pass (full @electron/osx-sign deep sign with a
+      #      real resource seal). The hardenedRuntime warning this triggers is
+      #      covered: entitlements.mac.plist already carries
+      #      com.apple.security.cs.disable-library-validation. Once a
+      #      Developer ID cert (CSC_LINK) is configured in secrets, replace
+      #      "-" with the cert name and add notarization.
+      #   2) This gate: codesign --verify --deep --strict fails the build on a
+      #      broken/missing seal but PASSES a valid ad-hoc seal (ad-hoc needs
+      #      no certificate), so releases stay green until a Developer ID is
+      #      configured, while the #337 broken-seal state can never ship again.
+      - name: Verify packaged app signature (packaging gate)
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP=$(find dist -maxdepth 2 -name "*.app" -print -quit)
+          test -n "$APP" || { echo "::error::no .app found under dist/"; exit 1; }
+          echo "verifying signature of: $APP"
+          codesign --verify --deep --strict --verbose=2 "$APP" || {
+            echo "::error::packaged app signature invalid (broken seal). See issue #337 — the dmg would install as 'damaged' on Apple Silicon."
+            exit 1
+          }
+          codesign -dv "$APP" 2>&1 | grep -E "Signature|Sealed" || true
+          echo "macOS signature gate passed"
+      # [20260911_Gate_MacSignature] END
       # [20260816_Gate_PackagedBootSmoke] Install the DMG we just built and
       # boot the real app. Asserts on the boot log: window created, startup
       # complete, and the renderer→preload→IPC bridge alive (hotkey

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,7 @@ chore: 升级 Electron 到 v36
 4. **Packaged boot smoke（mac）** — 挂载刚构建的 DMG、真实启动 app，轮询断言启动日志含"主窗口创建成功/应用启动完成/注册成功/Python链路自检通过"（热键注册来自渲染进程 IPC 证明 preload 桥；Python 自检是独立 spawn 嵌入式解释器跑 `import funasr`，证明解释器解析 + 依赖栈整体可用），且无致命模式（`NODE_MODULE_VERSION` / `Uncaught Exception` / `Unhandled Rejection` / preload 失败 / Python自检失败）
 5. **Packaged boot smoke（win）** — 静默安装（`/S`）刚构建的 EXE 后同样断言
 6. **Packaged boot-health probes（mac/win，Spec #266 T11）** — 以已安装产物为启动目标运行 boot-health 探针套件（preload 桥/麦克风按钮/mascot/CSP/6s 退出），打包态 asar 布局对 dev 模式 e2e 不可见
+7. <!-- [20260911_Gate_MacSignature] issue #337：v1.5.0 dmg 无资源密封被 Gatekeeper 判"已损坏" -->**macOS signature gate（mac）** — DMG 构建后对 `dist/**/Murmur.app` 执行 `codesign --verify --deep --strict`，密封损坏即中止发布；有效 ad-hoc 密封可通过（无需证书），根治需维护者在 CI secrets 配置 Developer ID（`CSC_LINK` 等）并开启公证<!-- [20260911_Gate_MacSignature] END -->
 
 经验教训：**构建全绿 ≠ 产物可用**。发布流水线的验收对象是"安装后的 app"，不是"dist/ 里有文件"。
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Download the latest build from [Releases](https://github.com/TeFuirnever/Murmur/
 > **First install notes**
 >
 > - **macOS**: if macOS reports "cannot verify the developer", right-click the app → **Open**
+> <!-- [20260911_Fix_DamagedAppWorkaround] Issue #337: the v1.5.0 dmg shipped with a broken ad-hoc seal, which Gatekeeper reports as "damaged" — a DIFFERENT scenario from "unverified developer"; right-click → Open does not bypass it. -->
+> - **macOS**: if macOS says the app "is damaged and can't be opened" (v1.5.0 ships with a broken signature seal), run in Terminal: `xattr -cr /Applications/Murmur.app && codesign --force --deep --sign - /Applications/Murmur.app` — details in [Troubleshooting](docs/troubleshooting.md)
+> <!-- [20260911_Fix_DamagedAppWorkaround] END -->
 > - **Windows**: if SmartScreen blocks the installer, click **More info** → **Run anyway**
 
 ## ⚡ Quick Start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,6 +117,9 @@
 > **首次安装提示**
 >
 > - **macOS**：如遇"无法验证开发者"，右键点击应用 → 选择"打开"
+> <!-- [20260911_Fix_DamagedAppWorkaround] Issue #337：v1.5.0 dmg 的 ad-hoc 签名密封损坏，Gatekeeper 报"已损坏"——与"无法验证开发者"是不同场景，右键打开无法绕过。 -->
+> - **macOS**：如提示"已损坏，无法打开"（v1.5.0 签名密封损坏），在终端执行：`xattr -cr /Applications/Murmur.app && codesign --force --deep --sign - /Applications/Murmur.app` —— 详见[故障排除](docs/troubleshooting.md)
+> <!-- [20260911_Fix_DamagedAppWorkaround] END -->
 > - **Windows**：如遇 SmartScreen 拦截，点击"更多信息" → "仍要运行"
 
 ## ⚡ 30 秒上手

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,26 @@
 
 ## 中文
 
+<!-- [20260911_Fix_DamagedAppWorkaround] Issue #337：v1.5.0 macOS dmg 只带 Electron
+     链接器 ad-hoc 签名、无资源密封，Apple Silicon 上被 Gatekeeper 判为"已损坏"。
+     与"无法验证开发者"是不同故障，右键打开无法绕过。 -->
+
+### macOS 提示"已损坏，无法打开"
+
+**症状**: 首次安装打开时提示"Murmur.app 已损坏，无法打开。你应该将它移到废纸篓。"
+
+**原因**: v1.5.0 及更早版本的安装包签名密封损坏（ad-hoc 签名缺少资源密封）。注意这与"无法验证开发者"是**不同**的问题——后者右键点击应用 →"打开"即可，本场景右键打开无效。
+
+**解决方案**（终端执行）:
+
+```bash
+xattr -cr /Applications/Murmur.app && codesign --force --deep --sign - /Applications/Murmur.app
+```
+
+第一条清除下载隔离属性，第二条用本地 ad-hoc 签名重建密封。如提示权限不足，在命令前加 `sudo`。修复后即可正常打开。
+
+<!-- [20260911_Fix_DamagedAppWorkaround] END -->
+
 ### FunASR 模型下载失败
 
 **症状**: 首次启动时一直显示"正在下载模型"或下载失败
@@ -93,6 +113,27 @@
 ---
 
 ## English
+
+<!-- [20260911_Fix_DamagedAppWorkaround] Issue #337: the v1.5.0 macOS dmg shipped
+     with only Electron's linker ad-hoc signature and no resource seal, so
+     Gatekeeper on Apple Silicon rejects it as "damaged". This is a different
+     failure from "unidentified developer"; right-click → Open cannot bypass it. -->
+
+### macOS Reports "Murmur.app Is Damaged and Can't Be Opened"
+
+**Symptom**: On first launch after installing, macOS says "Murmur.app is damaged and can't be opened. You should move it to the Trash."
+
+**Cause**: v1.5.0 and earlier shipped with a broken signature seal (ad-hoc signature without a resource seal). This is a **different** issue from "cannot verify the developer" — that one is fixed by right-click → Open, which does NOT work here.
+
+**Solutions** (run in Terminal):
+
+```bash
+xattr -cr /Applications/Murmur.app && codesign --force --deep --sign - /Applications/Murmur.app
+```
+
+The first command clears the quarantine attribute, the second rebuilds the seal with a local ad-hoc signature. Prefix with `sudo` if you get a permission error. The app opens normally afterwards.
+
+<!-- [20260911_Fix_DamagedAppWorkaround] END -->
 
 ### FunASR Model Download Fails
 

--- a/funasr_server.py
+++ b/funasr_server.py
@@ -402,6 +402,115 @@ class FunASRServer:
                 return True
         return False
 
+    # [20260911_Fix_336_HubLayout] Issue #336: modelscope 1.39's real
+    # on-disk layout matches NONE of the shapes _default_damo_root() knows:
+    #
+    #     <cache>/models/damo--<repo>/snapshots/<rev>/model.pt
+    #
+    # (NO `hub` layer, repo dirs renamed `damo--<name>`, an extra
+    # `snapshots/<revision>` level). Worse, the app always spawns the server
+    # with an EXPLICIT --damo-root (<userData>/models, which stays empty
+    # because download_models.py calls snapshot_download without cache_dir),
+    # so `_default_damo_root()` never ran and the gate reported
+    # models_not_downloaded forever while the UI flapped. The resolver chain
+    # below probes the explicit root FIRST (it wins when populated — the
+    # user's symlink workaround and upgrading users rely on that), then the
+    # modelscope default caches in both legacy and hub shapes.
+    _MODEL_REVISION = "v2.0.4"
+
+    @staticmethod
+    def _resolve_hub_repo(hub_root, repo_dir_name):
+        """Return the first READY hub-style snapshot dir for a repo, else None.
+
+        Hub layout (modelscope >= 1.39):
+            <hub_root>/damo--<repo>/snapshots/<rev>/<files>
+        The pinned revision is preferred (it is what AutoModel loads via
+        model_revision); any other READY snapshot is accepted so caches
+        populated with a different revision still pass the gate.
+        """
+        snapshots_dir = os.path.join(
+            hub_root, f"damo--{repo_dir_name}", "snapshots"
+        )
+        if not os.path.isdir(snapshots_dir):
+            return None
+        revisions = sorted(os.listdir(snapshots_dir), reverse=True)
+        revisions.sort(key=lambda rev: rev != FunASRServer._MODEL_REVISION)
+        for rev in revisions:
+            candidate = os.path.join(snapshots_dir, rev)
+            if FunASRServer._repo_ready(candidate):
+                return candidate
+        return None
+
+    @staticmethod
+    def _hub_models_roots():
+        """Directories that may hold damo--<repo> hub-style repos.
+
+        Covers $MODELSCOPE_CACHE (with and without the legacy `hub` layer)
+        and the default ~/.cache/modelscope — 1.39 drops the `hub` layer.
+        """
+        roots = []
+        env_root = os.environ.get("MODELSCOPE_CACHE")
+        if env_root:
+            roots.append(os.path.join(env_root, "models"))
+            roots.append(os.path.join(env_root, "hub", "models"))
+        home_dir = os.path.expanduser("~")
+        default_cache = os.path.join(home_dir, ".cache", "modelscope")
+        roots.append(os.path.join(default_cache, "models"))
+        roots.append(os.path.join(default_cache, "hub", "models"))
+        return roots
+
+    def _resolve_repo_dir(self, repo_dir_name):
+        """First READY on-disk directory for a repo across every known layout.
+
+        Order (explicit damo_root WINS when populated):
+          1. <damo_root>/<repo>                    — explicit, legacy shape
+          2. <damo_root>/damo--<repo>/snapshots/*  — explicit, hub shape
+             (covers --damo-root pointing AT the resolved modelscope root)
+          3. <default damo root>/<repo>            — modelscope cache, legacy
+          4. _hub_models_roots() hub shapes        — modelscope cache, 1.39
+        Returns None when the repo is ready nowhere (→ models_not_downloaded).
+        """
+        roots = []
+        if self.damo_root:
+            roots.append(self.damo_root)
+        default_root = self._default_damo_root()
+        if default_root not in roots:
+            roots.append(default_root)
+        for root in roots:
+            direct = os.path.join(root, repo_dir_name)
+            if self._repo_ready(direct):
+                return direct
+            found = self._resolve_hub_repo(root, repo_dir_name)
+            if found:
+                return found
+        for hub_root in self._hub_models_roots():
+            found = self._resolve_hub_repo(hub_root, repo_dir_name)
+            if found:
+                return found
+        return None
+
+    def _find_missing_required_models(self):
+        """必需模型中就绪检查未通过的 repo 列表（run() 的启动门禁用）
+
+        [20260911_Fix_336_HubLayout] Promoted from run() so the startup gate
+        is unit-testable, and switched from a single cache_path join to
+        _resolve_repo_dir so the hub layout and the empty-explicit-root
+        fallback are covered. ASR accepts either generation (SeACo primary,
+        old paraformer rollback — [20260820_T15_SeacoSwap]); punc optional.
+        """
+        vad_repo = "speech_fsmn_vad_zh-cn-16k-common-pytorch"
+        asr_repos = [
+            "speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+            "speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+        ]
+        missing = []
+        if not any(self._resolve_repo_dir(r) for r in asr_repos):
+            missing.append(asr_repos[0])
+        if not self._resolve_repo_dir(vad_repo):
+            missing.append(vad_repo)
+        return missing
+    # [20260911_Fix_336_HubLayout] END
+
     def _load_asr_model(self):
         """加载ASR模型（SeACo 优先，旧模型回退）"""
         from funasr import AutoModel
@@ -415,11 +524,16 @@ class FunASRServer:
         # which bypasses run()'s startup gate — an isdir-only check let a
         # mid-download dir holding only shard part-files through to
         # AutoModel (the confusing failure #255 fixed on the startup path).
-        cache_path = self.damo_root or self._default_damo_root()
+        # [20260911_Fix_336_HubLayout] The single-cache-path join was
+        # replaced by _resolve_repo_dir: the explicit --damo-root is usually
+        # an empty <userData>/models while the models live in modelscope
+        # 1.39's hub layout (issue #336). AutoModel still receives the repo
+        # id and resolves through modelscope's own cache — only the gate
+        # needed the new shapes.
         candidates = [
             m
             for m in (self.ASR_MODEL_SEACO, self.ASR_MODEL_FALLBACK)
-            if self._repo_ready(os.path.join(cache_path, m.split("/", 1)[1]))
+            if self._resolve_repo_dir(m.split("/", 1)[1]) is not None
         ]
         for model_name in candidates:
             try:
@@ -1525,21 +1639,15 @@ class FunASRServer:
         # [20260820_T15_SeacoSwap] Either ASR generation satisfies the
         # required-ASR check (SeACo for fresh installs / upgraded users,
         # old paraformer for mid-upgrade rollback states).
-        vad_repo = "speech_fsmn_vad_zh-cn-16k-common-pytorch"
-        asr_repos = [
-            "speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-            "speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-        ]
         # ASR (either generation) + VAD are required; punc is optional.
 
         # [20260905_Fix_255_RepoReadyShardGlob] Readiness gate promoted to
         # FunASRServer._repo_ready (staticmethod, shard-aware, testable).
-        asr_satisfied = any(
-            self._repo_ready(os.path.join(cache_path, r)) for r in asr_repos
-        )
-        missing_required = [] if asr_satisfied else asr_repos[:1]
-        if not self._repo_ready(os.path.join(cache_path, vad_repo)):
-            missing_required.append(vad_repo)
+        # [20260911_Fix_336_HubLayout] The gate itself was promoted to
+        # _find_missing_required_models() so the explicit-empty-damo_root
+        # fallback and the modelscope 1.39 hub layout resolve identically
+        # here, in _load_asr_model, and in the unit tests (issue #336).
+        missing_required = self._find_missing_required_models()
 
         if not missing_required:
             logger.info("模型文件存在，开始初始化")

--- a/main.ts
+++ b/main.ts
@@ -343,18 +343,52 @@ app.whenReady().then(async () => {
 // [20260725_E2E_CiStartupFix] END
 
 app.on("window-all-closed", () => {
+  // [20260911_Fix_339_DockActivate] Lifecycle observability — issue #339 was
+  // undebuggable from app.log because the close/hide/activate path had zero
+  // log lines. macOS intentionally stays alive (tray-resident); other
+  // platforms quit.
+  logger.info("window-all-closed事件", { platform: process.platform });
   if (process.platform !== "darwin") {
     app.quit();
   }
 });
 
+// [20260911_Fix_339_DockActivate] Issue #339: macOS Dock click must recover
+// the tray-resident window. Two cases:
+//   1. No windows at all (window was destroyed, e.g. Cmd+W): recreate AND
+//      re-sync the tray's window reference — trayManager captured the
+//      original window once at startup, so without setWindows() every tray
+//      show/click would no-op against the destroyed reference.
+//   2. A HIDDEN main window still exists (the custom close button's default
+//      close_behavior "hide" path): getAllWindows() is non-empty, so the old
+//      recreate-only handler did nothing and the app looked dead in the
+//      Dock. Now the existing window is shown/focused instead.
 app.on("activate", () => {
+  logger.info("activate事件 (Dock点击)", {
+    windowCount: BrowserWindow.getAllWindows().length,
+  });
   if (BrowserWindow.getAllWindows().length === 0) {
-    windowManager.createMainWindow();
+    windowManager
+      .createMainWindow()
+      .then((win) => {
+        if (win) {
+          trayManager.setWindows(win);
+        }
+      })
+      .catch((err: unknown) => {
+        logger.error("activate重建主窗口失败:", err);
+      });
+  } else {
+    windowManager.showMainWindow();
   }
 });
+// [20260911_Fix_339_DockActivate] END
 
 app.on("will-quit", async (e) => {
+  // [20260911_Fix_339_DockActivate] Log the quit entry so the full
+  // close → quit → cleanup path is traceable in app.log (issue #339).
+  logger.info("will-quit事件，开始清理 (热键/FunASR/数据库)");
+  // [20260911_Fix_339_DockActivate] END
   e.preventDefault();
   globalShortcut.unregisterAll();
 

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "mac": {
       "category": "public.app-category.productivity",
       "icon": "assets/icon.icns",
+      "identity": "-",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "entitlements.mac.plist",

--- a/preload.ts
+++ b/preload.ts
@@ -10,7 +10,11 @@
 // tsconfig.json sets `skipLibCheck: true`. The d.ts-internal errors are
 // caught separately by tests/unit/backend-type-safety.test.js (which scans
 // .d.ts for `any`). See ADR-013 for the wider preload ↔ handler ↔ db seam.
-import { contextBridge, ipcRenderer } from "electron";
+// [20260911_Fix_338_DragDropImport] webUtils added for getPathForFile:
+// Electron >= 32 removed File.path, so a renderer drop can only recover the
+// absolute file path through webUtils.getPathForFile in the preload (the
+// documented contextBridge pattern for drag & drop).
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import * as C from "./src/helpers/ipc-contracts";
 import type { ElectronAPI } from "./src/electronAPI";
 import type {
@@ -208,6 +212,10 @@ export const preloadApi: ElectronAPI = {
   importAudioFile: () => ipcRenderer.invoke(C.TRANSCRIPTION.IMPORT_FILE),
   validateAudioFile: (filePath: string) =>
     ipcRenderer.invoke(C.TRANSCRIPTION.VALIDATE_FILE, filePath),
+  // [20260911_Fix_338_DragDropImport] Resolve the absolute path of a File
+  // obtained from a renderer drag & drop. Returns "" for non-file blobs, so
+  // callers fall back instead of importing a phantom path.
+  getPathForFile: (file: File) => webUtils.getPathForFile(file),
   transcribeFile: (audioPath: string, options: unknown) =>
     ipcRenderer.invoke(C.TRANSCRIPTION.TRANSCRIBE_FILE, audioPath, options),
   cancelFileTranscription: () => ipcRenderer.invoke(C.TRANSCRIPTION.CANCEL),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,6 +138,47 @@ export default function App() {
   // can see it (survey gap: the state used to be trapped in the component)
   const fileTranscription = useFileTranscription();
 
+  // [20260911_Fix_338_DragDropImport] Issue #338: dropping an audio file
+  // anywhere on the main window did nothing — outside the FileDropZone (which
+  // only exists in file-import mode) no renderer code preventDefault()ed
+  // dragover, so Chromium discarded the drop before it reached business
+  // logic (and an unprevented drop can navigate the window to file://).
+  // These window-level handlers make the whole window a drop target that
+  // feeds the SAME pipeline as the dialog import (selectFileFromPath ->
+  // validateAudioFile IPC -> audioPathValidator), then switch to file-import
+  // mode so the result is visible. selectFileFromPath is a stable
+  // useCallback, so the listeners are registered once.
+  const selectDroppedFileFromPath = fileTranscription.selectFileFromPath;
+  useEffect(() => {
+    const handleWindowDragOver = (event: DragEvent) => {
+      // Required: Chromium only dispatches `drop` when dragover's default is
+      // prevented.
+      event.preventDefault();
+    };
+    const handleWindowDrop = (event: DragEvent) => {
+      // FileDropZone consumed this drop already (its handler preventDefaults
+      // during the bubble phase) — never import the same file twice.
+      if (event.defaultPrevented) return;
+      // Block Chromium's default file:// navigation for every drop.
+      event.preventDefault();
+      const droppedFile = event.dataTransfer?.files?.[0];
+      if (!droppedFile) return;
+      const droppedPath =
+        window.electronAPI?.getPathForFile?.(droppedFile) ||
+        (droppedFile as File & { path?: string }).path;
+      if (!droppedPath) return;
+      setAppMode("file-import");
+      void selectDroppedFileFromPath(droppedPath);
+    };
+    window.addEventListener("dragover", handleWindowDragOver);
+    window.addEventListener("drop", handleWindowDrop);
+    return () => {
+      window.removeEventListener("dragover", handleWindowDragOver);
+      window.removeEventListener("drop", handleWindowDrop);
+    };
+  }, [selectDroppedFileFromPath]);
+  // [20260911_Fix_338_DragDropImport] END
+
   // 安全粘贴函数
   const safePaste = useCallback(
     async (text: string) => {

--- a/src/components/FileDropZone.tsx
+++ b/src/components/FileDropZone.tsx
@@ -57,8 +57,17 @@ export default function FileDropZone({
     setIsDragging(false);
 
     const files = e.dataTransfer.files;
-    if (files.length > 0) {
-      const filePath = (files[0] as File & { path?: string }).path;
+    const droppedFile = files[0];
+    if (droppedFile) {
+      // [20260911_Fix_338_DragDropImport] Issue #338: Electron >= 32 removed
+      // File.path, so the old `file.path` read always yielded undefined and
+      // every drop silently fell through to the file dialog. Resolve via the
+      // preload's webUtils bridge first; keep the legacy read as a fallback
+      // for older runtimes.
+      const filePath =
+        window.electronAPI?.getPathForFile?.(droppedFile) ||
+        (droppedFile as File & { path?: string }).path;
+      // [20260911_Fix_338_DragDropImport] END
       if (filePath && onSelectFileFromPath) {
         onSelectFileFromPath(filePath);
       } else {

--- a/src/electronAPI.d.ts
+++ b/src/electronAPI.d.ts
@@ -180,6 +180,9 @@ export interface ElectronAPI {
     extension?: string;
     error?: string;
   }>;
+  // [20260911_Fix_338_DragDropImport] webUtils.getPathForFile bridge for
+  // drag & drop imports (Electron >= 32 removed File.path).
+  getPathForFile: (file: File) => string;
   transcribeFile: (
     audioPath: string,
     options?: Record<string, unknown>,

--- a/src/helpers/modelManager.ts
+++ b/src/helpers/modelManager.ts
@@ -57,6 +57,18 @@ const DOWNLOAD_STALL_TIMEOUT_MS = 10 * 60 * 1000;
 const DOWNLOAD_STALL_TIMEOUT_MESSAGE =
   "模型下载超时（10 分钟无进度）。已下载部分已保留，重试将自动断点续传";
 
+// [20260911_Fix_336_HubLayout] Issue #336: modelscope 1.39's real on-disk
+// layout is <cache>/models/damo--<repo>/snapshots/<rev>/ — NO `hub` layer,
+// repo dirs renamed `damo--<name>`, an extra `snapshots/<revision>` level.
+// Node's check and the Python readiness gate (funasr_server.py
+// _resolve_repo_dir) must resolve to the SAME place, otherwise the UI
+// flaps between 已加载/下载中. These constants drive the shared shape.
+const HUB_REPO_PREFIX = "damo--";
+// Pinned to the server-side model_revision; preferred when a repo dir
+// holds several snapshots.
+const PINNED_MODEL_REVISION = "v2.0.4";
+// [20260911_Fix_336_HubLayout] END
+
 class ModelManager {
   private logger: Logger;
   modelsDownloaded: boolean | null;
@@ -142,6 +154,17 @@ class ModelManager {
       "hub",
       "models",
     );
+    // [20260911_Fix_336_HubLayout] modelscope 1.39 drops the `hub` layer:
+    // fresh downloads land in ~/.cache/modelscope/models/damo--<repo>.
+    // $MODELSCOPE_CACHE can point anywhere, so probe its models roots too —
+    // Python's _default_damo_root()/_hub_models_roots() honor the same env.
+    const modelScopeCacheNoHub = path.join(
+      os.homedir(),
+      ".cache",
+      "modelscope",
+      "models",
+    );
+    const envCache = process.env.MODELSCOPE_CACHE;
 
     const candidates: string[] = [];
     if (process.env.NODE_ENV === "development") {
@@ -157,7 +180,15 @@ class ModelManager {
       // [20260724_TS_BigBang_DirnameFix] END
     }
     candidates.push(userDataModels);
+    // [20260911_Fix_336_HubLayout] Env-configured caches are probed BEFORE
+    // the home defaults: modelscope downloads INTO $MODELSCOPE_CACHE when
+    // set, so that is where the models actually are.
+    if (envCache) {
+      candidates.push(path.join(envCache, "models"));
+      candidates.push(path.join(envCache, "hub", "models"));
+    }
     candidates.push(modelScopeCache);
+    candidates.push(modelScopeCacheNoHub);
 
     for (const candidate of candidates) {
       if (!fs.existsSync(candidate)) continue;
@@ -165,15 +196,19 @@ class ModelManager {
       if (fs.existsSync(damoSub) && fs.readdirSync(damoSub).length > 0)
         return damoSub;
       if (fs.readdirSync(candidate).length > 0) {
-        const hasExpected = fs
-          .readdirSync(candidate)
-          .some(
-            (n) =>
-              n.startsWith("speech_seaco_paraformer") ||
-              n.startsWith("speech_paraformer") ||
-              n.startsWith("speech_fsmn") ||
-              n.startsWith("punc_ct"),
+        const hasExpected = fs.readdirSync(candidate).some((n) => {
+          // [20260911_Fix_336_HubLayout] Hub-layout repos carry a
+          // `damo--` prefix over the plain repo dir name.
+          const repoName = n.startsWith(HUB_REPO_PREFIX)
+            ? n.slice(HUB_REPO_PREFIX.length)
+            : n;
+          return (
+            repoName.startsWith("speech_seaco_paraformer") ||
+            repoName.startsWith("speech_paraformer") ||
+            repoName.startsWith("speech_fsmn") ||
+            repoName.startsWith("punc_ct")
           );
+        });
         if (hasExpected) return candidate;
       }
     }
@@ -193,6 +228,52 @@ class ModelManager {
     fs.mkdirSync(userDataModels, { recursive: true });
     return userDataModels;
   }
+
+  // [20260911_Fix_336_HubLayout] Per-repo resolver mirroring the Python
+  // gate (funasr_server.py _resolve_repo_dir): a repo lives either directly
+  // under the cache root (legacy damo-root shape) or in the modelscope 1.39
+  // hub shape damo--<repo>/snapshots/<rev>/. Returns the first dir that
+  // carries a marker file, or null — Node's check and the server gate then
+  // agree on "downloaded" (the mismatch WAS the #336 flapping UI).
+  _resolveRepoDir(cachePath: string, repoDirName: string): string | null {
+    const direct = path.join(cachePath, repoDirName);
+    if (fs.existsSync(direct)) return direct;
+    const snapshotsDir = path.join(
+      cachePath,
+      `${HUB_REPO_PREFIX}${repoDirName}`,
+      "snapshots",
+    );
+    if (!fs.existsSync(snapshotsDir)) return null;
+    const revisions = fs
+      .readdirSync(snapshotsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort((a, b) => {
+        // Pinned revision first — it is what the server loads; then the
+        // newest remaining revision.
+        if (a === PINNED_MODEL_REVISION) return -1;
+        if (b === PINNED_MODEL_REVISION) return 1;
+        return b.localeCompare(a);
+      });
+    for (const revision of revisions) {
+      const candidate = path.join(snapshotsDir, revision);
+      // Marker check via _verifyModel's directory branch (expected_size is
+      // ignored there): a mid-download snapshot holding only part-files
+      // must not count as present.
+      if (
+        this._verifyModel(candidate, {
+          name: repoDirName,
+          cache_path: repoDirName,
+          expected_size: 0,
+          required: false,
+        })
+      ) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+  // [20260911_Fix_336_HubLayout] END
 
   async checkModelFiles(): Promise<ModelCheckResult> {
     const now = Date.now();
@@ -230,20 +311,29 @@ class ModelManager {
       // satisfies minimum_ready — the server runs on the old generation
       // instead of refusing to start (review MAJOR fix).
       let isComplete = false;
-      const modelFile = path.join(cachePath, config.cache_path);
-      if (fs.existsSync(modelFile)) {
-        isComplete = this._verifyModel(modelFile, config);
+      // [20260911_Fix_336_HubLayout] Resolve through the hub layout too —
+      // a bare path.join would miss damo--<repo>/snapshots/<rev>/.
+      const resolvedPrimary = this._resolveRepoDir(
+        cachePath,
+        config.cache_path,
+      );
+      if (resolvedPrimary) {
+        isComplete = this._verifyModel(resolvedPrimary, config);
       }
       let ready = isComplete;
       if (!ready && config.fallback_name) {
-        const fallbackFile = path.join(
+        const fallbackDirName = config.fallback_name
+          .split("/")
+          .slice(1)
+          .join("/");
+        const resolvedFallback = this._resolveRepoDir(
           cachePath,
-          config.fallback_name.split("/").slice(1).join("/"),
+          fallbackDirName,
         );
-        if (fs.existsSync(fallbackFile)) {
-          ready = this._verifyModel(fallbackFile, {
+        if (resolvedFallback) {
+          ready = this._verifyModel(resolvedFallback, {
             ...config,
-            cache_path: config.fallback_name.split("/").slice(1).join("/"),
+            cache_path: fallbackDirName,
           });
         }
       }

--- a/src/helpers/windowManager.ts
+++ b/src/helpers/windowManager.ts
@@ -336,6 +336,20 @@ class WindowManager {
     return path.join(process.resourcesPath, "assets", "icon.png");
   }
 
+  // [20260911_Fix_339_DockActivate] Issue #339: the custom close button
+  // hides the main window (close_behavior defaults to "hide" — tray-resident
+  // design), so a macOS Dock click (app "activate") must re-show the EXISTING
+  // hidden window; BrowserWindow.getAllWindows() still contains it, which is
+  // why the old activate handler (recreate only when length === 0) left the
+  // app stuck in the Dock with no way back.
+  showMainWindow(): void {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.show();
+      this.mainWindow.focus();
+    }
+  }
+  // [20260911_Fix_339_DockActivate] END
+
   closeAllWindows(): void {
     if (this.mainWindow) {
       this.mainWindow.close();

--- a/tests/python/test_hub_layout_resolution.py
+++ b/tests/python/test_hub_layout_resolution.py
@@ -1,0 +1,244 @@
+# [20260911_Fix_336_HubLayout] Regression tests for issue #336
+# ("模型下载完成后服务端永远报 models_not_downloaded，UI 在 已加载/下载中/下载中断 之间抖动").
+#
+# Root cause (verified on the user machine): modelscope 1.39's real on-disk
+# layout matches NONE of the candidates known to the readiness gate:
+#
+#     ~/.cache/modelscope/models/damo--<repo>/snapshots/v2.0.4/model.pt
+#
+# i.e. cache root WITHOUT the legacy `hub` layer, repo dirs renamed
+# `damo--<name>`, and an extra `snapshots/<revision>` level. On top of that
+# the app always spawns the server with an EXPLICIT --damo-root
+# (<userData>/models, which stays EMPTY because download_models.py calls
+# snapshot_download without cache_dir), so `_default_damo_root()` never ran
+# at all and the gate could never see the modelscope cache.
+#
+# Contract under test:
+#   * _resolve_hub_repo(root, repo) returns the first READY
+#     damo--<repo>/snapshots/<rev> dir (pinned revision preferred), else None
+#   * _resolve_repo_dir(repo) probes the explicit damo_root FIRST (legacy
+#     AND hub shapes) and only then the modelscope default caches — an
+#     explicit root that DOES contain the models wins; an EMPTY explicit
+#     root must not shadow a populated modelscope cache
+#   * _find_missing_required_models() (run()'s startup gate) passes when the
+#     required repos exist ONLY in the 1.39 hub layout
+#   * _load_asr_model() resolves through the same hub layout
+# Runs on stdlib unittest + tempfile only.
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ),
+)
+
+os.environ.setdefault("MURMUR_DEVICE", "cpu")
+
+from funasr_server import FunASRServer  # noqa: E402
+
+SEACO_DIR = FunASRServer.ASR_MODEL_SEACO.split("/", 1)[1]
+VAD_DIR = "speech_fsmn_vad_zh-cn-16k-common-pytorch"
+PINNED_REVISION = "v2.0.4"
+
+
+class HubLayoutResolutionTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.home = os.path.join(self._tmp.name, "home")
+        self.explicit_root = os.path.join(self._tmp.name, "userdata", "models")
+        os.makedirs(self.home, exist_ok=True)
+        os.makedirs(self.explicit_root, exist_ok=True)
+        # os.path.expanduser("~") reads USERPROFILE on Windows and HOME on
+        # POSIX — patch both so the fake home applies on every platform
+        # (same reasoning as test_damo_root_layout.py).
+        self._old_env = {
+            key: os.environ.get(key)
+            for key in ("MODELSCOPE_CACHE", "HOME", "USERPROFILE")
+        }
+        os.environ["HOME"] = self.home
+        os.environ["USERPROFILE"] = self.home
+        os.environ.pop("MODELSCOPE_CACHE", None)
+
+    def tearDown(self):
+        for key, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    # --- fixture helpers -------------------------------------------------
+
+    @staticmethod
+    def _materialize_hub_repo(hub_root, repo_dir, revision=PINNED_REVISION,
+                              marker="model.pt"):
+        """Build <hub_root>/damo--<repo>/snapshots/<rev>/<marker> (1.39 layout)."""
+        snapshot_dir = os.path.join(
+            hub_root, f"damo--{repo_dir}", "snapshots", revision
+        )
+        os.makedirs(snapshot_dir, exist_ok=True)
+        Path(snapshot_dir, marker).write_text("x", encoding="utf-8")
+        return snapshot_dir
+
+    @staticmethod
+    def _materialize_legacy_repo(root, repo_dir, marker="model.pt"):
+        """Build <root>/<repo>/<marker> (damo-root layout)."""
+        repo_path = os.path.join(root, repo_dir)
+        os.makedirs(repo_path, exist_ok=True)
+        Path(repo_path, marker).write_text("x", encoding="utf-8")
+        return repo_path
+
+    def _home_hub_root(self):
+        """The 1.39 default cache root: ~/.cache/modelscope/models (no hub)."""
+        return os.path.join(self.home, ".cache", "modelscope", "models")
+
+    # --- _resolve_hub_repo ------------------------------------------------
+
+    def test_hub_repo_resolves_ready_snapshot(self):
+        hub_root = self._home_hub_root()
+        expected = self._materialize_hub_repo(hub_root, SEACO_DIR)
+        self.assertEqual(
+            FunASRServer._resolve_hub_repo(hub_root, SEACO_DIR), expected
+        )
+
+    def test_hub_repo_missing_snapshots_dir_returns_none(self):
+        hub_root = self._home_hub_root()
+        os.makedirs(os.path.join(hub_root, f"damo--{SEACO_DIR}"), exist_ok=True)
+        self.assertIsNone(FunASRServer._resolve_hub_repo(hub_root, SEACO_DIR))
+
+    def test_hub_repo_shard_only_snapshot_is_not_ready(self):
+        # A mid-download snapshot holding only a shard part-file must NOT
+        # satisfy the gate (same shard rule as issue #255).
+        hub_root = self._home_hub_root()
+        self._materialize_hub_repo(
+            hub_root, SEACO_DIR, marker="vocab.txt_0_167772159"
+        )
+        self.assertIsNone(FunASRServer._resolve_hub_repo(hub_root, SEACO_DIR))
+
+    def test_hub_repo_prefers_pinned_revision(self):
+        hub_root = self._home_hub_root()
+        self._materialize_hub_repo(hub_root, SEACO_DIR, revision="v9.9.9")
+        pinned = self._materialize_hub_repo(
+            hub_root, SEACO_DIR, revision=PINNED_REVISION
+        )
+        self.assertEqual(
+            FunASRServer._resolve_hub_repo(hub_root, SEACO_DIR), pinned
+        )
+
+    def test_hub_repo_accepts_other_ready_revision_when_pinned_absent(self):
+        hub_root = self._home_hub_root()
+        other = self._materialize_hub_repo(hub_root, SEACO_DIR, revision="v9.9.9")
+        self.assertEqual(
+            FunASRServer._resolve_hub_repo(hub_root, SEACO_DIR), other
+        )
+
+    # --- _resolve_repo_dir -------------------------------------------------
+
+    def test_empty_explicit_root_falls_back_to_home_hub_cache(self):
+        # THE #336 BUG: --damo-root points at the empty <userData>/models
+        # while the models live in the 1.39 hub layout under ~.
+        expected = self._materialize_hub_repo(self._home_hub_root(), SEACO_DIR)
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertEqual(server._resolve_repo_dir(SEACO_DIR), expected)
+
+    def test_populated_explicit_root_wins_over_hub_cache(self):
+        # An explicit damo_root that DOES contain the models keeps priority
+        # (the user's symlink workaround and upgrading users rely on it).
+        explicit = self._materialize_legacy_repo(self.explicit_root, SEACO_DIR)
+        self._materialize_hub_repo(self._home_hub_root(), SEACO_DIR)
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertEqual(server._resolve_repo_dir(SEACO_DIR), explicit)
+
+    def test_explicit_root_in_hub_shape_is_found(self):
+        # The explicit root itself may hold damo--<repo> dirs (e.g. when it
+        # IS the resolved modelscope models root passed via --damo-root).
+        expected = self._materialize_hub_repo(self.explicit_root, SEACO_DIR)
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertEqual(server._resolve_repo_dir(SEACO_DIR), expected)
+
+    def test_legacy_default_cache_still_resolves(self):
+        # Backward compat: models in the legacy default layout, no explicit
+        # root at all.
+        default_root = FunASRServer._default_damo_root()
+        expected = self._materialize_legacy_repo(default_root, SEACO_DIR)
+        server = FunASRServer()
+        self.assertEqual(server._resolve_repo_dir(SEACO_DIR), expected)
+
+    def test_missing_everywhere_returns_none(self):
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertIsNone(server._resolve_repo_dir(SEACO_DIR))
+
+    def test_env_cache_hub_layout_is_found(self):
+        # MODELSCOPE_CACHE pointing at a custom root with the 1.39 layout.
+        env_root = os.path.join(self._tmp.name, "mc")
+        expected = self._materialize_hub_repo(
+            os.path.join(env_root, "models"), SEACO_DIR
+        )
+        os.environ["MODELSCOPE_CACHE"] = env_root
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertEqual(server._resolve_repo_dir(SEACO_DIR), expected)
+
+    # --- startup gate (_find_missing_required_models) ----------------------
+
+    def test_gate_passes_with_hub_layout_and_empty_explicit_root(self):
+        # Full #336 scenario: required repos exist ONLY in the 1.39 hub
+        # layout; the explicit --damo-root is empty → gate must NOT report
+        # models_not_downloaded.
+        hub_root = self._home_hub_root()
+        self._materialize_hub_repo(hub_root, SEACO_DIR)
+        self._materialize_hub_repo(hub_root, VAD_DIR)
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertEqual(server._find_missing_required_models(), [])
+
+    def test_gate_reports_missing_when_nowhere_ready(self):
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertEqual(
+            server._find_missing_required_models(), [SEACO_DIR, VAD_DIR]
+        )
+
+    def test_gate_passes_on_fallback_asr_generation(self):
+        # The rollback paraformer satisfies the required-ASR check in the
+        # hub layout too (mirrors the legacy [20260820_T15_SeacoSwap] rule).
+        hub_root = self._home_hub_root()
+        fallback_dir = FunASRServer.ASR_MODEL_FALLBACK.split("/", 1)[1]
+        self._materialize_hub_repo(hub_root, fallback_dir)
+        self._materialize_hub_repo(hub_root, VAD_DIR)
+        server = FunASRServer(damo_root=self.explicit_root)
+        self.assertEqual(server._find_missing_required_models(), [])
+
+    # --- _load_asr_model through the hub layout ----------------------------
+
+    def test_load_asr_model_resolves_hub_layout(self):
+        import types
+
+        calls = []
+        fake_funasr = types.ModuleType("funasr")
+
+        def fake_automodel(model=None, **kwargs):
+            calls.append(model)
+            return object()
+
+        fake_funasr.AutoModel = fake_automodel
+        real = sys.modules.get("funasr")
+        sys.modules["funasr"] = fake_funasr
+        try:
+            self._materialize_hub_repo(self._home_hub_root(), SEACO_DIR)
+            server = FunASRServer(damo_root=self.explicit_root)
+            ok = server._load_asr_model()
+        finally:
+            if real is not None:
+                sys.modules["funasr"] = real
+            else:
+                sys.modules.pop("funasr", None)
+        self.assertTrue(ok)
+        self.assertEqual(calls, [FunASRServer.ASR_MODEL_SEACO])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_repo_ready_gate.py
+++ b/tests/python/test_repo_ready_gate.py
@@ -32,6 +32,29 @@ SEACO_DIR = FunASRServer.ASR_MODEL_SEACO.split("/", 1)[1]
 
 
 class RepoReadyGateTest(unittest.TestCase):
+    def setUp(self):
+        # [20260911_Fix_336_HubLayout] _resolve_repo_dir now falls back to
+        # the modelscope default caches under ~ when the explicit damo_root
+        # lacks a repo (issue #336) — isolate HOME/USERPROFILE (and any
+        # MODELSCOPE_CACHE) so these tests never see the developer
+        # machine's real, populated model cache.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._old_env = {
+            key: os.environ.get(key)
+            for key in ("MODELSCOPE_CACHE", "HOME", "USERPROFILE")
+        }
+        os.environ["HOME"] = self._tmp.name
+        os.environ["USERPROFILE"] = self._tmp.name
+        os.environ.pop("MODELSCOPE_CACHE", None)
+
+    def tearDown(self):
+        for key, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
     def _dir_with(self, *names):
         tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)

--- a/tests/python/test_seaco_fallback.py
+++ b/tests/python/test_seaco_fallback.py
@@ -23,6 +23,29 @@ OLD_DIR = funasr_server.FunASRServer.ASR_MODEL_FALLBACK.split("/", 1)[1]
 
 
 class AsrFallbackTest(unittest.TestCase):
+    def setUp(self):
+        # [20260911_Fix_336_HubLayout] _resolve_repo_dir now falls back to
+        # the modelscope default caches under ~ when the explicit damo_root
+        # lacks a repo (issue #336) — isolate HOME/USERPROFILE (and any
+        # MODELSCOPE_CACHE) so "absent from the explicit root" really means
+        # "absent everywhere", independent of the machine's real cache.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._old_env = {
+            key: os.environ.get(key)
+            for key in ("MODELSCOPE_CACHE", "HOME", "USERPROFILE")
+        }
+        os.environ["HOME"] = self._tmp.name
+        os.environ["USERPROFILE"] = self._tmp.name
+        os.environ.pop("MODELSCOPE_CACHE", None)
+
+    def tearDown(self):
+        for key, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
     def _make_repo(self, root, repo_dir):
         os.makedirs(os.path.join(root, repo_dir), exist_ok=True)
         # One config-ish file satisfies _repo_ready's glob patterns.

--- a/tests/unit/appFileDrop.test.tsx
+++ b/tests/unit/appFileDrop.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+// [20260911_Fix_338_DragDropImport] Issue #338 regression: dragging an audio
+// file from Finder/Explorer onto the Murmur main window did NOTHING — the
+// drop zone only existed inside file-import mode, and outside it no renderer
+// code preventDefault()ed dragover, so Chromium discarded the drop before any
+// business logic (and an unprevented drop can navigate the window to file://).
+// These tests pin the window-level drop target: any drop on the window feeds
+// the SAME import pipeline as the dialog button (validateAudioFile IPC ->
+// audioPathValidator) and switches to file-import mode to show the result.
+
+import "../setup/react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("../../src/hooks/useRecording", () => ({
+  useRecording: () => ({
+    isRecording: false,
+    isProcessing: false,
+    isOptimizing: false,
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    error: null,
+  }),
+  determineProcessingMode: vi.fn(() => "optimize"),
+}));
+
+vi.mock("../../src/hooks/useModelStatus", () => ({
+  useModelStatus: () => ({
+    stage: "ready",
+    isReady: true,
+    downloadProgress: 0,
+    error: null,
+    downloadModels: vi.fn(),
+    checkModelStatus: vi.fn(),
+  }),
+  ModelStatusProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+vi.mock("../../src/hooks/useHotkey", () => ({
+  useHotkey: () => ({
+    hotkey: "Cmd+Shift+Space",
+    registerHotkey: vi.fn().mockResolvedValue(undefined),
+    unregisterHotkey: vi.fn(),
+    syncRecordingState: vi.fn(),
+  }),
+}));
+
+vi.mock("../../src/hooks/useWindowDrag", () => ({
+  useWindowDrag: () => ({
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    handleMouseMove: vi.fn(),
+    handleMouseUp: vi.fn(),
+    handleClick: () => true,
+  }),
+}));
+
+const validateAudioFile = vi.fn();
+const getPathForFile = vi.fn();
+const importAudioFile = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateAudioFile.mockResolvedValue({
+    success: true,
+    filePath: "/dropped.wav",
+    fileName: "dropped.wav",
+    fileSize: 2048,
+    extension: ".wav",
+  });
+  getPathForFile.mockReturnValue("/dropped.wav");
+  importAudioFile.mockResolvedValue({ success: false, canceled: true });
+  (window as unknown as { electronAPI: Record<string, unknown> }).electronAPI =
+    {
+      getSetting: vi.fn().mockResolvedValue("paste"),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+      getAllSettings: vi.fn().mockResolvedValue({}),
+      copyText: vi.fn().mockResolvedValue(undefined),
+      onHotkeyTriggered: vi.fn(() => () => {}),
+      onWindowMaximizeChange: vi.fn(() => () => {}),
+      onSettingsUpdate: vi.fn(() => () => {}),
+      onModelStatusUpdate: vi.fn(() => () => {}),
+      getAIModes: vi.fn().mockResolvedValue([]),
+      setAlwaysOnTop: vi.fn(),
+      validateAudioFile,
+      getPathForFile,
+      importAudioFile,
+      onFileTranscriptionProgress: vi.fn(() => () => {}),
+      transcribeFile: vi.fn(() => new Promise(() => {})),
+    };
+});
+
+// Import AFTER mocks
+import App from "../../src/App";
+
+function fireWindowDrop(files: File[]): Event {
+  const evt = new Event("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(evt, "dataTransfer", { value: { files } });
+  fireEvent(window, evt);
+  return evt;
+}
+
+describe("[20260911_Fix_338_DragDropImport] window-level audio drop", () => {
+  it("prevents the default on window dragover so the drop is not discarded", () => {
+    render(React.createElement(App));
+    const evt = new Event("dragover", { bubbles: true, cancelable: true });
+    fireEvent(window, evt);
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it("prevents the default on window drop so Chromium never navigates to file://", () => {
+    render(React.createElement(App));
+    const evt = fireWindowDrop([]);
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it("imports a file dropped anywhere on the window through the shared pipeline", async () => {
+    render(React.createElement(App));
+    // App boots in recording mode: the FileDropZone is NOT mounted, so this
+    // drop can only be handled by the window-level target.
+    const file = new File(["audio"], "dropped.wav", { type: "audio/wav" });
+    fireWindowDrop([file]);
+
+    await waitFor(() =>
+      expect(validateAudioFile).toHaveBeenCalledWith("/dropped.wav"),
+    );
+    // The dialog import path must NOT be used as a fallback.
+    expect(importAudioFile).not.toHaveBeenCalled();
+    // Mode switched to file-import and the validated file is selected.
+    expect(await screen.findByText("dropped.wav")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/file-dropzone.test.tsx
+++ b/tests/unit/file-dropzone.test.tsx
@@ -83,6 +83,37 @@ describe("[20260816_Test_FileDropZone] FileDropZone", () => {
     expect(onSelectFile).toHaveBeenCalledTimes(1);
   });
 
+  // [20260911_Fix_338_DragDropImport] Issue #338 regression: Electron >= 32
+  // removed File.path, so a dropped file must resolve its absolute path via
+  // the preload's webUtils.getPathForFile bridge, not via file.path.
+  it("resolves the dropped file path via electronAPI.getPathForFile", () => {
+    const onSelectFileFromPath = vi.fn();
+    const onSelectFile = vi.fn();
+    const getPathForFile = vi.fn(() => "/resolved/dropped.wav");
+    (
+      window as unknown as { electronAPI: { getPathForFile: unknown } }
+    ).electronAPI = { getPathForFile };
+    try {
+      render(
+        <FileDropZone
+          fileInfo={null}
+          onSelectFile={onSelectFile}
+          onSelectFileFromPath={onSelectFileFromPath}
+        />,
+      );
+      // No .path on the File — matches modern Electron where it is removed.
+      const file = new File(["audio"], "dropped.wav", { type: "audio/wav" });
+      fireDrop(screen.getByTestId("file-drop-zone"), [file]);
+      expect(getPathForFile).toHaveBeenCalledWith(file);
+      expect(onSelectFileFromPath).toHaveBeenCalledWith(
+        "/resolved/dropped.wav",
+      );
+      expect(onSelectFile).not.toHaveBeenCalled();
+    } finally {
+      delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    }
+  });
+
   it("ignores an empty drop", () => {
     const onSelectFile = vi.fn();
     render(<FileDropZone fileInfo={null} onSelectFile={onSelectFile} />);

--- a/tests/unit/main-lifecycle.test.ts
+++ b/tests/unit/main-lifecycle.test.ts
@@ -1,0 +1,224 @@
+// [20260911_Fix_339_DockActivate] Regression tests for issue #339: on macOS
+// the custom close button hides the main window (close_behavior defaults to
+// "hide" — tray-resident design), but the app.on("activate") handler only
+// recreated the window when getAllWindows() was empty. A HIDDEN window still
+// counts, so Dock clicks did nothing and the app looked force-quit-only dead.
+//
+// The contract under test, in main.ts app lifecycle handlers:
+//   1. activate with an existing (hidden) main window → showMainWindow()
+//      is called so the window reappears.
+//   2. activate with zero windows → createMainWindow() recreates the window
+//      AND trayManager.setWindows() is refreshed with the new window (the
+//      tray captured the original window reference once at startup; without
+//      the re-sync every tray show/click no-ops on the destroyed reference).
+//   3. activate, window-all-closed and will-quit all log through the shared
+//      LogManager so the lifecycle is observable in app.log (issue #339
+//      notes the path was previously invisible).
+//
+// Harness mirrors main-boot-order.test.ts: every helper module main.ts
+// imports is mocked to spies; electron's app.on registrations are captured
+// into a handler map the tests invoke directly. whenReady is left pending —
+// the lifecycle handlers under test are registered at module top level, no
+// boot needed.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => {
+  type AppEventHandler = (...args: unknown[]) => unknown;
+  const appOnHandlers: Record<string, AppEventHandler> = {};
+  const hiddenWindow = {
+    on: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    show: vi.fn(),
+    focus: vi.fn(),
+  };
+  return {
+    appOnHandlers,
+    hiddenWindow,
+    allWindows: [] as unknown[],
+    loggerInfo: vi.fn(),
+    windowManager: {
+      mainWindow: null as unknown,
+      _setupCSP: vi.fn(),
+      setDefaultAlwaysOnTop: vi.fn(),
+      createMainWindow: vi.fn(),
+      loadMainWindowContent: vi.fn(async () => undefined),
+      showMainWindow: vi.fn(),
+    },
+    trayManager: {
+      setWindows: vi.fn(),
+      createTray: vi.fn(async () => undefined),
+    },
+  };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp/murmur-lifecycle-test"),
+    getVersion: vi.fn(() => "0.0.0-test"),
+    // Pending forever: startApp never runs; the tests only need the
+    // top-level app.on(...) registrations.
+    whenReady: vi.fn(() => new Promise<void>(() => {})),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+      h.appOnHandlers[event] = handler;
+    }),
+    quit: vi.fn(),
+    exit: vi.fn(),
+    disableHardwareAcceleration: vi.fn(),
+    dock: { show: vi.fn(async () => {}) },
+  },
+  globalShortcut: {
+    register: vi.fn(),
+    unregister: vi.fn(),
+    unregisterAll: vi.fn(),
+    isRegistered: vi.fn(() => false),
+  },
+  BrowserWindow: class {
+    static getAllWindows() {
+      return h.allWindows;
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: vi.fn(() => true),
+    encryptString: vi.fn(),
+    decryptString: vi.fn(),
+  },
+  ipcMain: {
+    on: vi.fn(),
+    handle: vi.fn(),
+    handleOnce: vi.fn(),
+    removeHandler: vi.fn(),
+    removeAllListeners: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/helpers/logManager", () => ({
+  default: class {
+    info = h.loggerInfo;
+    warn = vi.fn();
+    error = vi.fn();
+    debug = vi.fn();
+    getSystemInfo = vi.fn(() => ({}));
+  },
+}));
+
+vi.mock("../../src/helpers/environment", () => ({
+  default: class {
+    ensureDataDirectory = vi.fn(() => "/tmp/murmur-lifecycle-test");
+  },
+}));
+
+vi.mock("../../src/helpers/windowManager", () => ({
+  default: class {
+    mainWindow = h.windowManager.mainWindow;
+    _setupCSP = h.windowManager._setupCSP;
+    setDefaultAlwaysOnTop = h.windowManager.setDefaultAlwaysOnTop;
+    createMainWindow = h.windowManager.createMainWindow;
+    loadMainWindowContent = h.windowManager.loadMainWindowContent;
+    showMainWindow = h.windowManager.showMainWindow;
+  },
+}));
+
+vi.mock("../../src/helpers/database", () => ({
+  default: class {
+    initialize = vi.fn();
+    setFileConfigPath = vi.fn();
+    getSetting = vi.fn(() => undefined);
+    setSafeStorage = vi.fn();
+    close = vi.fn();
+  },
+}));
+
+vi.mock("../../src/helpers/clipboard", () => ({
+  default: class {},
+}));
+
+vi.mock("../../src/helpers/funasrManager", () => ({
+  default: class {
+    initializeAtStartup = vi.fn(async () => undefined);
+    gracefulShutdown = vi.fn(async () => undefined);
+  },
+}));
+
+vi.mock("../../src/helpers/tray", () => ({
+  default: class {
+    setWindows = h.trayManager.setWindows;
+    createTray = h.trayManager.createTray;
+  },
+}));
+
+vi.mock("../../src/helpers/hotkeyManager", () => ({
+  default: class {},
+}));
+
+vi.mock("../../src/helpers/ipc", () => ({
+  registerAll: vi.fn(),
+}));
+
+async function importMain(): Promise<void> {
+  await import("../../main");
+}
+
+describe("[20260911_Fix_339_DockActivate] main.ts lifecycle handlers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    for (const key of Object.keys(h.appOnHandlers)) {
+      delete h.appOnHandlers[key];
+    }
+    h.allWindows = [];
+    h.windowManager.mainWindow = null;
+  });
+
+  it("activate with an existing hidden main window shows it instead of recreating", async () => {
+    h.allWindows = [h.hiddenWindow];
+    h.windowManager.mainWindow = h.hiddenWindow;
+    h.windowManager.createMainWindow.mockResolvedValue(h.hiddenWindow);
+
+    await importMain();
+    h.appOnHandlers["activate"]!();
+
+    expect(h.windowManager.showMainWindow).toHaveBeenCalledTimes(1);
+    expect(h.windowManager.createMainWindow).not.toHaveBeenCalled();
+  });
+
+  it("activate with zero windows recreates the main window and re-syncs the tray reference", async () => {
+    h.allWindows = [];
+    h.windowManager.createMainWindow.mockResolvedValue(h.hiddenWindow);
+
+    await importMain();
+    h.appOnHandlers["activate"]!();
+    // createMainWindow is async; the tray re-sync happens after it resolves.
+    await vi.waitFor(() =>
+      expect(h.trayManager.setWindows).toHaveBeenCalledWith(h.hiddenWindow),
+    );
+
+    expect(h.windowManager.createMainWindow).toHaveBeenCalledTimes(1);
+    expect(h.windowManager.showMainWindow).not.toHaveBeenCalled();
+  });
+
+  it("activate logs through the shared logger so the Dock path is observable", async () => {
+    h.allWindows = [h.hiddenWindow];
+    h.windowManager.mainWindow = h.hiddenWindow;
+
+    await importMain();
+    h.appOnHandlers["activate"]!();
+
+    expect(h.loggerInfo).toHaveBeenCalled();
+  });
+
+  it("window-all-closed is wired and logged; on macOS it does not quit (tray-resident)", async () => {
+    await importMain();
+    const handler = h.appOnHandlers["window-all-closed"];
+    expect(typeof handler).toBe("function");
+
+    const electron = await import("electron");
+    handler!();
+
+    expect(h.loggerInfo).toHaveBeenCalled();
+    if (process.platform === "darwin") {
+      expect(electron.app.quit).not.toHaveBeenCalled();
+    } else {
+      expect(electron.app.quit).toHaveBeenCalled();
+    }
+  });
+});

--- a/tests/unit/modelManager-hub-layout.test.ts
+++ b/tests/unit/modelManager-hub-layout.test.ts
@@ -1,0 +1,176 @@
+// [20260911_Fix_336_HubLayout] Regression tests for issue #336: modelscope
+// 1.39 downloads into ~/.cache/modelscope/models/damo--<repo>/snapshots/<rev>/
+// (no `hub` layer, repo dirs renamed `damo--<name>`, extra snapshots level),
+// which getModelCachePath()/checkModelFiles() could not see — Node's check
+// passed or failed on a DIFFERENT directory than the Python readiness gate,
+// which is exactly the flapping 已加载/下载中 UI from the issue.
+//
+// Contract under test:
+//   * getModelCachePath() resolves the 1.39 no-hub modelscope root when it
+//     holds damo--<repo> repos, and still prefers a populated userData
+//     models dir (upgrading users / the symlink workaround).
+//   * _resolveRepoDir() maps a repo name to the direct legacy dir or the
+//     first ready damo--<repo>/snapshots/<rev> dir (marker-checked).
+//   * checkModelFiles() passes end-to-end when the models exist ONLY in the
+//     1.39 hub layout — agreeing with the Python gate.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import ModelManager from "../../src/helpers/modelManager";
+
+const SEACO_REPO =
+  "speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch";
+const FALLBACK_REPO =
+  "speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch";
+const VAD_REPO = "speech_fsmn_vad_zh-cn-16k-common-pytorch";
+const PUNC_REPO = "punc_ct-transformer_zh-cn-common-vocab272727-pytorch";
+const PINNED_REVISION = "v2.0.4";
+
+function makeManager(): ModelManager {
+  return new ModelManager({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  });
+}
+
+/** Build <hubRoot>/damo--<repo>/snapshots/<rev>/<marker> (1.39 layout). */
+function materializeHubRepo(
+  hubRoot: string,
+  repo: string,
+  revision = PINNED_REVISION,
+  marker = "model.pt",
+): string {
+  const snapshotDir = path.join(
+    hubRoot,
+    `damo--${repo}`,
+    "snapshots",
+    revision,
+  );
+  fs.mkdirSync(snapshotDir, { recursive: true });
+  fs.writeFileSync(path.join(snapshotDir, marker), "x");
+  return snapshotDir;
+}
+
+describe("[20260911_Fix_336_HubLayout] modelscope 1.39 hub layout", () => {
+  let tmpDir: string;
+  let fakeHome: string;
+  let fakeUserData: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mm-hub-"));
+    fakeHome = path.join(tmpDir, "home");
+    // The electron require fails under vitest, so userDataPath falls back to
+    // os.tmpdir(); spy tmpdir to keep userData/models deterministic+empty.
+    fakeUserData = path.join(tmpDir, "userdata");
+    fs.mkdirSync(fakeHome, { recursive: true });
+    fs.mkdirSync(fakeUserData, { recursive: true });
+    vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+    vi.spyOn(os, "tmpdir").mockReturnValue(fakeUserData);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function hubRoot(): string {
+    return path.join(fakeHome, ".cache", "modelscope", "models");
+  }
+
+  describe("getModelCachePath", () => {
+    it("resolves the 1.39 no-hub modelscope root holding damo-- repos", () => {
+      materializeHubRepo(hubRoot(), SEACO_REPO);
+      const m = makeManager();
+      expect(m.getModelCachePath()).toBe(hubRoot());
+    });
+
+    it("still prefers a populated userData models dir (upgrading users)", () => {
+      const userDataModels = path.join(fakeUserData, "models");
+      fs.mkdirSync(path.join(userDataModels, SEACO_REPO), { recursive: true });
+      materializeHubRepo(hubRoot(), SEACO_REPO);
+      const m = makeManager();
+      expect(m.getModelCachePath()).toBe(userDataModels);
+    });
+
+    it("ignores a hub root whose damo-- dirs match no known model", () => {
+      materializeHubRepo(hubRoot(), "unrelated_model");
+      const m = makeManager();
+      // Falls through to the userData fallback (created on demand).
+      expect(m.getModelCachePath()).toBe(path.join(fakeUserData, "models"));
+    });
+  });
+
+  describe("_resolveRepoDir", () => {
+    it("returns the direct legacy dir when present", () => {
+      const direct = path.join(tmpDir, SEACO_REPO);
+      fs.mkdirSync(direct, { recursive: true });
+      const m = makeManager();
+      expect(m._resolveRepoDir(tmpDir, SEACO_REPO)).toBe(direct);
+    });
+
+    it("returns the ready snapshot dir for the hub layout", () => {
+      const expected = materializeHubRepo(tmpDir, SEACO_REPO);
+      const m = makeManager();
+      expect(m._resolveRepoDir(tmpDir, SEACO_REPO)).toBe(expected);
+    });
+
+    it("skips snapshot dirs without a marker file", () => {
+      materializeHubRepo(tmpDir, SEACO_REPO, PINNED_REVISION, "notes.txt");
+      const m = makeManager();
+      expect(m._resolveRepoDir(tmpDir, SEACO_REPO)).toBeNull();
+    });
+
+    it("prefers the pinned revision over other ready snapshots", () => {
+      materializeHubRepo(tmpDir, SEACO_REPO, "v9.9.9");
+      const pinned = materializeHubRepo(tmpDir, SEACO_REPO, PINNED_REVISION);
+      const m = makeManager();
+      expect(m._resolveRepoDir(tmpDir, SEACO_REPO)).toBe(pinned);
+    });
+
+    it("returns null when the repo is nowhere on disk", () => {
+      const m = makeManager();
+      expect(m._resolveRepoDir(tmpDir, SEACO_REPO)).toBeNull();
+    });
+  });
+
+  describe("checkModelFiles", () => {
+    it("passes when models exist ONLY in the 1.39 hub layout", async () => {
+      // THE #336 SCENARIO: nothing under userData/models; every repo lives
+      // in ~/.cache/modelscope/models/damo--<repo>/snapshots/v2.0.4/.
+      for (const repo of [SEACO_REPO, VAD_REPO, PUNC_REPO]) {
+        materializeHubRepo(hubRoot(), repo);
+      }
+      const m = makeManager();
+      m.clearCache();
+      const r = await m.checkModelFiles();
+      expect(r.cache_path).toBe(hubRoot());
+      expect(r.models_downloaded).toBe(true);
+      expect(r.minimum_ready).toBe(true);
+      expect(r.missing_models).toEqual([]);
+    });
+
+    it("counts a hub-layout fallback ASR as ready while flagging the upgrade", async () => {
+      materializeHubRepo(hubRoot(), FALLBACK_REPO);
+      materializeHubRepo(hubRoot(), VAD_REPO);
+      materializeHubRepo(hubRoot(), PUNC_REPO);
+      const m = makeManager();
+      m.clearCache();
+      const r = await m.checkModelFiles();
+      expect(r.minimum_ready).toBe(true);
+      expect(r.models_downloaded).toBe(false);
+      expect(r.missing_models).toEqual(["asr"]);
+      expect(r.model_details!.asr!.downloaded).toBe(true);
+    });
+
+    it("reports missing when the hub snapshots hold no marker files", async () => {
+      materializeHubRepo(hubRoot(), SEACO_REPO, PINNED_REVISION, "notes.txt");
+      const m = makeManager();
+      m.clearCache();
+      const r = await m.checkModelFiles();
+      expect(r.models_downloaded).toBe(false);
+      expect(r.missing_models).toContain("asr");
+    });
+  });
+});

--- a/tests/unit/seaco-model-catalog.test.ts
+++ b/tests/unit/seaco-model-catalog.test.ts
@@ -62,7 +62,13 @@ describe("[20260820_T15_SeacoSwap] source-contract sync points", () => {
     );
     expect(check).toContain("speech_seaco_paraformer_large");
     expect(check).toContain("speech_paraformer-large");
-    expect(check).toContain("asr_satisfied");
+    // [20260911_Fix_336_HubLayout] The gate was promoted from run()'s inline
+    // `asr_satisfied` to _find_missing_required_models() (issue #336: hub
+    // layout + empty-explicit-root fallback). The either-generation contract
+    // is unchanged — anchor on the new resolution call.
+    expect(check).toContain(
+      "any(self._resolve_repo_dir(r) for r in asr_repos)",
+    );
   });
 
   it("cache discovery prefixes include the SeACo directory", () => {

--- a/tests/unit/windowManager-events.test.ts
+++ b/tests/unit/windowManager-events.test.ts
@@ -621,6 +621,36 @@ describe("[20260906_Spec259_T2] windowManager branch close-out", () => {
     expect(main.focus).not.toHaveBeenCalled();
   });
 
+  // [20260911_Fix_339_DockActivate] Issue #339: after the close button hides
+  // the main window (tray-resident design), a macOS Dock click fires
+  // app.on("activate"), which must re-show the existing hidden window.
+  it("showMainWindow shows and focuses the existing hidden main window", async () => {
+    process.env.NODE_ENV = "development";
+    const WindowManager = await loadWindowManager();
+    const wm = new WindowManager();
+    const main = (await wm.createMainWindow())!;
+
+    wm.showMainWindow();
+
+    expect(main.show).toHaveBeenCalledTimes(1);
+    expect(main.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("showMainWindow is a safe no-op when the main window is missing or destroyed", async () => {
+    process.env.NODE_ENV = "development";
+    const WindowManager = await loadWindowManager();
+    const wm = new WindowManager();
+
+    expect(() => wm.showMainWindow()).not.toThrow();
+
+    const main = (await wm.createMainWindow())!;
+    main.isDestroyed = vi.fn(() => true);
+    wm.showMainWindow();
+    expect(main.show).not.toHaveBeenCalled();
+    expect(main.focus).not.toHaveBeenCalled();
+  });
+  // [20260911_Fix_339_DockActivate] END
+
   it("closeAllWindows closes every open window and is a safe no-op on a fresh manager", async () => {
     process.env.NODE_ENV = "development";
     const WindowManager = await loadWindowManager();


### PR DESCRIPTION
## 概要

修复 v1.5.0 macOS 现场报告的 4 个 bug（同一台机器、同一安装环境）：closes #336, closes #337, closes #338, closes #339。

每个 bug 一个独立 commit，均按 TDD 流程（回归测试先红后绿），改动带 tag 注释。

## 修复内容

### #336 模型状态横跳（a8b8a26）
- **根因**：`--damo-root` 显式传参（指向空的 userData/models）短路了 `_default_damo_root()` 布局探测；且 modelscope 1.39 实际落盘布局 `~/.cache/modelscope/models/damo--<repo>/snapshots/v2.0.4/` 与两侧所有候选均不匹配 → Node 检查通过 / Python 门禁失败 → UI 横跳。
- **修复**：`funasr_server.py` 新增 `_resolve_repo_dir`/`_hub_models_roots`/`_resolve_hub_repo`/`_find_missing_required_models`（显式 root 优先，空则回退 modelscope 缓存，支持 hub 新布局，shard 感知）；`modelManager.ts` 同步实现 `_resolveRepoDir` 与新候选根，双侧解析一致。
- **测试**：新增 `tests/python/test_hub_layout_resolution.py`（15 例）+ `tests/unit/modelManager-hub-layout.test.ts`（11 例），均先红后绿。

### #339 关闭卡死 Dock（3c81ddb）
- **根因**：托盘常驻设计下，`app.on("activate")` 只在窗口数为 0 时重建，被 hide 的窗口仍计数 → Dock 点击无反应；托盘引用在窗口销毁重建后失效（次生 bug）；关闭路径零日志。
- **修复**：新增 `windowManager.showMainWindow()`；activate 时显示隐藏窗口或重建并重新 `trayManager.setWindows()`；`window-all-closed`/`will-quit`/`activate` 补生命周期日志。
- **测试**：新增 `tests/unit/main-lifecycle.test.ts`（4 例）+ `windowManager-events.test.ts` 2 例，先红后绿。

### #338 拖放导入无反应（1ca3e8a）
- **根因**：主窗口无 `dragover preventDefault`（Chromium 丢弃 drop）；且 `FileDropZone` 读取的 `File.path` 在 Electron ≥32 已移除，路径解析本身就是坏的。
- **修复**：preload 暴露 `webUtils.getPathForFile`；`App.tsx` 窗口级 dragover/drop 监听（阻止 file:// 导航、避免重复导入、复用与按钮导入同一条 `selectFileFromPath` → `audioPathValidator` 管线）。
- **测试**：`file-dropzone.test.tsx` + 新增 `appFileDrop.test.tsx`（3 例），先红后绿。
- **遗留**：Playwright 合成 File 无真实 OS 路径，e2e 无法覆盖；建议打包版人工 QA。

### #337 安装报「已损坏」（bff73b0）
- **根因**：`build.mac` 无 `identity` + CI `CSC_IDENTITY_AUTO_DISCOVERY: false` → electron-builder 完全跳过签名，产物只剩链接器 ad-hoc 签名、无资源密封（用 1.4.0 实物包复现）。
- **修复**：`identity: "-"` 启用完整 ad-hoc 深度签名（有效密封，无需证书）；release CI 新增 `codesign --verify --deep --strict` 门禁（有效 ad-hoc 可通过、破损密封失败，本地双向实测）；双语 README + troubleshooting 补「已损坏」场景 `xattr -cr` 绕行；CONTRIBUTING 登记为 release gate #7。
- **遗留**：根治需 maintainer 配置 Developer ID 证书（`CSC_LINK` 等 CI secrets）并移除 `identity: "-"`（已写入 workflow 注释）。

## 验证

- `pnpm ci:check`：11/11 通过（format/lint/license/typecheck×2/覆盖率测试/build×3/dev smoke），仅一条非阻塞 security audit 警告。
- 全量 vitest 2370/2370 绿；Python 135 测试 OK。

## 风险

- `main.ts`/`windowManager.ts`/`funasrManager` 链路为高风险区：改动均为附加式、窄范围；Windows `window-all-closed` → quit 语义未动。
- #337 的 hardened runtime 在 ad-hoc 下首次实际生效，依赖既有 `disable-library-validation` entitlement —— 请留意下一个 `v*` tag 的打包启动 smoke（gate #4）。
