### PR TITLE
feat: 单实例锁 — 二实例硬退出 + 已有实例窗口唤起 (Spec #258 Phase 0, closes #260)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -26,6 +26,22 @@ import LogManager from "./src/helpers/logManager";
 // Initialize log manager
 const logger = new LogManager();
 
+// [20260912_Feat_260_SingleInstance] Ticket #260 (Spec #258 Phase 0): a
+// second app instance must hard-exit here, BEFORE any manager/database/IPC
+// initialization — the defect under fix is double-open contention on the
+// FunASR subprocess and SQLite, so app.quit() alone is not enough (the
+// module top-level init below would still run while quit is in flight).
+// process.exit(1) is safe at this point: nothing has been initialized, so
+// there is nothing for the will-quit cleanup to release.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  logger.warn("已检测到正在运行的 Murmur 实例，第二实例立即退出", {
+    platform: process.platform,
+  });
+  process.exit(1);
+}
+// [20260912_Feat_260_SingleInstance] END
+
 // Add global error handling
 process.on("uncaughtException", (error: Error & { code?: string }) => {
   logger.error("Uncaught Exception:", error);
@@ -353,18 +369,13 @@ app.on("window-all-closed", () => {
   }
 });
 
-// [20260911_Fix_339_DockActivate] Issue #339: macOS Dock click must recover
-// the tray-resident window. Two cases:
-//   1. No windows at all (window was destroyed, e.g. Cmd+W): recreate AND
-//      re-sync the tray's window reference — trayManager captured the
-//      original window once at startup, so without setWindows() every tray
-//      show/click would no-op against the destroyed reference.
-//   2. A HIDDEN main window still exists (the custom close button's default
-//      close_behavior "hide" path): getAllWindows() is non-empty, so the old
-//      recreate-only handler did nothing and the app looked dead in the
-//      Dock. Now the existing window is shown/focused instead.
-app.on("activate", () => {
-  logger.info("activate事件 (Dock点击)", {
+// [20260912_Feat_260_SingleInstance] Shared awaken path for Dock clicks
+// (activate, macOS) and second-instance launches (ticket #260, Spec #258):
+// bring the tray-resident window back, recreating it when destroyed. The
+// second-instance event carries NO payload usable for CLI communication
+// (single direction, no result channel) — window awakening is its only job.
+function showOrCreateMainWindow(): void {
+  logger.info("唤起主窗口", {
     windowCount: BrowserWindow.getAllWindows().length,
   });
   if (BrowserWindow.getAllWindows().length === 0) {
@@ -376,11 +387,32 @@ app.on("activate", () => {
         }
       })
       .catch((err: unknown) => {
-        logger.error("activate重建主窗口失败:", err);
+        logger.error("唤起重建主窗口失败:", err);
       });
   } else {
     windowManager.showMainWindow();
   }
+}
+
+app.on("second-instance", () => {
+  logger.info("second-instance事件 (二次启动唤起已有实例)");
+  showOrCreateMainWindow();
+});
+// [20260912_Feat_260_SingleInstance] END
+
+// [20260911_Fix_339_DockActivate] Issue #339: macOS Dock click must recover
+// the tray-resident window. Two cases:
+//   1. No windows at all (window was destroyed, e.g. Cmd+W): recreate AND
+//      re-sync the tray's window reference — trayManager captured the
+//      original window once at startup, so without setWindows() every tray
+//      show/click would no-op against the destroyed reference.
+//   2. A HIDDEN main window still exists (the custom close button's default
+//      close_behavior "hide" path): getAllWindows() is non-empty, so the old
+//      recreate-only handler did nothing and the app looked dead in the
+//      Dock. Now the existing window is shown/focused instead.
+app.on("activate", () => {
+  logger.info("activate事件 (Dock点击)");
+  showOrCreateMainWindow();
 });
 // [20260911_Fix_339_DockActivate] END
 

--- a/tests/unit/main-boot-order.test.ts
+++ b/tests/unit/main-boot-order.test.ts
@@ -46,6 +46,9 @@ vi.mock("electron", () => ({
     getVersion: vi.fn(() => "0.0.0-test"),
     whenReady: vi.fn(() => h.whenReadyPromise),
     on: vi.fn(),
+    // [20260912_Feat_260_SingleInstance] main.ts now requests the lock at
+    // the entry; the boot-order harness plays the FIRST instance.
+    requestSingleInstanceLock: vi.fn(() => true),
     quit: vi.fn(),
     exit: vi.fn(),
     disableHardwareAcceleration: vi.fn(),

--- a/tests/unit/main-lifecycle.test.ts
+++ b/tests/unit/main-lifecycle.test.ts
@@ -36,6 +36,12 @@ const h = vi.hoisted(() => {
     hiddenWindow,
     allWindows: [] as unknown[],
     loggerInfo: vi.fn(),
+    // [20260912_Feat_260_SingleInstance] Ticket #260 (Spec #258): lock
+    // acquisition knob + handles for the init calls a second instance must
+    // NEVER reach (SQLite open, IPC handler registration).
+    hasSingleInstanceLock: true,
+    dbInitialize: vi.fn(),
+    registerIPCHandlers: vi.fn(),
     windowManager: {
       mainWindow: null as unknown,
       _setupCSP: vi.fn(),
@@ -61,6 +67,9 @@ vi.mock("electron", () => ({
     on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
       h.appOnHandlers[event] = handler;
     }),
+    // [20260912_Feat_260_SingleInstance] Lock acquisition is knob-driven so
+    // tests can play both the first and the second instance.
+    requestSingleInstanceLock: vi.fn(() => h.hasSingleInstanceLock),
     quit: vi.fn(),
     exit: vi.fn(),
     disableHardwareAcceleration: vi.fn(),
@@ -120,7 +129,7 @@ vi.mock("../../src/helpers/windowManager", () => ({
 
 vi.mock("../../src/helpers/database", () => ({
   default: class {
-    initialize = vi.fn();
+    initialize = h.dbInitialize;
     setFileConfigPath = vi.fn();
     getSetting = vi.fn(() => undefined);
     setSafeStorage = vi.fn();
@@ -151,7 +160,7 @@ vi.mock("../../src/helpers/hotkeyManager", () => ({
 }));
 
 vi.mock("../../src/helpers/ipc", () => ({
-  registerAll: vi.fn(),
+  registerAll: h.registerIPCHandlers,
 }));
 
 async function importMain(): Promise<void> {
@@ -220,5 +229,96 @@ describe("[20260911_Fix_339_DockActivate] main.ts lifecycle handlers", () => {
     } else {
       expect(electron.app.quit).toHaveBeenCalled();
     }
+  });
+});
+
+// ── [20260912_Feat_260_SingleInstance] Ticket #260 (Spec #258 Phase 0) ────
+// Contracts:
+//   1. A second instance (requestSingleInstanceLock === false) hard-exits
+//      with a NON-ZERO code BEFORE any manager/database/IPC init — the
+//      whole defect is double-open contention on the FunASR subprocess and
+//      SQLite, so module top-level init must never run in that process.
+//   2. The first instance registers a second-instance handler whose ONLY
+//      job is window awakening: existing window → showMainWindow(); zero
+//      windows → createMainWindow() + tray re-sync (same contract as the
+//      Dock activate path).
+//   3. Normal single-instance startup is untouched (the preceding suite
+//      stays green with the lock acquired).
+describe("[20260912_Feat_260_SingleInstance] main.ts single-instance lock", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    for (const key of Object.keys(h.appOnHandlers)) {
+      delete h.appOnHandlers[key];
+    }
+    h.allWindows = [];
+    h.windowManager.mainWindow = null;
+    h.hasSingleInstanceLock = true;
+  });
+
+  it("requests the single-instance lock exactly once at the application entry", async () => {
+    const electron = await import("electron");
+    await importMain();
+
+    expect(electron.app.requestSingleInstanceLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("second instance hard-exits non-zero BEFORE opening the database or registering IPC", async () => {
+    h.hasSingleInstanceLock = false;
+    // process.exit must actually stop the module: simulate it with a throw
+    // so the top-level init below the lock check is proven unreachable.
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`PROCESS_EXIT:${code}`);
+    }) as never);
+    // Restore even on assertion failure — a leaked throwing process.exit
+    // would cascade confusingly into the following tests.
+    try {
+      await expect(importMain()).rejects.toThrow("PROCESS_EXIT:1");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      // The contention this ticket removes: a second instance must not open
+      // SQLite, register IPC handlers, or start the FunASR subprocess chain.
+      expect(h.dbInitialize).not.toHaveBeenCalled();
+      expect(h.registerIPCHandlers).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  // [20260912_Feat_260_SingleInstance] The one-directional contract made
+  // explicit: Electron delivers (event, argv, workingDirectory) on
+  // second-instance; the handler must IGNORE them (no CLI routing, no quit)
+  // and only awaken the window.
+  it("second-instance event with an existing window shows it instead of recreating", async () => {
+    h.allWindows = [h.hiddenWindow];
+    h.windowManager.mainWindow = h.hiddenWindow;
+    const electron = await import("electron");
+
+    await importMain();
+    const handler = h.appOnHandlers["second-instance"];
+    expect(typeof handler).toBe("function");
+    handler!(
+      {} as unknown,
+      ["/fake/argv/second-launch"] as unknown as string[],
+    );
+
+    expect(h.windowManager.showMainWindow).toHaveBeenCalledTimes(1);
+    expect(h.windowManager.createMainWindow).not.toHaveBeenCalled();
+    expect(electron.app.quit).not.toHaveBeenCalled();
+  });
+
+  it("second-instance event with zero windows recreates the window and re-syncs the tray", async () => {
+    h.allWindows = [];
+    h.windowManager.createMainWindow.mockResolvedValue(h.hiddenWindow);
+
+    await importMain();
+    h.appOnHandlers["second-instance"]!();
+    await vi.waitFor(() =>
+      expect(h.trayManager.setWindows).toHaveBeenCalledWith(h.hiddenWindow),
+    );
+
+    expect(h.windowManager.createMainWindow).toHaveBeenCalledTimes(1);
+    expect(h.windowManager.showMainWindow).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

应用入口补 `requestSingleInstanceLock`（Spec #258 MCP/CLI 的前置缺口，today 双开争抢 FunASR 子进程与 SQLite）：

- **锁检查位置**：main.ts 的 LogManager 创建之后、PATH/userData/管理器初始化之前。未获锁 `process.exit(1)` 硬退出——`app.quit()` 不够，模块顶层 init 会在 quit 完成前继续跑（恰好是要消除的 SQLite 打开与 IPC 注册）
- **second-instance 仅做窗口唤起**：与 macOS Dock activate 共享 `showOrCreateMainWindow()`（有窗 show/focus，无窗重建 + 托盘引用重同步）。单向事件无结果通道，不承载 CLI 通信语义（注释明示）
- 正常单实例启动路径零变化（既有断言未动，全绿）

## 测试（先红后绿）

main-lifecycle 扩展 4 用例：锁请求恰好一次；二实例退出前 DB/IPC 零触达（process.exit 以 throw 模拟，初始化不可达性可证伪）；second-instance 携带 Electron `(event, argv)` 载荷仍只唤起不 quit（单向契约显式锁定）；无窗重建 + 托盘重同步。main-boot-order mock 补 `requestSingleInstanceLock`。

## 独立 code-review

APPROVE，5 NIT 零阻塞。已采纳 3：Dock 路径重复 windowCount 日志去除、exitSpy try/finally 恢复、单向契约从隐式改显式测试。留 2 个低危理论项（quit 期间唤起可能建出即毁窗口、dev 模式 2s 延迟窗口唤起早于 safeStorage 沉降——与既有 activate 路径同暴露面，Phase 0 不处理）。

## 风险声明

- `process.exit(1)` 跳过 will-quit 清理：经评审确认安全——锁检查点之前无任何已建资源（LogManager 构造无副作用，日志为同步 appendFile 已落盘）
- 双开语义变化：第二实例从「真的双开」变为「退出并唤起已有窗口」——这正是本票目的

## 验证

`pnpm ci:check` 11/11 全绿；全量测试通过

Closes #260