### PR TITLE
test: mac 打包 boot-health 预算对齐冷 torch 导入现实（解除 v1.5.1 发布阻塞 build-mac）

### DIFF
--- a/tests/e2e/suites/00-boot-health.test.ts
+++ b/tests/e2e/suites/00-boot-health.test.ts
@@ -99,7 +99,8 @@ const BOOT_PROBES = {
 // (logManager.ts:72-103 routes every level to the file). The server
 // milestones are the same app.log contract the release smoke gates on
 // (see funasrManager.ts [20260818_T3_PythonSelfCheckMilestone]).
-const FUNASR_INIT_SETTLE_TIMEOUT_MS = 30_000;
+// Budget note: the settle timeout value is platform-scaled — see
+// [20260912_Test_MacPackagedBootSettleBudget] below.
 const FUNASR_INIT_SETTLE_POLL_MS = 500;
 const FUNASR_INIT_MILESTONE =
   /FunASR服务器(启动成功|初始化失败)|FunASR启动初始化失败/;
@@ -138,11 +139,38 @@ function funasrAppLogPath(): string {
 const QUIT_BUDGET_MS = 15_000;
 // [20260912_Test_WinPackagedQuitBudget] END
 
+// [20260912_Test_MacPackagedBootSettleBudget] Release run 34644372201
+// (build-mac) failed 0.2b: on the 3-core mac release runner the FunASR
+// python cold boot measured 56.4s from spawn to init milestone
+// (20:39:04.48 → 20:40:00.90) — 7x the warm run's 8.0s (run
+// 34641412843) and consistent with the smoke step's documented >180s
+// fully-cold torch import ([20260905_Fix_150SmokeColdCache], the reason
+// the mac smoke budgets 360s for the same milestone family). The flat
+// 30s settle budget was structurally unfit for that runner. darwin gets
+// 300s — a ceiling, not an expectation: warm boots settle in ~8s, PR CI
+// (env-unavailable milestone) on the first poll, and a genuinely
+// wedged python still fails the suite, just later. win32 keeps 30s
+// (python boot measured 5-6s in both v1.5.1 release attempts).
+const FUNASR_INIT_SETTLE_TIMEOUT_MS =
+  process.platform === "darwin" ? 300_000 : 30_000;
+
+// Suite per-test ceiling, same root cause: 0.2's check-funasr-status
+// probe pays a cold `import funasr` per STATUS call on the mac runner
+// (78s measured in attempt 1 of run 34644372201 against the old 90s
+// ceiling). darwin 360s aligns with the mac smoke budget; win32 keeps
+// 90s. A real hang still fails the test — the budget shapes WHEN, not
+// WHETHER.
+const BOOT_TEST_TIMEOUT_MS = process.platform === "darwin" ? 360_000 : 90_000;
+// [20260912_Test_MacPackagedBootSettleBudget] END
+
 test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
   // [20260906_Test_PackagedBootHealth] Spec #266 T11: in packaged-app runs
   // (release workflow) first boot pays cold asar/entitlements cost; the
   // config default 45s would mask the real launch timeout of 60s.
-  test.setTimeout(90_000);
+  // [20260912_Test_MacPackagedBootSettleBudget] Value platform-scaled —
+  // see tag above (darwin 360s for the mac runner's cold torch import,
+  // win32 stays 90s).
+  test.setTimeout(BOOT_TEST_TIMEOUT_MS);
 
   let electronApp;
   let window;
@@ -155,6 +183,15 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
   // fires DURING boot — potentially before launchElectronApp() returns.
   let funasrLogOffset = 0;
   // [20260912_Test_WinPackagedBootFunasrSettle] END
+  // [20260912_Test_MacPackagedBootSettleBudget] Set when the packaged
+  // app process terminates (Playwright 'close' event). 0.2b polls
+  // app.log for up to 300s on darwin; if the app dies mid-wait (the
+  // clean will-quit/exit 0 teardown seen in runs 34581815142 and
+  // 34644372201) the poll must fail fast with a precise cause instead
+  // of timing out opaquely. Test 0.7's intentional close also sets it,
+  // but no poll is active by then.
+  let appTerminated = false;
+  // [20260912_Test_MacPackagedBootSettleBudget] END
   // [20260725_E2E_BootHealthGate_CodeReviewS2] Renderer console listener
   // is attached in beforeAll IMMEDIATELY after firstWindow() resolves so
   // it catches initial-mount errors, not just post-reload ones. Previously
@@ -175,6 +212,12 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
     }
     // [20260912_Test_WinPackagedBootFunasrSettle] END
     ({ app: electronApp, window } = await launchElectronApp());
+    // [20260912_Test_MacPackagedBootSettleBudget] Track process
+    // termination so 0.2b's poll can fail fast (see declaration above).
+    electronApp.on("close", () => {
+      appTerminated = true;
+    });
+    // [20260912_Test_MacPackagedBootSettleBudget] END
     window.on("console", (msg) => {
       if (msg.type() === "error") consoleErrors.push(msg.text());
     });
@@ -242,12 +285,24 @@ test.describe.serial("Suite 0: Boot Health (Phase A-E)", () => {
   // success, server init failure (models_not_downloaded — the expected
   // release-CI state), or FunASR unavailable (python env missing — the
   // PR-CI state; no server ever spawns, so the wait resolves on the
-  // first poll).
+  // first poll). [20260912_Test_MacPackagedBootSettleBudget] The poll
+  // budget is 300s on darwin (cold torch import measured 56s, worst
+  // documented >180s) and the predicate fails fast if the app process
+  // terminates mid-wait — a dead app means the teardown recurred, not a
+  // slow boot.
   test("0.2b FunASR first-boot init settles before renderer probes", async () => {
     const logPath = funasrAppLogPath();
     await expect
       .poll(
         () => {
+          if (appTerminated) {
+            throw new Error(
+              "packaged app terminated while waiting for the FunASR init " +
+                "milestone — clean will-quit/exit 0 teardown (Playwright-side " +
+                "graceful close under runner load), not a slow python boot; " +
+                "see [20260912_Test_MacPackagedBootSettleBudget]",
+            );
+          }
           try {
             const content = fs.readFileSync(logPath, "utf8");
             // Clamp: if boot rotated/recreated the log (cleanOldLogs


### PR DESCRIPTION
## 背景

发布 run [34644372201](https://github.com/TeFuirnever/Murmur/actions/runs/34644372201) (tag v1.5.1) build-mac ❌ 于 "Boot-health e2e probes against packaged app (mac)"，两处失败：

1. **0.2b 沉降等待 30.2s 超时** — FunASR init 里程碑 30s 内未出现在 app.log。
2. **0.2 IPC 探针失败** — "check-funasr-status did not resolve (1.5m)"，随后 "Target page, context or browser has been closed"。

对照：build-win ✅（#347 的 Windows 加固已连续 3 次通过）；run 34641412843 中 mac 0.2b 曾以 8.1s 通过。

## 根因（日志证据）

**不是模型下载**：两个大下载（node 191.9MB / 嵌入式 python 缓存 236.7MB，~46MB/s）发生在 job 起步的 20:29:59–20:30:28，远在 boot-health (20:37–20:45) 之前；mac 发布 runner 的模型缓存为空，打包应用按预期走 `models_not_downloaded` 路径，**测试期间没有任何 modelscope 下载**。

真实根因是 **mac runner（3 逻辑核）的冷 torch 导入耗时**：

| 指标 | 暖机 run 34641412843 | 冷/忙 run 34644372201 |
|---|---|---|
| FunASR 安装自检 | ~27s | **71s** |
| python spawn→init 里程碑 | 8.0s | **56.4s** |
| 0.2 IPC 探针 | 快 | **78s**（逼近 90s 上限） |
| electron.launch | 1.4s | 38s（retry） |

smoke 步骤注释（`[20260905_Fix_150SmokeColdCache]`）文档化全冷 `import funasr` 曾超过 180s——mac smoke 因此给同族里程碑 **360s** 预算。0.2b 的扁平 30s 与套件 90s 上限对该 runner 结构性不足。

此外该 run 应用再次于等待期间收到干净的 `app.quit()`（`Debugger ending → 清理发送者 → will-quit → exit 0`，与 Windows 4/4 完全同签名；唯一无日志的 quit 来源是 Playwright Electron 自定义关闭处理器 `evaluate(({app}) => app.quit())`，由 exit watchdog → `gracefullyCloseAll()` 触发）——非应用代码缺陷。

## 改动（仅 `tests/e2e/suites/00-boot-health.test.ts`，tag `20260912_Test_MacPackagedBootSettleBudget`）

- `FUNASR_INIT_SETTLE_TIMEOUT_MS` 平台缩放：**darwin 300s / win32 30s**（暖机 ~8s 即沉降，预算只是上限；真挂死照样失败，只是更晚——不削弱挂死检测）。
- 套件单测上限平台缩放：**darwin 360s / win32 90s**（与 mac smoke 的 360s 对齐；0.2 探针每次 STATUS 调用都要支付一次冷 `import funasr`）。
- 0.2b 轮询新增**应用终止快速失败**：等待期间进程退出（`close` 事件）立即以精确原因失败，替代盲等超时。

## 验证

- `pnpm lint` ✅ `pnpm typecheck` ✅ `pnpm typecheck:tests` ✅ `pnpm vitest run` ✅（170 文件 / 2370 测试全过）
- PR CI 将覆盖双平台 dev 模式 boot-health（PR 环境无嵌入式 python → 0.2b 走 env-unavailable 里程碑首轮即过）。

## 残留风险

Playwright 侧优雅关闭（app 收到 mid-suite app.quit）的精确触发条件（stdin close / 信号）未从留存日志完全证实；若再次发生，0.2b 现在会以明确错误快速失败而非盲等 30s，下游测试仍会给出 "Target closed" 归因。