### PR TITLE
fix: macOS 打包 EMFILE — 提升 DMG 步骤 fd 软限制

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,15 @@ jobs:
         run: pnpm run build:renderer
 
       - name: Build macOS DMG
-        run: pnpm electron-builder --mac --publish never
+        # [20260912_Fix_MacPackagingEMFILE] electron-builder unpacks the
+        # embedded-python tree (torch ships tens of thousands of headers)
+        # with one open fd per file; the default 256 soft limit on macOS
+        # runners made the DMG step die with EMFILE 2/2 in run 34631944103.
+        # Raise the soft fd limit for the packaging process only.
+        run: |
+          ulimit -n 65536 || true
+          pnpm electron-builder --mac --publish never
+        # [20260912_Fix_MacPackagingEMFILE] END
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

v1.5.1 release 构建 34631944103 的 build-mac 连续两次（含一次重跑）在 Build macOS DMG 步骤失败：`EMFILE: too many open files`（electron-builder 解包嵌入式 Python 的 torch 头文件树，数万文件各占一个 fd，macOS runner 默认软限制 256）。同代码在构建 34581815142 曾通过——runner 间软限制差异导致的概率性失败，属于环境问题。

## 修复

DMG 打包步骤前 `ulimit -n 65536`（仅作用于该步骤进程）。tag `20260912_Fix_MacPackagingEMFILE`。

合并后将重打 v1.5.1 tag 重新发布（前两次构建中 test/build-win 均已绿，含 PR #347 的 boot-health 时序加固实测通过）。