### PR TITLE
feat: 录音自动路径 INSERT→UPDATE 重排 — 转写即落盘 + T2 守卫润色写回 (Spec #193 T9②, closes #322)

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -121,8 +121,14 @@ export const preloadApi: ElectronAPI = {
     ipcRenderer.invoke(C.TRANSCRIPTION.DELETE, id),
   // [20260906_Feat_TranscriptionUpdate] Manual polish write-back (spec #193
   // T1, ticket #228): persist polished text into the saved record.
-  updateTranscription: (id: number, patch: Record<string, unknown>) =>
-    ipcRenderer.invoke(C.TRANSCRIPTION.UPDATE, id, patch),
+  // [20260912_Fix_322_AutoUpdateGuard] Ticket #322: options (the T2
+  // skipWhenManuallyEdited seam) ride the UPDATE channel so the auto-polish
+  // write-back can never clobber a manually edited record.
+  updateTranscription: (
+    id: number,
+    patch: Record<string, unknown>,
+    options?: { skipWhenManuallyEdited?: boolean },
+  ) => ipcRenderer.invoke(C.TRANSCRIPTION.UPDATE, id, patch, options),
   clearAllTranscriptions: () => ipcRenderer.invoke(C.TRANSCRIPTION.CLEAR),
   diarizeAudio: (id: number) => ipcRenderer.invoke(C.TRANSCRIPTION.DIARIZE, id),
 

--- a/src/electronAPI.d.ts
+++ b/src/electronAPI.d.ts
@@ -118,6 +118,13 @@ export interface ElectronAPI {
     confidence?: number;
     duration?: number;
     audio_format?: string;
+    // [20260912_TypeContract_SaveTranscriptionPayload] Ticket #322: language
+    // and file_size ride the SAVE channel from the recording auto-path
+    // INSERT (useRecording.ts) and the main-process handler persists them —
+    // declared here so the payload passes typecheck without casts (contract
+    // test: preload-bridge-contract.test.ts).
+    language?: string;
+    file_size?: number;
   }) => Promise<TranscriptionSaveResult>;
   getTranscriptions: (
     limit: number,
@@ -137,6 +144,10 @@ export interface ElectronAPI {
       text?: string;
       manually_edited?: boolean;
     },
+    // [20260912_Fix_322_AutoUpdateGuard] Ticket #322: the auto-polish
+    // write-back passes the T2 manual-edit guard; omitted (undefined) by
+    // the user-triggered polish/edit path, which stays unrestricted.
+    options?: { skipWhenManuallyEdited?: boolean },
   ) => Promise<TranscriptionUpdateResult>;
   diarizeAudio: (id: number) => Promise<{
     success: boolean;

--- a/src/helpers/ipc/transcriptionHandlers.ts
+++ b/src/helpers/ipc/transcriptionHandlers.ts
@@ -105,11 +105,16 @@ interface DatabaseManager {
   clearAllTranscriptions(): unknown;
   // [20260906_Feat_TranscriptionUpdate] Manual polish write-back
   // (spec #193 T1, ticket #228). Column whitelisting lives in the DB layer.
+  // [20260912_Fix_322_AutoUpdateGuard] Ticket #322: the T2 manual-edit
+  // guard option passes through, and a guarded skip comes back as a
+  // success no-op carrying `skipped`.
   updateTranscription(
     id: number,
     patch: Record<string, unknown>,
+    options?: { skipWhenManuallyEdited?: boolean },
   ): {
     changes?: number;
+    skipped?: boolean;
   };
 }
 
@@ -540,13 +545,33 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   // caller can observe the persisted mark.
   ipcMain.handle(
     C.TRANSCRIPTION.UPDATE,
-    (_event, id: number, patch: Record<string, unknown>) => {
+    (
+      _event,
+      id: number,
+      patch: Record<string, unknown>,
+      options?: { skipWhenManuallyEdited?: boolean },
+    ) => {
       try {
         const row = databaseManager.getTranscriptionById(id);
         if (!row) {
           return { success: false, error: "转录记录不存在" };
         }
-        const result = databaseManager.updateTranscription(id, patch);
+        // [20260912_Fix_322_AutoUpdateGuard] Ticket #322: the end-of-recording
+        // auto-polish write-back now rides this channel, so caller options
+        // (the T2 skipWhenManuallyEdited seam) must reach the DB-layer guard.
+        const result = databaseManager.updateTranscription(id, patch, options);
+        // [20260912_Fix_322_AutoUpdateGuard] A skipped guard outcome is a
+        // success no-op (the user's manual edit won), NOT a missing row —
+        // report skipped + the refreshed flag so the renderer can fall back
+        // to the raw text instead of treating it as an error.
+        if (result?.skipped) {
+          const current = databaseManager.getTranscriptionById(id);
+          return {
+            success: true,
+            skipped: true,
+            manually_edited: current?.manually_edited,
+          };
+        }
         // [20260906_Feat_TranscriptionUpdate_Review] A row deleted between
         // update and re-read must not report success with undefined fields.
         if (!result || result.changes === 0) {

--- a/src/hooks/useRecording.ts
+++ b/src/hooks/useRecording.ts
@@ -207,7 +207,10 @@ export const useRecording = ({
           const raw_text = transcriptionResult.text || "";
 
           // 准备转录数据
-          const transcriptionData: Record<string, unknown> = {
+          // [20260912_Refactor_322_InsertUpdateFlow] Typed by inference (not
+          // Record<string, unknown>) so the payload satisfies the declared
+          // saveTranscription contract without a cast.
+          const transcriptionData = {
             // [20260819_T10_CleanerWiring] DB raw_text keeps the PRE-CLEAN
             // ASR text when the main-process cleaner changed anything
             // (recoverable original); AI polish below still uses the
@@ -220,6 +223,36 @@ export const useRecording = ({
             file_size: uint8Array.length,
           };
 
+          // [20260912_Refactor_322_InsertUpdateFlow] Ticket #322: persist the
+          // raw record IMMEDIATELY at transcription completion (crash-safe:
+          // the raw text survives even if the polish step dies or the app
+          // closes mid-polish). The polished columns are written back later
+          // through the T1 updateTranscription channel — the renderer never
+          // INSERTs a second time.
+          const savedResult =
+            await window.electronAPI.saveTranscription(transcriptionData);
+          // [20260912_Fix_322_AutoUpdateGuard] The SAVE handler never
+          // rejects — failures arrive as {success:false}. Surface them so an
+          // unsavable transcription is not silently shown as persisted,
+          // while keeping the transcription itself usable.
+          if (savedResult?.success) {
+            if (window.electronAPI && window.electronAPI.log) {
+              window.electronAPI.log("info", "转录数据保存成功:", savedResult);
+            }
+          } else {
+            if (window.electronAPI && window.electronAPI.log) {
+              window.electronAPI.log("error", "转录数据保存失败:", savedResult);
+            }
+            setError("转录保存失败: " + (savedResult?.error || "未知错误"));
+          }
+          let savedId: number | null = null;
+          if (savedResult?.lastInsertRowid) {
+            savedId = savedResult.lastInsertRowid;
+            if (onSaveCompleteRef.current) {
+              onSaveCompleteRef.current({ id: savedId });
+            }
+          }
+
           // 立即显示初步结果
           if (onTranscriptionCompleteRef.current) {
             onTranscriptionCompleteRef.current({
@@ -228,7 +261,10 @@ export const useRecording = ({
             });
           }
 
-          // 异步处理AI优化和保存（只保存一次）
+          // [20260912_Refactor_322_InsertUpdateFlow] The deferred chain is
+          // now strictly polish-side: read settings → polish → UPDATE the
+          // row INSERTed above via the T1 channel → notify. Persistence of
+          // the raw text no longer waits on this chain.
           setIsOptimizing(true);
           optimizationTimeoutRef.current = setTimeout(async () => {
             if (cancelledRef.current) return;
@@ -248,10 +284,9 @@ export const useRecording = ({
                 defaultMode = useAI ? "auto" : "off";
               }
 
-              const finalData: Record<string, unknown> = {
-                ...transcriptionData,
-              };
-
+              // Polish: produce the result only — persistence goes through
+              // the UPDATE below.
+              let processedText: string | undefined;
               if (defaultMode !== "off") {
                 try {
                   if (window.electronAPI && window.electronAPI.log) {
@@ -266,31 +301,22 @@ export const useRecording = ({
                     defaultMode === "auto" || !defaultMode
                       ? determineProcessingMode(raw_text)
                       : defaultMode;
-                  // [20260908_Fix_BatchReview_M2] T9④ completion: the 60s
-                  // renderer race is removed — the orchestrator's deadline
-                  // matrix (first-delta/idle/total) owns timeout semantics.
-                  // (This removal was lost when the earlier INSERT→UPDATE
-                  // restructure was reverted wholesale.)
+                  // [20260908_Fix_BatchReview_M2] T9④ completion: the
+                  // orchestrator's deadline matrix (first-delta/idle/total)
+                  // owns timeout semantics; the renderer has no race of its
+                  // own.
                   const result = (await window.electronAPI.processText(
                     raw_text,
                     mode,
                   )) as import("../types/ipc").AIProcessResult;
 
                   if (result && result.success) {
-                    const processed_text = result.text;
-                    finalData.processed_text = processed_text;
-                    // 如果AI优化后的文本与原始文本不同，则将优化后的文本作为主文本
-                    if (
-                      processed_text &&
-                      processed_text.trim() !== raw_text.trim()
-                    ) {
-                      finalData.text = processed_text;
-                    }
+                    processedText = result.text;
                     if (window.electronAPI && window.electronAPI.log) {
                       window.electronAPI.log(
                         "info",
                         "AI文本优化成功",
-                        (processed_text ?? "").substring(0, 50) + "...",
+                        (processedText ?? "").substring(0, 50) + "...",
                       );
                     }
                   } else {
@@ -313,57 +339,87 @@ export const useRecording = ({
                 }
               }
 
-              // 保存转录数据（只保存一次）
-              if (window.electronAPI) {
-                if (window.electronAPI && window.electronAPI.log) {
-                  window.electronAPI.log(
-                    "info",
-                    "准备保存转录数据:",
-                    finalData,
-                  );
+              // [20260912_Fix_322_AutoUpdateGuard] updateRecord: write the
+              // polished columns back to the row INSERTed at transcription
+              // completion, guarded by the T2 manual-edit seam — a record
+              // the user edited during the polish window is never
+              // overwritten (the handler reports a skipped success no-op).
+              // The write-back outcome gates the enhanced notify so the
+              // panel text always mirrors the DB row.
+              let writeBackApplied = false;
+              if (savedId !== null && processedText) {
+                const patch: {
+                  processed_text?: string;
+                  text?: string;
+                } = { processed_text: processedText };
+                if (processedText.trim() !== raw_text.trim()) {
+                  patch.text = processedText;
                 }
-                const savedResult = await window.electronAPI.saveTranscription(
-                  finalData as any,
-                );
-                if (savedResult?.lastInsertRowid && onSaveCompleteRef.current) {
-                  onSaveCompleteRef.current({
-                    id: savedResult.lastInsertRowid,
+                const updateResult =
+                  await window.electronAPI.updateTranscription(savedId, patch, {
+                    skipWhenManuallyEdited: true,
                   });
-                }
-                if (window.electronAPI && window.electronAPI.log) {
-                  window.electronAPI.log(
-                    "info",
-                    "转录数据保存成功:",
-                    savedResult,
-                  );
-                }
-
-                // 通知UI更新并触发复制操作
-                if (
-                  defaultMode !== "off" &&
-                  finalData.processed_text &&
-                  finalData.processed_text !== raw_text
-                ) {
-                  // 有AI优化结果时
-                  const enhancedResult = {
-                    ...transcriptionResult,
-                    text: finalData.processed_text,
-                    processed_text: finalData.processed_text,
-                    enhanced_by_ai: true,
-                  };
-                  if (onAIOptimizationCompleteRef.current) {
-                    onAIOptimizationCompleteRef.current(enhancedResult);
+                if (updateResult?.skipped) {
+                  if (window.electronAPI && window.electronAPI.log) {
+                    window.electronAPI.log(
+                      "info",
+                      "润色写回已跳过（记录已被手动编辑）:",
+                      updateResult,
+                    );
+                  }
+                } else if (updateResult?.success) {
+                  writeBackApplied = true;
+                  if (window.electronAPI && window.electronAPI.log) {
+                    window.electronAPI.log("info", "润色结果已写回:", patch);
                   }
                 } else {
-                  // 没有AI优化或AI优化失败时，使用原始文本
-                  const finalResult = {
-                    ...transcriptionResult,
-                    text: raw_text,
-                    enhanced_by_ai: false,
-                  };
-                  if (onAIOptimizationCompleteRef.current) {
-                    onAIOptimizationCompleteRef.current(finalResult);
+                  if (window.electronAPI && window.electronAPI.log) {
+                    window.electronAPI.log(
+                      "error",
+                      "润色结果写回失败:",
+                      updateResult,
+                    );
                   }
+                }
+              } else if (savedId === null && processedText) {
+                // No row id from the INSERT: nothing to write back to —
+                // log so the lost polish is diagnosable.
+                if (window.electronAPI && window.electronAPI.log) {
+                  window.electronAPI.log(
+                    "error",
+                    "润色结果未持久化（无记录 id）:",
+                    processedText.substring(0, 50) + "...",
+                  );
+                }
+              }
+
+              // 通知UI更新并触发复制操作 — the enhanced branch requires an
+              // applied write-back so the panel text mirrors the DB row.
+              if (
+                defaultMode !== "off" &&
+                processedText &&
+                processedText !== raw_text &&
+                writeBackApplied
+              ) {
+                // 有AI优化结果时
+                const enhancedResult = {
+                  ...transcriptionResult,
+                  text: processedText,
+                  processed_text: processedText,
+                  enhanced_by_ai: true,
+                };
+                if (onAIOptimizationCompleteRef.current) {
+                  onAIOptimizationCompleteRef.current(enhancedResult);
+                }
+              } else {
+                // 没有AI优化或AI优化失败时，使用原始文本
+                const finalResult = {
+                  ...transcriptionResult,
+                  text: raw_text,
+                  enhanced_by_ai: false,
+                };
+                if (onAIOptimizationCompleteRef.current) {
+                  onAIOptimizationCompleteRef.current(finalResult);
                 }
               }
             } catch (err) {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -104,6 +104,10 @@ export interface TranscriptionUpdateResult {
   // refreshed record's manual-edit flag (SQLite INTEGER 0/1) echoed back so
   // the edit-save caller can observe the persisted mark.
   manually_edited?: number;
+  // [20260912_Fix_322_AutoUpdateGuard] Ticket #322: true when the T2
+  // skipWhenManuallyEdited guard skipped the write (a success no-op — the
+  // user's manual edit won); the auto path falls back to the raw text.
+  skipped?: boolean;
   error?: string;
 }
 

--- a/tests/unit/backend-type-safety.test.ts
+++ b/tests/unit/backend-type-safety.test.ts
@@ -92,10 +92,11 @@ describe("Project type safety — all .ts/.tsx/.d.ts follow standards", () => {
       pattern: "(window as any).webkitAudioContext",
       reason: "Legacy Safari/Chrome prefixed AudioContext — not in TS DOM lib",
     },
-    {
-      pattern: "finalData as any",
-      reason: "AudioWorklet port message shape — untyped at the boundary",
-    },
+    // [20260912_Refactor_322_InsertUpdateFlow] the `finalData as any` entry
+    // was removed — the INSERT payload is now typed by inference and
+    // satisfies the widened saveTranscription declaration (contract test:
+    // preload-bridge-contract.test.ts), so no cast remains in
+    // useRecording.ts.
     {
       pattern: "(import.meta as any).hot",
       reason:

--- a/tests/unit/preload-bridge-contract.test.ts
+++ b/tests/unit/preload-bridge-contract.test.ts
@@ -18,6 +18,9 @@
 // asserts typeof api[name] === "function" for every critical name. No `any`.
 // [20260726_TypeGate_PreloadBridgeContract] END
 import { describe, it, expect, vi, beforeEach } from "vitest";
+// [20260912_TypeContract_SaveTranscriptionPayload] Bridge type contract for
+// the saveTranscription payload (see the test at the bottom of this file).
+import type { ElectronAPI } from "../../src/electronAPI";
 
 // vi.mock factories are hoisted above all other code, so any variable they
 // close over must also be hoisted. vi.hoisted runs its callback before any
@@ -160,5 +163,27 @@ describe("preload bridge contract", () => {
       undefined,
       "req-42",
     );
+  });
+
+  // [20260912_TypeContract_SaveTranscriptionPayload] Ticket #322: the
+  // recording auto-path INSERT payload (useRecording.ts) must satisfy the
+  // DECLARED bridge type without casts — `language` and `file_size` travel
+  // the SAVE channel in production and belong in the contract. Enforcement
+  // is compile-time via the typecheck:tests gate (excess property checks
+  // reject object literals carrying keys missing from the declaration);
+  // the runtime assertion below merely anchors the test.
+  it("saveTranscription declares the full auto-path INSERT payload shape", () => {
+    type SaveTranscriptionPayload = Parameters<
+      ElectronAPI["saveTranscription"]
+    >[0];
+    const autoPathPayload: SaveTranscriptionPayload = {
+      text: "cleaned text",
+      raw_text: "original text",
+      confidence: 0.9,
+      language: "zh-CN",
+      duration: 1.5,
+      file_size: 1024,
+    };
+    expect(autoPathPayload.text).toBe("cleaned text");
   });
 });

--- a/tests/unit/transcriptionHandlers.test.ts
+++ b/tests/unit/transcriptionHandlers.test.ts
@@ -276,7 +276,13 @@ describe("transcriptionHandlers", () => {
 
       const patch = { processed_text: "润色后", text: "润色后" };
       const result = (await handler({}, 42, patch)) as HandlerResult;
-      expect(mockDb.updateTranscription).toHaveBeenCalledWith(42, patch);
+      // [20260912_Fix_322_AutoUpdateGuard] The handler forwards the (absent)
+      // options slot too — the auto path relies on this pass-through.
+      expect(mockDb.updateTranscription).toHaveBeenCalledWith(
+        42,
+        patch,
+        undefined,
+      );
       expect(result.success).toBe(true);
     });
 
@@ -323,6 +329,59 @@ describe("transcriptionHandlers", () => {
       expect(result.success).toBe(true);
       expect(result.manually_edited).toBe(1);
       expect(result.text).toBe("编辑后的文本");
+    });
+
+    // [20260912_Fix_322_AutoUpdateGuard] Ticket #322: the auto-polish
+    // write-back rides this channel, so caller options (the T2
+    // skipWhenManuallyEdited seam) MUST reach the DB-layer guard.
+    it("forwards the skipWhenManuallyEdited option to the DB layer", async () => {
+      const C = await setup();
+      const handler = registeredHandlers.get(C.TRANSCRIPTION.UPDATE)!;
+
+      const patch = { processed_text: "润色后", text: "润色后" };
+      await handler({}, 42, patch, { skipWhenManuallyEdited: true });
+      expect(mockDb.updateTranscription).toHaveBeenCalledWith(42, patch, {
+        skipWhenManuallyEdited: true,
+      });
+    });
+
+    // [20260912_Fix_322_AutoUpdateGuard] A skipped guard outcome is a
+    // success no-op (the user's manual edit won), NOT a missing row — the
+    // handler must report skipped + the refreshed flag instead of the
+    // 转录记录不存在 error the changes===0 path produces.
+    it("reports skipped (not missing-row) when the DB guard skips a manually-edited row", async () => {
+      mockDb.updateTranscription!.mockReturnValueOnce({
+        changes: 0,
+        lastInsertRowid: 0,
+        skipped: true,
+      });
+      mockDb.getTranscriptionById!.mockReturnValue({
+        id: 42,
+        text: "用户编辑的文本",
+        processed_text: "用户编辑的文本",
+        raw_text: "原始识别",
+        manually_edited: 1,
+      });
+      const C = await setup();
+      const handler = registeredHandlers.get(C.TRANSCRIPTION.UPDATE)!;
+
+      const result = (await handler(
+        {},
+        42,
+        { processed_text: "润色后" },
+        {
+          skipWhenManuallyEdited: true,
+        },
+      )) as {
+        success: boolean;
+        skipped?: boolean;
+        manually_edited?: number;
+        error?: string;
+      };
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      expect(result.manually_edited).toBe(1);
+      expect(result.error).toBeUndefined();
     });
   });
 

--- a/tests/unit/useRecording.test.tsx
+++ b/tests/unit/useRecording.test.tsx
@@ -20,6 +20,13 @@
 //   - Real timers: FileReader/Blob.arrayBuffer use microtasks that fake
 //     timers would break; each transcription test drains the 100ms
 //     optimization timeout (via isOptimizing===false) before asserting.
+//
+// [20260912_Refactor_322_InsertUpdateFlow] Ticket #322: the save flow is
+// INSERT → UPDATE. saveTranscription (INSERT with raw_text) fires
+// IMMEDIATELY at transcription completion; polished columns land via the
+// T1 updateTranscription channel after the orchestrator resolves. The
+// renderer must never save twice. Mock shapes therefore carry
+// lastInsertRowid on saveTranscription plus an updateTranscription mock.
 import "../setup/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
@@ -390,7 +397,10 @@ describe("[20260729_Test_UseRecording] useRecording — stopRecording", () => {
         duration: 1.5,
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 1 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -449,7 +459,10 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       }),
       // 'off' skips AI optimization so we don't wait on processText.
       getSetting: vi.fn().mockResolvedValue("off"),
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 2 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -496,7 +509,10 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
     setElectronAPI({
       transcribeAudio,
       getSetting: vi.fn().mockResolvedValue("off"),
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 3 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -528,6 +544,9 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       success: true,
       text: "你好，世界。",
     });
+    const updateTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, changes: 1 });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -538,7 +557,10 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       // 'auto' => determineProcessingMode picks the mode.
       getSetting: vi.fn().mockResolvedValue("auto"),
       processText,
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 42 }),
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -560,6 +582,18 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       expect.stringContaining("optimize"),
     );
 
+    // [20260912_Refactor_322_InsertUpdateFlow] The polish result lands via
+    // the T1 UPDATE channel against the INSERTed row, not a second INSERT.
+    await waitFor(() => expect(updateTranscription).toHaveBeenCalledTimes(1));
+    expect(updateTranscription).toHaveBeenCalledWith(
+      42,
+      {
+        processed_text: "你好，世界。",
+        text: "你好，世界。",
+      },
+      { skipWhenManuallyEdited: true },
+    );
+
     // The optimization timeout also flips isOptimizing true→false.
     await waitFor(() => expect(result.current.isOptimizing).toBe(false));
     expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1);
@@ -574,6 +608,9 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
     });
   });
 
+  // [20260912_Refactor_322_InsertUpdateFlow] The INSERT now fires at
+  // transcription completion, so onSaveComplete carries the row id before
+  // the polish timeout ever arms.
   it("fires onSaveComplete with the inserted row id after saving", async () => {
     const onSaveComplete = vi.fn();
     setElectronAPI({
@@ -588,6 +625,7 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
         success: true,
         lastInsertRowid: 42,
       }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -600,8 +638,8 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       result.current.stopRecording();
     });
 
-    // saveTranscription runs in the 100ms optimization timeout even when
-    // AI is off.
+    // The INSERT runs in processAudio right after transcription — long
+    // before the 100ms optimization timeout.
     await waitFor(() => expect(onSaveComplete).toHaveBeenCalledTimes(1));
     expect(onSaveComplete).toHaveBeenCalledWith({ id: 42 });
 
@@ -611,11 +649,12 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
   });
 
   // [20260906_Feat_ManualEditProtection] Spec #193 T2 (ticket #229) regres-
-  // sion lock on the end-of-recording auto-polish persist site: a FRESH
-  // (never-edited) recording is polished and saved exactly as today — the
-  // polished text lands in the saved payload and the auto path never sets
-  // the manually_edited flag (that flag belongs to the user's edit-save).
-  it("auto-polishes a fresh record: polished payload saved once, flag never set", async () => {
+  // sion lock on the end-of-recording auto-polish persist site.
+  // [20260912_Refactor_322_InsertUpdateFlow] Ticket #322 contract: the raw
+  // record is INSERTed exactly once at transcription completion; the polish
+  // lands via the T1 UPDATE channel; the auto path never sets the
+  // manually_edited flag (that flag belongs to the user's edit-save).
+  it("auto-polishes a fresh record: INSERT raw once, polish updated via UPDATE, flag never set", async () => {
     const processText = vi.fn().mockResolvedValue({
       success: true,
       text: "润色后的文本",
@@ -623,6 +662,9 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
     const saveTranscription = vi
       .fn()
       .mockResolvedValue({ success: true, lastInsertRowid: 7 });
+    const updateTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, changes: 1 });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -633,6 +675,7 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       getSetting: vi.fn().mockResolvedValue("auto"),
       processText,
       saveTranscription,
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -645,18 +688,100 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       result.current.stopRecording();
     });
 
-    await waitFor(() => expect(processText).toHaveBeenCalledTimes(1));
-    // Saved exactly once, after the polish, with both columns populated.
+    // INSERTed exactly once, before the polish, carrying only raw fields.
     await waitFor(() => expect(saveTranscription).toHaveBeenCalledTimes(1));
-    const payload = saveTranscription.mock.calls[0]![0] as Record<
+    const inserted = saveTranscription.mock.calls[0]![0] as Record<
       string,
       unknown
     >;
-    expect(payload.text).toBe("润色后的文本");
-    expect(payload.processed_text).toBe("润色后的文本");
-    expect(payload).not.toHaveProperty("manually_edited");
+    expect(inserted.text).toBe("原始识别文本");
+    expect(inserted).not.toHaveProperty("processed_text");
+    expect(inserted).not.toHaveProperty("manually_edited");
+
+    // The polish columns arrive via UPDATE against the INSERTed row id.
+    await waitFor(() => expect(updateTranscription).toHaveBeenCalledTimes(1));
+    expect(updateTranscription).toHaveBeenCalledWith(
+      7,
+      {
+        processed_text: "润色后的文本",
+        text: "润色后的文本",
+      },
+      { skipWhenManuallyEdited: true },
+    );
+    const patch = updateTranscription.mock.calls[0]![1] as Record<
+      string,
+      unknown
+    >;
+    expect(patch).not.toHaveProperty("manually_edited");
+    // No second save — the renderer never INSERTs twice.
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
 
     await waitFor(() => expect(result.current.isOptimizing).toBe(false));
+  });
+
+  // [20260912_Refactor_322_InsertUpdateFlow] The record must exist (raw_text
+  // persisted) the moment transcription completes — not one polish later —
+  // so a crash or slow AI call can no longer lose the transcription.
+  it("INSERTs the raw record immediately at transcription completion, before the polish timeout", async () => {
+    const onTranscriptionComplete = vi.fn();
+    const onSaveComplete = vi.fn();
+    const processText = vi
+      .fn()
+      .mockResolvedValue({ success: true, text: "润色结果" });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 9 });
+    setElectronAPI({
+      transcribeAudio: vi.fn().mockResolvedValue({
+        success: true,
+        text: "原始文本",
+        confidence: 0.9,
+        duration: 1.5,
+      }),
+      getSetting: vi.fn().mockResolvedValue("auto"),
+      processText,
+      saveTranscription,
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
+      log: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { result } = renderHook(() =>
+      useRecording({ onTranscriptionComplete, onSaveComplete }),
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    // The INSERT is NOT deferred to the 100ms optimization timeout: by the
+    // time the preliminary result is shown, the row already exists.
+    await waitFor(() =>
+      expect(onTranscriptionComplete).toHaveBeenCalledTimes(1),
+    );
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
+    const inserted = saveTranscription.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(inserted).toMatchObject({
+      raw_text: "原始文本",
+      text: "原始文本",
+      confidence: 0.9,
+      duration: 1.5,
+    });
+    expect(inserted).not.toHaveProperty("processed_text");
+    expect(onSaveComplete).toHaveBeenCalledWith({ id: 9 });
+
+    // Drain the polish chain, then prove ordering: the INSERT preceded the
+    // orchestrator call.
+    await waitFor(() => expect(result.current.isOptimizing).toBe(false));
+    expect(processText).toHaveBeenCalled();
+    expect(saveTranscription.mock.invocationCallOrder[0]!).toBeLessThan(
+      processText.mock.invocationCallOrder[0]!,
+    );
   });
 
   it("migrates legacy enable_ai_optimization setting when default_mode is null", async () => {
@@ -675,7 +800,10 @@ describe("[20260729_Test_UseRecording] useRecording — transcription flow", () 
       }),
       getSetting,
       processText,
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 4 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -792,7 +920,10 @@ describe("[20260729_Test_UseRecording] useRecording — cancelRecording", () => 
         duration: 0.5,
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 23 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -945,8 +1076,16 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
     await waitFor(() => expect(result.current.isProcessing).toBe(false));
   });
 
+  // [20260912_Refactor_322_InsertUpdateFlow] The INSERT fires at
+  // transcription completion, so clearing the armed polish timeout can no
+  // longer un-save the record — what it prevents is the polish UPDATE and,
+  // critically, any SECOND saveTranscription (the renderer never INSERTs
+  // twice).
   it("clears an armed optimization timeout when a new recording starts", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 1 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -956,26 +1095,31 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
       saveTranscription,
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
     const { result } = renderHook(() => useRecording());
     await startAndStop(result);
-    // The 100ms optimization timeout is now armed (isOptimizing === true).
+    // The immediate INSERT has landed; the 100ms polish timeout is now
+    // armed (isOptimizing === true).
     await waitFor(() => expect(result.current.isOptimizing).toBe(true));
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await result.current.startRecording();
     });
     expect(result.current.isRecording).toBe(true);
 
-    // The cleared timeout never fires, so nothing is saved.
+    // The cleared timeout never fires, so no polish UPDATE runs and — the
+    // regression this test locks — no second INSERT happens either.
     await act(async () => {
       await new Promise((resolve) => {
         setTimeout(resolve, 250);
       });
     });
-    expect(saveTranscription).not.toHaveBeenCalled();
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
+    expect(updateTranscription).not.toHaveBeenCalled();
 
     // End the second recording; the cancelled flag neutralizes its own
     // optimization timeout after the test ends.
@@ -1010,7 +1154,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         duration: 1,
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 5 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1086,11 +1233,14 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
   });
 
   it("defaults missing transcription fields when saving", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 6 });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({ success: true }),
       getSetting: vi.fn().mockResolvedValue("off"),
       saveTranscription,
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1133,7 +1283,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         duration: 1,
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 7 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1170,7 +1323,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting,
       processText,
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 8 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1197,7 +1353,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting: vi.fn().mockResolvedValue(undefined),
       processText,
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 10 }),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1215,6 +1374,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       .fn()
       .mockResolvedValue({ success: false, error: "上游500" });
     const onAIOptimizationComplete = vi.fn();
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1224,7 +1384,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting: vi.fn().mockResolvedValue("auto"),
       processText,
-      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 11 }),
+      updateTranscription,
       log,
     });
 
@@ -1240,6 +1403,8 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         expect.objectContaining({ success: false }),
       ),
     );
+    // A failed polish leaves the just-INSERTed raw row untouched.
+    expect(updateTranscription).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1),
     );
@@ -1251,7 +1416,12 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
   });
 
   it("keeps the raw text when the optimized text is identical", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 12 });
