### PR TITLE
test: Windows 打包 boot-health 时序加固（解除 v1.5.1 发布阻塞）

### DIFF
--- a/tests/e2e/suites/00-boot-health.test.ts
+++ b/tests/e2e/suites/00-boot-health.test.ts
@@ -32,6 +32,9 @@
 // [20260725_E2E_BootHealthGate] END
 
 import { test, expect } from "@playwright/test";
+import fs from "fs";
+import os from "os";
+import path from "path";
 import {
   launchElectronApp,
   closeElectronApp,
@@ -71,6 +74,53 @@ const BOOT_PROBES = {
 };
 // [20260725_E2E_BootHealthGate] END
 
+// [20260912_Test_WinPackagedBootFunasrSettle] v1.5.1 release CI (run
+// 34581815142, both workflow attempts) failed this suite on Windows 4/4
+// sub-runs: the FunASR manager self-check takes ~20s on the 4-core
+// runner, so the Python server spawn lands exactly while 0.3-0.6 probe
+// the app; the interpreter+funasr import storm collided with 0.5's
+// reload / 0.6's evaluate and the app received a teardown (will-quit,
+// exit 0) mid-probe. Waiting for the server's first init result (test
+// 0.2b below) moves the storm BEFORE the fragile probes, and parks the
+// Python process in stdin readline so 0.7's gracefulShutdown "exit"
+// command is answered immediately. The milestone strings are the same
+// app.log contract the release smoke gates on (see funasrManager.ts
+// [20260818_T3_PythonSelfCheckMilestone]).
+const FUNASR_INIT_SETTLE_TIMEOUT_MS = 30_000;
+const FUNASR_INIT_SETTLE_POLL_MS = 500;
+const FUNASR_INIT_MILESTONE = /FunASR服务器(启动成功|初始化失败)/;
+
+// Mirrors LogManager.getLogDirectory(): <userData>/logs/app.log, with
+// userData resolved from the app name ("murmur") per platform. Matches
+// the packaged path observed in release CI (%APPDATA%\murmur\logs).
+function funasrAppLogPath(): string {
+  if (process.platform === "win32") {
+    return path.join(process.env.APPDATA ?? "", "murmur", "logs", "app.log");
+  }
+  if (process.platform === "darwin") {
+    return path.join(
+      os.homedir(),
+      "Library",
+      "Application Support",
+      "murmur",
+      "logs",
+      "app.log",
+    );
+  }
+  return path.join(os.homedir(), ".config", "murmur", "logs", "app.log");
+}
+// [20260912_Test_WinPackagedBootFunasrSettle] END
+
+// [20260912_Test_WinPackagedQuitBudget] Quit budget for test 0.7. The
+// will-quit handler races FunASR gracefulShutdown at 5s
+// (main.ts:397-400); Windows packaged teardown then measured ~3-5s more
+// until Playwright's 'close' fires (run 34581815142: app.exit → process
+// exit 4.7s; total close 6.5s vs the old flat 6s budget). darwin keeps
+// the original 6s (teardown <1s there); win32 gets 15s = 5s race +
+// ~5s teardown + slack.
+const QUIT_BUDGET_MS = process.platform === "win32" ? 15_000 : 6_000;
+// [20260912_Test_WinPackagedQuitBudget] END
+
 test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
   // [20260906_Test_PackagedBootHealth] Spec #266 T11: in packaged-app runs
   // (release workflow) first boot pays cold asar/entitlements cost; the
@@ -79,6 +129,13 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
 
   let electronApp;
   let window;
+  // [20260912_Test_WinPackagedBootFunasrSettle] Byte offset into app.log
+  // captured at launch; the 0.2b milestone scan only reads content
+  // appended AFTER it, so a previous instance's log (the release
+  // pipeline's PowerShell smoke boots the same packaged app first)
+  // cannot false-positive the settle wait.
+  let funasrLogOffset = 0;
+  // [20260912_Test_WinPackagedBootFunasrSettle] END
   // [20260725_E2E_BootHealthGate_CodeReviewS2] Renderer console listener
   // is attached in beforeAll IMMEDIATELY after firstWindow() resolves so
   // it catches initial-mount errors, not just post-reload ones. Previously
@@ -90,6 +147,14 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
 
   test.beforeAll(async () => {
     ({ app: electronApp, window } = await launchElectronApp());
+    // [20260912_Test_WinPackagedBootFunasrSettle] Capture the app.log
+    // offset AFTER launch (the boot may have rotated/truncated the file).
+    try {
+      funasrLogOffset = fs.statSync(funasrAppLogPath()).size;
+    } catch {
+      funasrLogOffset = 0; // first boot on this machine — no log yet
+    }
+    // [20260912_Test_WinPackagedBootFunasrSettle] END
     window.on("console", (msg) => {
       if (msg.type() === "error") consoleErrors.push(msg.text());
     });
@@ -145,6 +210,36 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
         `IPC channel "${channel}" did not resolve`,
       ).resolves.toBeDefined();
     }
+  });
+
+  // 0.2b — [20260912_Test_WinPackagedBootFunasrSettle] wait for the
+  // FunASR Python server's first-boot init result before the reload /
+  // evaluate probes below. On Windows release CI the interpreter+funasr
+  // import storm (~5s on the 4-core runner) overlaps tests 0.3-0.6 and
+  // the app received a mid-probe teardown 4/4 sub-runs (run
+  // 34581815142). Web-first poll (R1) on the app.log milestone — no
+  // fixed waitForTimeout (§8). Both terminal outcomes satisfy the wait:
+  // models present ("启动成功") or models absent ("初始化失败" —
+  // models_not_downloaded, the expected CI state).
+  test("0.2b FunASR first-boot init settles before renderer probes", async () => {
+    const logPath = funasrAppLogPath();
+    await expect
+      .poll(
+        () => {
+          try {
+            return FUNASR_INIT_MILESTONE.test(
+              fs.readFileSync(logPath, "utf8").slice(funasrLogOffset),
+            );
+          } catch {
+            return false; // app.log not created yet
+          }
+        },
+        {
+          timeout: FUNASR_INIT_SETTLE_TIMEOUT_MS,
+          intervals: [FUNASR_INIT_SETTLE_POLL_MS],
+        },
+      )
+      .toBe(true);
   });
 
   // 0.3 — Phase C6: preload bridge exposes the contract. The threshold of
