### PR TITLE
fix: 打包排除 python include 编译期头文件 — 根治 macOS EMFILE

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
       "!node_modules/.cache/**/*",
       "!src/node_modules/**/*",
       "!python/**/*.pyc",
-      "!python/**/__pycache__/**/*"
+      "!python/**/__pycache__/**/*",
+      "!python/**/include/**/*"
     ],
     "asarUnpack": [
       "funasr_server.py",


### PR DESCRIPTION
## 概要

release 构建 34639017318 证实：fd 软限制已成功提升到 65536（日志：hard=unlimited, effective=65536）但 DMG 步骤**依然 EMFILE**——fd 限制不是根因，electron-builder 解包 `app.asar.unpacked/python`（约 2.8 万文件）时的并发 fd 占用另有放大机制。

## 修复（Plan B，tag 20260912_Fix_MacPackagingEMFILE，JSON 不支持注释故说明在此）

`build.files` 增加 `!python/**/include/**/*`：排除编译期 C/C++ 头文件（torch/include 8334 文件 46MB、numpy core/include 等），运行时全部不需要（funasr 仅走 torch Python API，无 cpp_extension JIT 编译），纯推理负载无影响。

## 验证

- 收益：包内 python 文件数减少约 30%（8334+/2.8万），dmg 体积同步缩小 ~46MB+
- 安全网：同 job 的 mac 打包启动 smoke（gate #4）会以修剪后的产物实跑启动探针，缺失文件类回归会当场拦截

## 历程

1. PR #348 ulimit 65536 → 静默超硬限失败，仍 256
2. PR #349 对齐硬限制+诊断输出 → 确认 65536 生效仍 EMFILE（fd 非根因）
3. 本 PR 减文件数 → 根治