+    const updateTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, changes: 1 });
     const onAIOptimizationComplete = vi.fn();
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
@@ -1266,6 +1436,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         text: "完全相同",
       }),
       saveTranscription,
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1275,13 +1446,23 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
     await startAndStop(result);
 
     await waitFor(() => expect(saveTranscription).toHaveBeenCalledTimes(1));
-    const saved = saveTranscription.mock.calls[0]![0] as Record<
+    const inserted = saveTranscription.mock.calls[0]![0] as Record<
       string,
       unknown
     >;
-    // processed_text is recorded but must not replace the main text.
-    expect(saved.processed_text).toBe("完全相同");
-    expect(saved.text).toBe("完全相同");
+    // The INSERT carries the raw (cleaned) text only.
+    expect(inserted.text).toBe("完全相同");
+
+    // [20260912_Refactor_322_InsertUpdateFlow] processed_text is still
+    // recorded for an identical polish, but the patch must NOT overwrite
+    // the main text (no `text` key when the polish is not different).
+    await waitFor(() => expect(updateTranscription).toHaveBeenCalledTimes(1));
+    const patch = updateTranscription.mock.calls[0]![1] as Record<
+      string,
+      unknown
+    >;
+    expect(patch).toEqual({ processed_text: "完全相同" });
+
     await waitFor(() =>
       expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1),
     );
