### PR TITLE
fix: fd 软限制对齐硬限制 + 诊断输出（macOS EMFILE 第二轮）

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,10 +134,17 @@ jobs:
         # [20260912_Fix_MacPackagingEMFILE] electron-builder unpacks the
         # embedded-python tree (torch ships tens of thousands of headers)
         # with one open fd per file; the default 256 soft limit on macOS
-        # runners made the DMG step die with EMFILE 2/2 in run 34631944103.
-        # Raise the soft fd limit for the packaging process only.
+        # runners made the DMG step die with EMFILE 2/2 in run 34631944103
+        # and again in 34636557974 where `ulimit -n 65536 || true` silently
+        # failed (soft > hard is rejected; || true swallowed it). Set soft
+        # to the runner's hard limit (capped at 65536), fall back to 10240,
+        # and LOG the effective value so the next failure is diagnosable.
         run: |
-          ulimit -n 65536 || true
+          HARD=$(ulimit -Hn)
+          echo "fd hard limit: $HARD, soft before: $(ulimit -Sn)"
+          if [ "$HARD" = "unlimited" ]; then TARGET=65536; elif [ "$HARD" -gt 65536 ]; then TARGET=65536; else TARGET=$HARD; fi
+          ulimit -n "$TARGET" || ulimit -n 10240 || true
+          echo "fd soft limit effective: $(ulimit -Sn)"
           pnpm electron-builder --mac --publish never
         # [20260912_Fix_MacPackagingEMFILE] END
         env:


### PR DESCRIPTION
## 概要

PR #348 的 `ulimit -n 65536 || true` 在 release 构建 34636557974 中依然 EMFILE——软限制设超过硬限制会被内核拒绝，`|| true` 吞掉错误后软限制仍是 256。

## 修复

软限制设为硬限制（上限 65536），失败回退 10240，并**输出实际生效值**——下次再失败可直接从日志判断是限制没提上去还是另有原因。

## Plan B（本 PR 不做）

若 runner 硬限制本身极低导致 EMFILE 依旧：从打包内容排除 `python/**/include/**` 编译期头文件（torch include 约上万文件，运行时不需要），既根治 EMFILE 又显著缩小 dmg 体积——需单独验证后实施。