@@ -219,13 +314,15 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
   });
 
   // 0.7 — Phase E3: graceful shutdown. will-quit race timeout is 5s
-  // (main.ts will-quit handler); 6s gives 1s of slack. If this fails, a
-  // manager's before-quit hook is hanging — typically FunASR Python spawn
-  // teardown or sqlite open handle. Nulls electronApp so afterAll skips.
-  test("0.7 app quits within 6s (will-quit race timeout is 5s)", async () => {
+  // (main.ts will-quit handler); QUIT_BUDGET_MS adds the platform
+  // teardown headroom measured in release CI (see tag above). If this
+  // fails, a manager's before-quit hook is hanging — typically FunASR
+  // Python spawn teardown or sqlite open handle. Nulls electronApp so
+  // afterAll skips.
+  test("0.7 app quits within budget (will-quit race timeout is 5s)", async () => {
     const start = Date.now();
     await closeElectronApp(electronApp);
-    expect(Date.now() - start).toBeLessThan(6_000);
+    expect(Date.now() - start).toBeLessThan(QUIT_BUDGET_MS);
     electronApp = null; // prevent double-close in afterAll
   });
 });

--- a/tests/e2e/suites/00-boot-health.test.ts
+++ b/tests/e2e/suites/00-boot-health.test.ts
@@ -83,12 +83,26 @@ const BOOT_PROBES = {
 // exit 0) mid-probe. Waiting for the server's first init result (test
 // 0.2b below) moves the storm BEFORE the fragile probes, and parks the
 // Python process in stdin readline so 0.7's gracefulShutdown "exit"
-// command is answered immediately. The milestone strings are the same
-// app.log contract the release smoke gates on (see funasrManager.ts
-// [20260818_T3_PythonSelfCheckMilestone]).
+// command is answered immediately.
+//
+// "Settled" = ANY terminal FunASR state, not just a spawned server
+// (PR #347 CI run 34629631370 failed 0.2b on BOTH platforms because
+// the lint-and-test runners have no embedded Python env at all):
+//   1. 启动成功   — server up, models initialized (dev machines);
+//   2. 初始化失败 — server up, models_not_downloaded (release runners);
+//   3. 启动初始化失败 — initializeAtStartup threw (e.g. "嵌入式Python环境
+//      不可用" on PR CI); the server NEVER spawns in this state
+//      (preInitializeModels early-returns on installed:false,
+//      funasrManager.ts:329-333), so there is no storm to wait out and
+//      0.2b resolves immediately.
+// All three are logger.info/warn lines and therefore land in app.log
+// (logManager.ts:72-103 routes every level to the file). The server
+// milestones are the same app.log contract the release smoke gates on
+// (see funasrManager.ts [20260818_T3_PythonSelfCheckMilestone]).
 const FUNASR_INIT_SETTLE_TIMEOUT_MS = 30_000;
 const FUNASR_INIT_SETTLE_POLL_MS = 500;
-const FUNASR_INIT_MILESTONE = /FunASR服务器(启动成功|初始化失败)/;
+const FUNASR_INIT_MILESTONE =
+  /FunASR服务器(启动成功|初始化失败)|FunASR启动初始化失败/;
 
 // Mirrors LogManager.getLogDirectory(): <userData>/logs/app.log, with
 // userData resolved from the app name ("murmur") per platform. Matches
@@ -130,10 +144,12 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
   let electronApp;
   let window;
   // [20260912_Test_WinPackagedBootFunasrSettle] Byte offset into app.log
-  // captured at launch; the 0.2b milestone scan only reads content
-  // appended AFTER it, so a previous instance's log (the release
-  // pipeline's PowerShell smoke boots the same packaged app first)
-  // cannot false-positive the settle wait.
+  // captured BEFORE launch in beforeAll; the 0.2b milestone scan only
+  // reads content appended AFTER it, so a previous instance's log (the
+  // release pipeline's PowerShell smoke boots the same packaged app
+  // first) cannot false-positive the settle wait. It must be captured
+  // pre-launch because the env-unavailable milestone (state 3 above)
+  // fires DURING boot — potentially before launchElectronApp() returns.
   let funasrLogOffset = 0;
   // [20260912_Test_WinPackagedBootFunasrSettle] END
   // [20260725_E2E_BootHealthGate_CodeReviewS2] Renderer console listener
@@ -146,15 +162,16 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
   const consoleErrors = [];
 
   test.beforeAll(async () => {
-    ({ app: electronApp, window } = await launchElectronApp());
     // [20260912_Test_WinPackagedBootFunasrSettle] Capture the app.log
-    // offset AFTER launch (the boot may have rotated/truncated the file).
+    // offset BEFORE launch so boot-time milestones (state 3 fires ~0.5s
+    // in) are guaranteed to land after it.
     try {
       funasrLogOffset = fs.statSync(funasrAppLogPath()).size;
     } catch {
       funasrLogOffset = 0; // first boot on this machine — no log yet
     }
     // [20260912_Test_WinPackagedBootFunasrSettle] END
+    ({ app: electronApp, window } = await launchElectronApp());
     window.on("console", (msg) => {
       if (msg.type() === "error") consoleErrors.push(msg.text());
     });
@@ -212,23 +229,29 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
     }
   });
 