@@ -1295,7 +1476,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
   it("handles an AI success result that carries no text", async () => {
     const log = vi.fn().mockResolvedValue(undefined);
     const onAIOptimizationComplete = vi.fn();
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 13 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1306,6 +1490,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       getSetting: vi.fn().mockResolvedValue("auto"),
       processText: vi.fn().mockResolvedValue({ success: true }),
       saveTranscription,
+      updateTranscription,
       log,
     });
 
@@ -1318,13 +1503,15 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
     await waitFor(() =>
       expect(log).toHaveBeenCalledWith("info", "AI文本优化成功", "..."),
     );
+    // No polished text => nothing to write back via UPDATE.
+    expect(updateTranscription).not.toHaveBeenCalled();
     await waitFor(() => expect(saveTranscription).toHaveBeenCalledTimes(1));
-    const saved = saveTranscription.mock.calls[0]![0] as Record<
+    const inserted = saveTranscription.mock.calls[0]![0] as Record<
       string,
       unknown
     >;
-    expect(saved.processed_text).toBeUndefined();
-    expect(saved.text).toBe("无文本结果");
+    expect(inserted.processed_text).toBeUndefined();
+    expect(inserted.text).toBe("无文本结果");
     await waitFor(() =>
       expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1),
     );
@@ -1337,7 +1524,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
 
   it("logs a thrown AI error and still saves the raw transcription", async () => {
     const log = vi.fn().mockResolvedValue(undefined);
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 14 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1348,6 +1538,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       getSetting: vi.fn().mockResolvedValue("auto"),
       processText: vi.fn().mockRejectedValue(new Error("模型崩溃")),
       saveTranscription,
+      updateTranscription,
       log,
     });
 
