### PR TITLE
test: 退出预算 darwin 对齐 15s（mac 打包 boot-health 0.7）

### DIFF
--- a/tests/e2e/suites/00-boot-health.test.ts
+++ b/tests/e2e/suites/00-boot-health.test.ts
@@ -127,12 +127,15 @@ function funasrAppLogPath(): string {
 
 // [20260912_Test_WinPackagedQuitBudget] Quit budget for test 0.7. The
 // will-quit handler races FunASR gracefulShutdown at 5s
-// (main.ts:397-400); Windows packaged teardown then measured ~3-5s more
-// until Playwright's 'close' fires (run 34581815142: app.exit → process
-// exit 4.7s; total close 6.5s vs the old flat 6s budget). darwin keeps
-// the original 6s (teardown <1s there); win32 gets 15s = 5s race +
-// ~5s teardown + slack.
-const QUIT_BUDGET_MS = process.platform === "win32" ? 15_000 : 6_000;
+// (main.ts:397-400); packaged teardown then measured ~3-5s more on
+// Windows (run 34581815142: total close 6.5s vs the old flat 6s
+// budget). [20260912_Test_MacPackagedQuitBudget] With the 0.2b settle
+// in place the FunASR server is fully booted at quit time, so darwin
+// now pays the real gracefulShutdown + torch-interpreter teardown too:
+// run 34641412843 measured 10.8s and 11.3s vs the old darwin 6s
+// budget. The assertion exists to catch quit HANGS, not to time the
+// shutdown — 15s both platforms (5s race + ~6s teardown + slack).
+const QUIT_BUDGET_MS = 15_000;
 // [20260912_Test_WinPackagedQuitBudget] END
 
 test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {


### PR DESCRIPTION
## 概要

release 构建 34641412843：**EMFILE 已根治**（PR #350 排除 include 头文件后 DMG 步骤通过、签名门禁通过），build-mac 推进到 boot-health e2e 后挂在 0.7——退出耗时实测 10.8s/11.3s > darwin 6s 预算（2/2 一致）。

## 原因

PR #347 的 0.2b 沉降让 FunASR 服务在退出前已完全启动，darwin 现在也要付真实的 gracefulShutdown（5s race）+ torch 解释器 teardown；此前 6s 预算只在「退出时 python 还在 boot」的世界里成立。该断言本意是捕捉退出**挂死**而非给关闭计时。

## 修复

`QUIT_BUDGET_MS` 双平台统一 15s（tag 20260912_Test_MacPackagedQuitBudget，说明并入既有注释）。lint / typecheck:tests 通过。