-  // 0.2b — [20260912_Test_WinPackagedBootFunasrSettle] wait for the
-  // FunASR Python server's first-boot init result before the reload /
-  // evaluate probes below. On Windows release CI the interpreter+funasr
-  // import storm (~5s on the 4-core runner) overlaps tests 0.3-0.6 and
-  // the app received a mid-probe teardown 4/4 sub-runs (run
-  // 34581815142). Web-first poll (R1) on the app.log milestone — no
-  // fixed waitForTimeout (§8). Both terminal outcomes satisfy the wait:
-  // models present ("启动成功") or models absent ("初始化失败" —
-  // models_not_downloaded, the expected CI state).
+  // 0.2b — [20260912_Test_WinPackagedBootFunasrSettle] wait for FunASR
+  // to reach ANY terminal first-boot state before the reload / evaluate
+  // probes below. On Windows release CI the interpreter+funasr import
+  // storm (~5s on the 4-core runner) overlaps tests 0.3-0.6 and the app
+  // received a mid-probe teardown 4/4 sub-runs (run 34581815142).
+  // Web-first poll (R1) on the app.log milestone — no fixed
+  // waitForTimeout (§8). Terminal states (see tag above): server init
+  // success, server init failure (models_not_downloaded — the expected
+  // release-CI state), or FunASR unavailable (python env missing — the
+  // PR-CI state; no server ever spawns, so the wait resolves on the
+  // first poll).
   test("0.2b FunASR first-boot init settles before renderer probes", async () => {
     const logPath = funasrAppLogPath();
     await expect
       .poll(
         () => {
           try {
+            const content = fs.readFileSync(logPath, "utf8");
+            // Clamp: if boot rotated/recreated the log (cleanOldLogs
+            // deletes >7d files), the pre-launch offset can exceed the
+            // new file's length — scan the whole fresh file instead.
             return FUNASR_INIT_MILESTONE.test(
-              fs.readFileSync(logPath, "utf8").slice(funasrLogOffset),
+              content.slice(Math.min(funasrLogOffset, content.length)),
             );
           } catch {
             return false; // app.log not created yet


### PR DESCRIPTION
## 概要

修复 v1.5.1 release 构建（run 34581815142）`build-win` 打包启动 smoke 的稳定失败（4/4 子运行复现），解除发布阻塞。

## 根因（非产品代码回归）

失败的 boot-health e2e 是 v1.5.0→v1.5.1 之间新增的 release gate（7d166b3, Spec #266 T11），首次接触 Windows 打包应用即败，两个叠加原因：

1. **测试 0.6「Execution context destroyed」（3/4）**：4 核 Windows runner 上 FunASR 自检需 ~20s，Python 服务进程的启动风暴（解释器 + funasr import）恰好落在 0.3–0.6 探针窗口内，Playwright↔app 的 inspector 会话中断，应用在 0.5 reload 后收到 teardown（will-quit, exit 0）。日志时序 4/4 一致：spawn → 1.1~2.4s 后 will-quit。所有应用内部退出路径（托盘/关闭按钮/更新器）均被日志排除；Python 退出被证明是 will-quit 的下游而非原因。
2. **测试 0.7 退出超时（1/4，结构性）**：will-quit 的「exit」命令要等服务端 ~4.7s import 完才会被读取，加上 Windows 打包进程 teardown 实测 ~5s，总计 6.538s > 6s 预算。

## 修复（仅测试基座，+102/−5，tag 20260912_Test_WinPackagedBootFunasrSettle / WinPackagedQuitBudget）

1. 新增串行测试 0.2b：`expect.poll`（30s/500ms）等待 app.log 中 FunASR 首次初始化里程碑（`启动成功|初始化失败`，复用 release smoke 既有日志契约，byte offset 防前序实例误判）——把 CPU 风暴移到脆弱探针之前，并让 python 停在 readline 使 0.7 的退出命令即时响应
2. 退出预算平台化：`win32 ? 15s : 6s`（5s will-quit race + ~5s 实测 win32 teardown + 余量）

## 验证

- `pnpm lint` 0 警告；`pnpm typecheck` + `typecheck:tests` 干净；`pnpm vitest run` 170 文件 2370 测试全绿
- 打包版 Windows e2e 本身只能在 release runner 上跑——合并后重打 v1.5.1 tag 即为真实验证

## 残余风险

0.2b 沉降等待基于 4/4 的风暴碰撞相关性；若下次 release 仍在 0.6 失败，说明触发源另有所在，届时 0.2b 通过后能拿到 trace.zip/error-context 精确定位。附发现（另开票）：`funasrServer.initializationPromise` 成功初始化后未置空，无模型机器上 `is_initializing` 永远为 true。