@@ -1361,12 +1552,18 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         expect.any(Error),
       ),
     );
+    expect(updateTranscription).not.toHaveBeenCalled();
     await waitFor(() => expect(saveTranscription).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(result.current.isOptimizing).toBe(false));
   });
 
   it("runs the optimization pipeline without a log bridge method", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 15 });
+    const updateTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, changes: 1 });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1380,6 +1577,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         text: "无日志优化",
       }),
       saveTranscription,
+      updateTranscription,
       // No `log` key on purpose: every log guard must short-circuit.
     });
 
@@ -1387,19 +1585,30 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
     await startAndStop(result);
 
     await waitFor(() => expect(saveTranscription).toHaveBeenCalledTimes(1));
-    const saved = saveTranscription.mock.calls[0]![0] as Record<
+    const inserted = saveTranscription.mock.calls[0]![0] as Record<
       string,
       unknown
     >;
-    expect(saved.processed_text).toBe("无日志优化");
-    expect(saved.text).toBe("无日志优化");
+    // The INSERT carries the raw text; the polish lands via UPDATE.
+    expect(inserted.text).toBe("无日志原文");
+    await waitFor(() => expect(updateTranscription).toHaveBeenCalledTimes(1));
+    expect(updateTranscription).toHaveBeenCalledWith(
+      15,
+      {
+        processed_text: "无日志优化",
+        text: "无日志优化",
+      },
+      { skipWhenManuallyEdited: true },
+    );
     expect(result.current.error).toBeNull();
     await waitFor(() => expect(result.current.isOptimizing).toBe(false));
   });
 
   it("tolerates a missing log method when the AI step fails", async () => {
     const onAIOptimizationComplete = vi.fn();
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 16 });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1410,6 +1619,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       getSetting: vi.fn().mockResolvedValue("auto"),
       processText: vi.fn().mockResolvedValue({ success: false }),
       saveTranscription,
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
     });
 
     const { result } = renderHook(() =>
@@ -1430,7 +1640,9 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
   });
 
   it("tolerates a missing log method when processText throws", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 17 });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1441,6 +1653,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       getSetting: vi.fn().mockResolvedValue("auto"),
       processText: vi.fn().mockRejectedValue(new Error("静默失败")),
       saveTranscription,
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
     });
 
     const { result } = renderHook(() => useRecording());
@@ -1451,7 +1664,11 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
     await waitFor(() => expect(result.current.isOptimizing).toBe(false));
   });
 
-  it("skips saving when the bridge disappears while settings are loading", async () => {
+  // [20260912_Refactor_322_InsertUpdateFlow] With the INSERT hoisted to
+  // transcription completion, a bridge that dies mid-settings-read can only
+  // skip the polish UPDATE — the raw record is already persisted and no
+  // second save may appear.
+  it("skips the polish write-back when the bridge disappears while settings are loading", async () => {
     let resolveSettings: (value: unknown) => void = () => {};
     const getSetting = vi.fn(
       (_key: string) =>
@@ -1459,7 +1676,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
           resolveSettings = resolve;
         }),
     );
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 18 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1469,6 +1689,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting,
       saveTranscription,
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1482,14 +1703,19 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       resolveSettings("off");
     });
 
-    // The save block is guarded by a falsy electronAPI and is skipped.
+    // With mode "off" no polished text is ever produced, so the write-back
+    // has nothing to send; the INSERT already happened exactly once.
     await waitFor(() => expect(result.current.isOptimizing).toBe(false));
-    expect(saveTranscription).not.toHaveBeenCalled();
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
+    expect(updateTranscription).not.toHaveBeenCalled();
     expect(result.current.error).toBeNull();
   });
 
   it("surfaces a processing error when the bridge disappears before the timeout fires", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 19 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1499,6 +1725,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
       saveTranscription,
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1509,11 +1736,17 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
     setElectronAPI(undefined);
     await waitFor(() => expect(result.current.error).toContain("转录处理失败"));
     await waitFor(() => expect(result.current.isOptimizing).toBe(false));
-    expect(saveTranscription).not.toHaveBeenCalled();
+    // The raw INSERT survived (it fired at transcription completion); the
+    // vanished bridge must not trigger a second save or a partial UPDATE.
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
+    expect(updateTranscription).not.toHaveBeenCalled();
   });
 
   it("clears an armed optimization timeout when cancelRecording runs during optimization", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 20 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
         success: true,
@@ -1523,6 +1756,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
       saveTranscription,
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1539,11 +1773,17 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         setTimeout(resolve, 250);
       });
     });
-    expect(saveTranscription).not.toHaveBeenCalled();
+    // The raw INSERT stands; the cleared timeout prevents the polish chain
+    // (and any second save) from running.
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
+    expect(updateTranscription).not.toHaveBeenCalled();
   });
 
   it("skips the optimization callback when recording is cancelled mid-processing", async () => {
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 21 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     const onAIOptimizationComplete = vi.fn();
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
@@ -1554,6 +1794,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       }),
       getSetting: vi.fn().mockResolvedValue("off"),
       saveTranscription,
+      updateTranscription,
       log: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -1576,7 +1817,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         setTimeout(resolve, 250);
       });
     });
-    expect(saveTranscription).not.toHaveBeenCalled();
+    // The immediate INSERT stands (it preceded the cancel); the cancelled
+    // callback neutralizes the polish chain entirely.
+    expect(saveTranscription).toHaveBeenCalledTimes(1);
+    expect(updateTranscription).not.toHaveBeenCalled();
     expect(onAIOptimizationComplete).not.toHaveBeenCalled();
     // The cancelled callback returned before its finally block, so the
     // optimizing flag stays latched at true.
@@ -1606,7 +1850,10 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       success: false,
       error: "AI请求超时（150秒），请尝试缩短文本或检查网络",
     });
-    const saveTranscription = vi.fn().mockResolvedValue({ success: true });
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 22 });
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
     const onAIOptimizationComplete = vi.fn();
     setElectronAPI({
       transcribeAudio: vi.fn().mockResolvedValue({
@@ -1622,6 +1869,7 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
         timeout?: number,
       ) => Promise<import("../../src/types/ipc").AIProcessResult>,
       saveTranscription,
+      updateTranscription,
       log,
     });
 
@@ -1640,17 +1888,259 @@ describe("[20260816_Test_BranchPush] useRecording — branch arcs", () => {
       expect.objectContaining({ success: false }),
     );
     expect(saveTranscription).toHaveBeenCalledTimes(1);
-    const saved = saveTranscription.mock.calls[0]![0] as Record<
+    const inserted = saveTranscription.mock.calls[0]![0] as Record<
       string,
       unknown
     >;
-    expect(saved.processed_text).toBeUndefined();
-    expect(saved.text).toBe("超时原文");
+    expect(inserted.processed_text).toBeUndefined();
+    expect(inserted.text).toBe("超时原文");
+    // A failed orchestrator call leaves the raw row untouched.
+    expect(updateTranscription).not.toHaveBeenCalled();
     expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1);
     expect(onAIOptimizationComplete.mock.calls[0]![0]).toMatchObject({
       text: "超时原文",
       enhanced_by_ai: false,
     });
     expect(result.current.isOptimizing).toBe(false);
+  });
+
+  // [20260912_Fix_322_AutoUpdateGuard] Ticket #322 review HIGH: the auto
+  // write-back MUST carry the T2 manual-edit guard so a record the user
+  // edited during the polish window is never overwritten.
+  it("passes the skipWhenManuallyEdited guard on the auto write-back", async () => {
+    const updateTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, changes: 1 });
+    setElectronAPI({
+      transcribeAudio: vi.fn().mockResolvedValue({
+        success: true,
+        text: "守卫原文",
+        confidence: 1,
+        duration: 1,
+      }),
+      getSetting: vi.fn().mockResolvedValue("auto"),
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "守卫润色结果" }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 30 }),
+      updateTranscription,
+      log: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { result } = renderHook(() => useRecording());
+    await startAndStop(result);
+
+    await waitFor(() => expect(updateTranscription).toHaveBeenCalledTimes(1));
+    expect(updateTranscription).toHaveBeenCalledWith(
+      30,
+      { processed_text: "守卫润色结果", text: "守卫润色结果" },
+      { skipWhenManuallyEdited: true },
+    );
+    await waitFor(() => expect(result.current.isOptimizing).toBe(false));
+  });
+
+  // [20260912_Fix_322_AutoUpdateGuard] A skipped guard outcome (the user's
+  // manual edit won) is a success no-op: the panel must fall back to the
+  // raw text so UI and DB agree, without surfacing an error.
+  it("falls back to the raw text when the write-back is skipped (manually edited)", async () => {
+    const onAIOptimizationComplete = vi.fn();
+    const log = vi.fn().mockResolvedValue(undefined);
+    const updateTranscription = vi.fn().mockResolvedValue({
+      success: true,
+      skipped: true,
+      manually_edited: 1,
+    });
+    setElectronAPI({
+      transcribeAudio: vi.fn().mockResolvedValue({
+        success: true,
+        text: "被编辑原文",
+        confidence: 1,
+        duration: 1,
+      }),
+      getSetting: vi.fn().mockResolvedValue("auto"),
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "被编辑润色结果" }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 31 }),
+      updateTranscription,
+      log,
+    });
+
+    const { result } = renderHook(() =>
+      useRecording({ onAIOptimizationComplete }),
+    );
+    await startAndStop(result);
+
+    await waitFor(() => expect(updateTranscription).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1),
+    );
+    expect(onAIOptimizationComplete.mock.calls[0]![0]).toMatchObject({
+      text: "被编辑原文",
+      enhanced_by_ai: false,
+    });
+    expect(result.current.error).toBeNull();
+    await waitFor(() => expect(result.current.isOptimizing).toBe(false));
+  });
+
+  // [20260912_Fix_322_AutoUpdateGuard] A failed write-back (e.g. the row was
+  // deleted mid-polish) logs and degrades to the raw text — the panel must
+  // not claim an enhancement the DB does not hold.
+  it("falls back to the raw text when the write-back fails", async () => {
+    const onAIOptimizationComplete = vi.fn();
+    const log = vi.fn().mockResolvedValue(undefined);
+    const updateTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: "转录记录不存在" });
+    setElectronAPI({
+      transcribeAudio: vi.fn().mockResolvedValue({
+        success: true,
+        text: "写回失败原文",
+        confidence: 1,
+        duration: 1,
+      }),
+      getSetting: vi.fn().mockResolvedValue("auto"),
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "写回失败润色结果" }),
+      saveTranscription: vi
+        .fn()
+        .mockResolvedValue({ success: true, lastInsertRowid: 32 }),
+      updateTranscription,
+      log,
+    });
+
+    const { result } = renderHook(() =>
+      useRecording({ onAIOptimizationComplete }),
+    );
+    await startAndStop(result);
+
+    await waitFor(() =>
+      expect(log).toHaveBeenCalledWith(
+        "error",
+        "润色结果写回失败:",
+        expect.objectContaining({ success: false }),
+      ),
+    );
+    await waitFor(() =>
+      expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1),
+    );
+    expect(onAIOptimizationComplete.mock.calls[0]![0]).toMatchObject({
+      text: "写回失败原文",
+      enhanced_by_ai: false,
+    });
+    await waitFor(() => expect(result.current.isOptimizing).toBe(false));
+  });
+
+  // [20260912_Refactor_322_InsertUpdateFlow] Without a row id there is
+  // nothing to write back to: the polish is logged as unpersisted, the raw
+  // row stands, and the panel mirrors the DB (raw text).
+  it("skips the write-back and notifies the raw text when the INSERT returns no row id", async () => {
+    const onAIOptimizationComplete = vi.fn();
+    const onSaveComplete = vi.fn();
+    const log = vi.fn().mockResolvedValue(undefined);
+    const updateTranscription = vi.fn().mockResolvedValue({ success: true });
+    setElectronAPI({
+      transcribeAudio: vi.fn().mockResolvedValue({
+        success: true,
+        text: "无id原文",
+        confidence: 1,
+        duration: 1,
+      }),
+      getSetting: vi.fn().mockResolvedValue("auto"),
+      processText: vi
+        .fn()
+        .mockResolvedValue({ success: true, text: "无id润色结果" }),
+      saveTranscription: vi.fn().mockResolvedValue({ success: true }),
+      updateTranscription,
+      log,
+    });
+
+    const { result } = renderHook(() =>
+      useRecording({ onAIOptimizationComplete, onSaveComplete }),
+    );
+    await startAndStop(result);
+
+    // The polish chain completes (notify fires) without any persistence of
+    // the polished columns and without an onSaveComplete id.
+    await waitFor(() =>
+      expect(onAIOptimizationComplete).toHaveBeenCalledTimes(1),
+    );
+    expect(onSaveComplete).not.toHaveBeenCalled();
+    expect(updateTranscription).not.toHaveBeenCalled();
+    expect(onAIOptimizationComplete.mock.calls[0]![0]).toMatchObject({
+      text: "无id原文",
+      enhanced_by_ai: false,
+    });
+    expect(result.current.error).toBeNull();
+    await waitFor(() => expect(result.current.isOptimizing).toBe(false));
+  });
+
+  // [20260912_Refactor_322_InsertUpdateFlow] The immediate INSERT surfaces
+  // invoke-level rejections through processAudio's own error path.
+  it("surfaces an error when the immediate INSERT rejects", async () => {
+    const onTranscriptionComplete = vi.fn();
+    setElectronAPI({
+      transcribeAudio: vi.fn().mockResolvedValue({
+        success: true,
+        text: "拒绝原文",
+        confidence: 1,
+        duration: 1,
+      }),
+      getSetting: vi.fn().mockResolvedValue("off"),
+      saveTranscription: vi.fn().mockRejectedValue(new Error("db locked")),
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
+      log: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { result } = renderHook(() =>
+      useRecording({ onTranscriptionComplete }),
+    );
+    await startAndStop(result);
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toContain("音频处理失败");
+    expect(result.current.error).toContain("db locked");
+    // The INSERT precedes the result notification — a rejected save means
+    // nothing reached the panel either.
+    expect(onTranscriptionComplete).not.toHaveBeenCalled();
+  });
+
+  // [20260912_Refactor_322_InsertUpdateFlow] Cancel semantic change,
+  // deliberately locked: a completed transcription is persisted even when
+  // the recording is cancelled mid-processing (the old flow showed the text
+  // in the UI but silently dropped it from the DB — the incoherent state
+  // this ticket removes). Cancel only kills the polish chain.
+  it("keeps the immediate INSERT when the recording is cancelled mid-recording", async () => {
+    const saveTranscription = vi
+      .fn()
+      .mockResolvedValue({ success: true, lastInsertRowid: 33 });
+    setElectronAPI({
+      transcribeAudio: vi.fn().mockResolvedValue({
+        success: true,
+        text: "取消仍存原文",
+        confidence: 1,
+        duration: 1,
+      }),
+      getSetting: vi.fn().mockResolvedValue("off"),
+      saveTranscription,
+      updateTranscription: vi.fn().mockResolvedValue({ success: true }),
+      log: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { result } = renderHook(() => useRecording());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    await act(async () => {
+      result.current.cancelRecording();
+    });
+
+    await waitFor(() => expect(saveTranscription).toHaveBeenCalledTimes(1));
+    expect(result.current.isRecording).toBe(false);
   });
 });


### PR DESCRIPTION
## What

录音结束自动路径保存流重构（T9②，#322）：**转写完成即 INSERT（含 raw_text）→ 编排器完成后经 T1 `updateTranscription` 通道 UPDATE 润色列**，渲染端不再二次插入。`useRecording` 的 ~90 行 `setTimeout` 单体拆为 设置读取 → 润色 → UPDATE → 通知 四段。

## Why

- 旧流程持久化挂在润色之后：润色慢（编排器 deadline matrix 最长 ~150s）或中途崩溃时转写全文丢失
- 旧流程取消录音后「UI 显示结果但 DB 丢弃」的不一致状态
- 前次尝试因单上下文装不下整体 revert（见 #322 评审发现），本票独立完成

## Review（独立上下文 code-review，1 HIGH + 4 MINOR + 2 NIT 全部修复）

- **HIGH（阻塞项，已修）**：自动写回走 T1 通道后可能覆盖润色窗口内被用户手动编辑的记录（违反 Spec #193 T2 不变量）。修复：`skipWhenManuallyEdited` 守卫全链打通（handler 转发 options + skipped 回显 / preload 第三参 / d.ts / types），hook 写回携带守卫；DB 层注释（database.ts:418）本就要求录音结束管线必传此选项
- MINOR：写回三态门控增强通知（skipped/failed 降级原文，面板与 DB 一致）；INSERT 信封失败显式 `setError`（原来静默忽略）；补 3 个失败分支测试 + handler 层 2 个守卫测试
- NIT：中文注释改英文、过期测试注释更新
- MINOR-4（取消语义）**有意保持新行为**并加锁定测试：取消后已完成的转写仍持久化（旧流程的不一致被移除，cancel 仅中止润色链）。如需「取消即丢弃」产品语义请指出，改动点在 processAudio 的 INSERT 前加 `cancelledRef` 门

## 风险声明

1. **取消语义变更**（上述）— 用户可感知，已锁定测试，可一键反转
2. INSERT 失败路径错误文案从「转录处理失败」变为「音频处理失败」（仅 bridge 消失微窗口可触发；信封失败仍走新的「转录保存失败」）
3. 手动编辑路径（TranscriptionResult / history edit-save）不传 options → 保持 T2 设计的「不限流」，行为零变化

## 验证

- `pnpm ci:check` 11/11 全绿（format/lint/license/typecheck/typecheck:tests/test+coverage/build×3/dev smoke；security audit 非阻塞警告为存量）
- useRecording 57 用例 / transcriptionHandlers 含守卫用例 / database-manual-edit-protection DB 层接缝测试 全绿
- 类型契约测试：录音自动路径 INSERT 载荷必须免 cast 通过桥接声明（typecheck:tests 门禁强制）

Closes #322