### PR TITLE
poc: Windows named pipe ACL 攻击面探针 + 可重复采集 workflow (Spec #258 #263, 1/2)

### DIFF
--- a/.github/workflows/poc-named-pipe.yml
+++ b/.github/workflows/poc-named-pipe.yml
@@ -1,0 +1,34 @@
+# [20260912_Poc_263_NamedPipeAcl] Ticket #263 (Spec #258): one-off
+# workflow_dispatch runner for the Windows named pipe ACL PoC. Collects the
+# first-hand probe data on a real windows-latest host and uploads the JSON
+# verdict as an artifact. Not part of the release gates — manual dispatch
+# only (the probe spawns throwaway pipe servers and client processes).
+name: poc-named-pipe
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  named-pipe-poc:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run named pipe ACL probe
+        shell: pwsh
+        run: |
+          node scripts/poc/windows-named-pipe-acl.mjs 2>&1 | Tee-Object -FilePath poc-output.txt
+          Write-Host "---- machine-readable verdict (stdout JSON) ----"
+          Get-Content poc-output.txt
+
+      - name: Upload probe verdict
+        uses: actions/upload-artifact@v4
+        with:
+          name: named-pipe-poc-verdict
+          path: poc-output.txt
+          retention-days: 30
+# [20260912_Poc_263_NamedPipeAcl] END

--- a/scripts/poc/windows-named-pipe-acl.mjs
+++ b/scripts/poc/windows-named-pipe-acl.mjs
@@ -1,0 +1,361 @@
+// [20260912_Poc_263_NamedPipeAcl] Ticket #263 (Spec #258 Phase 0 hard gate):
+// first-hand probe of the Windows named pipe attack surface for Murmur's
+// local IPC channel decision. Pure spike — no product code is imported or
+// changed.
+//
+// What it measures, on a real Windows host (run from an unrelated client
+// CHILD process, simulating another local program):
+//   P1  Pipe enumeration: can an unrelated process list \\.\pipe\ and spot
+//       our server pipe by prefix? (If YES, an "unguessable name" alone is
+//       NOT a confidentiality control.)
+//   P2  Unauthenticated read: can that process connect to the pipe and read
+//       a frame WITHOUT any token handshake? (The default-DACL exposure.)
+//   P3  ACL control surface: does Node's net.Server expose ANY API to
+//       tighten the pipe DACL? (Expected: none — documented constraint.)
+//   P4  App-layer compensating control: does a token handshake reject a
+//       client that connects with a wrong/absent token, and admit the
+//       tokened one? (The candidate mitigation, proven end-to-end.)
+//   P5  Wrong-name reachability: connect attempts to a random 128-bit pipe
+//       name unknown to the client fail by NOT_FOUND (baseline sanity).
+//
+// Cross-USER execution is NOT possible on a CI runner (single user) — that
+// residual is explicitly recorded UNVERIFIED in the research doc; P1/P2 via
+// a separate process still validates the mechanism, not just same-process
+// loopbacks.
+//
+// Output: a single JSON verdict object on stdout (machine-readable) plus
+// human-readable progress on stderr. Exit 0 always on Windows (verdicts
+// carry the booleans); exit 2 on non-Windows hosts.
+// [20260912_Poc_263_NamedPipeAcl] END
+import net from "node:net";
+import { readdirSync } from "node:fs";
+import { spawn } from "node:child_process";
+import crypto from "node:crypto";
+
+const PIPE_NAMESPACE = "murmur-poc-";
+const TOKEN_BYTES = 32;
+const SERVER_START_TIMEOUT_MS = 5000;
+const CLIENT_CONNECT_TIMEOUT_MS = 3000;
+const CLIENT_PROCESS_TIMEOUT_MS = 20000;
+
+function log(message) {
+  process.stderr.write(`[poc] ${message}\n`);
+}
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error(`${label} timed out after ${ms}ms`)),
+        ms,
+      );
+    }),
+  ]);
+}
+
+/** One frame = one newline-terminated JSON blob (Murmur's planned protocol). */
+function sendFrame(socket, object) {
+  socket.write(`${JSON.stringify(object)}\n`);
+}
+
+function readFrame(socket) {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    const onData = (chunk) => {
+      buffer += chunk.toString("utf8");
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex !== -1) {
+        socket.off("data", onData);
+        resolve(JSON.parse(buffer.slice(0, newlineIndex)));
+      }
+    };
+    socket.on("data", onData);
+    socket.on("error", reject);
+  });
+}
+
+function connectPipe(pipeName) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(pipeName);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("connect timed out"));
+    }, CLIENT_CONNECT_TIMEOUT_MS);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Runs in the CHILD (client) process. Receives the server pipe name ONLY
+ * when probing P2/P4 (the server hands it over deliberately); for P1 the
+ * child must FIND the pipe by enumerating the namespace with just the
+ * prefix — that is the whole point of the probe.
+ */
+async function runClientChild(serializedTask) {
+  const task = JSON.parse(serializedTask);
+  const verdict = { role: "client", probes: {} };
+
+  if (task.probe === "enumerate-and-read") {
+    // P1: enumerate the pipe namespace with only the prefix.
+    const allPipes = readdirSync("\\\\.\\pipe\\");
+    const matches = allPipes.filter((name) => name.startsWith(PIPE_NAMESPACE));
+    verdict.probes.enumeration = {
+      totalPipeCount: allPipes.length,
+      prefixMatches: matches.length,
+      foundTarget: matches.includes(task.pipeName),
+    };
+    if (!verdict.probes.enumeration.foundTarget) {
+      process.stdout.write(`${JSON.stringify(verdict)}\n`);
+      return;
+    }
+
+    // P2: connect + read the greeting frame WITHOUT presenting any token.
+    try {
+      const socket = await connectPipe(task.pipeName);
+      const greeting = await readFrame(socket);
+      verdict.probes.unauthenticatedRead = {
+        connected: true,
+        greetingReceived: greeting.greeting ?? null,
+        serverSideAuthenticated: false,
+      };
+      socket.destroy();
+    } catch (err) {
+      verdict.probes.unauthenticatedRead = {
+        connected: false,
+        error: String(err.message ?? err),
+      };
+    }
+  }
+
+  if (task.probe === "token-handshake") {
+    // P4: connect and send a WRONG token first; expect rejection. The
+    // server then allows a retry slot which we use WITHOUT a token (absent
+    // token must also be rejected). The parent verifies the tokened path
+    // separately from the server side.
+    const attempt = async (token) => {
+      try {
+        const socket = await connectPipe(task.pipeName);
+        sendFrame(socket, { token });
+        const reply = await readFrame(socket);
+        socket.destroy();
+        return {
+          rejected: reply.error ?? null,
+          accepted: reply.accepted === true,
+        };
+      } catch (err) {
+        return { connectOrReadError: String(err.message ?? err) };
+      }
+    };
+    verdict.probes.wrongToken = await attempt("definitely-not-the-token");
+    verdict.probes.absentToken = await attempt(null);
+  }
+
+  if (task.probe === "random-name-unreachable") {
+    // P5 baseline: an unknown 128-bit name must simply not connect.
+    try {
+      const socket = await connectPipe(task.pipeName);
+      socket.destroy();
+      verdict.probes.randomName = { connected: true };
+    } catch (err) {
+      verdict.probes.randomName = {
+        connected: false,
+        code: err.code ?? String(err.message ?? err),
+      };
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify(verdict)}\n`);
+}
+
+/**
+ * Server side. Runs one probe session at a time so each child gets a
+ * freshly named pipe and a clean token store.
+ */
+async function runServerProbe(probe) {
+  const secretToken = crypto.randomBytes(TOKEN_BYTES).toString("hex");
+  const randomSuffix = crypto.randomBytes(16).toString("hex");
+  const pipeName = `\\\\.\\pipe\\${PIPE_NAMESPACE}${randomSuffix}`;
+  const verdict = { probe, pipeNamePrefix: PIPE_NAMESPACE, probes: {} };
+
+  if (probe === "random-name-unreachable") {
+    // P5: serve NOTHING on the secret name; the child just tries to reach it.
+    const child = spawnChild({ probe, pipeName });
+    const result = await withTimeout(
+      collectChild(child),
+      CLIENT_PROCESS_TIMEOUT_MS,
+      "client",
+    );
+    verdict.probes = result.probes;
+    return verdict;
+  }
+
+  const connections = [];
+  const server = net.createServer((socket) => {
+    connections.push(socket);
+    if (probe === "enumerate-and-read") {
+      // P2: the server GREETES unauthenticated clients (worst case: a
+      // chatty server that answers before any auth). If the child reads
+      // this, unauthenticated read is proven.
+      sendFrame(socket, { greeting: "unauthenticated-greeting" });
+      return;
+    }
+    if (probe === "token-handshake") {
+      // P4: app-layer auth — first frame must carry the exact token.
+      let buffer = "";
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        const newlineIndex = buffer.indexOf("\n");
+        if (newlineIndex === -1) return;
+        let frame;
+        try {
+          frame = JSON.parse(buffer.slice(0, newlineIndex));
+        } catch {
+          socket.destroy();
+          return;
+        }
+        if (frame.token === secretToken) {
+          sendFrame(socket, { accepted: true });
+        } else {
+          sendFrame(socket, { error: "token-rejected" });
+          socket.end();
+        }
+      });
+    }
+  });
+
+  await withTimeout(
+    new Promise((resolve) => server.listen(pipeName, resolve)),
+    SERVER_START_TIMEOUT_MS,
+    "server listen",
+  );
+  log(`server listening on ${pipeName} (probe=${probe})`);
+
+  try {
+    if (probe === "enumerate-and-read") {
+      const child = spawnChild({ probe, pipeName });
+      const result = await withTimeout(
+        collectChild(child),
+        CLIENT_PROCESS_TIMEOUT_MS,
+        "client",
+      );
+      verdict.probes = result.probes;
+    }
+
+    if (probe === "token-handshake") {
+      const child = spawnChild({ probe, pipeName });
+      const result = await withTimeout(
+        collectChild(child),
+        CLIENT_PROCESS_TIMEOUT_MS,
+        "client",
+      );
+      verdict.probes = result.probes;
+      // Server-side half of P4: the CORRECT token is admitted.
+      const socket = await connectPipe(pipeName);
+      sendFrame(socket, { token: secretToken });
+      const reply = await readFrame(socket);
+      socket.destroy();
+      verdict.probes.correctTokenFromAnotherHandle = reply;
+    }
+
+    if (probe === "acl-surface") {
+      // P3: enumerate the public API of a listening pipe server — the
+      // documented constraint is that Node's net module has no ACL/DACL
+      // control; verify no security-ish members exist on the server or its
+      // handle-ish properties.
+      const members = new Set();
+      let current = server;
+      while (current && current !== Object.prototype) {
+        Object.getOwnPropertyNames(current).forEach((name) =>
+          members.add(name),
+        );
+        current = Object.getPrototypeOf(current);
+      }
+      verdict.probes.aclSurface = {
+        serverMembers: [...members].sort(),
+        hasSecurityApi: [...members].some((name) =>
+          /secur|dacl|acl|sid|priv/i.test(name),
+        ),
+        nodeVersion: process.versions.node,
+      };
+    }
+  } finally {
+    for (const socket of connections) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  return verdict;
+}
+
+function spawnChild(task) {
+  const child = spawn(
+    process.execPath,
+    [process.argv[1], "--client", JSON.stringify(task)],
+    {
+      stdio: ["ignore", "pipe", "inherit"],
+    },
+  );
+  log(`spawned client pid=${child.pid} probe=${task.probe}`);
+  return child;
+}
+
+function collectChild(child) {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.on("exit", () => {
+      try {
+        const jsonLine = stdout.trim().split("\n").at(-1);
+        resolve(JSON.parse(jsonLine));
+      } catch {
+        reject(new Error(`client output unparsable: ${stdout.slice(0, 200)}`));
+      }
+    });
+    child.on("error", reject);
+  });
+}
+
+// ─── Entry ────────────────────────────────────────────────────────────────
+const clientArgIndex = process.argv.indexOf("--client");
+if (clientArgIndex !== -1) {
+  await runClientChild(process.argv[clientArgIndex + 1]);
+  process.exit(0);
+}
+
+if (process.platform !== "win32") {
+  process.stderr.write(
+    "[poc] Windows-only probe. On other hosts this script is a no-op (exit 2).\n",
+  );
+  process.exit(2);
+}
+
+const PROBES = [
+  "acl-surface",
+  "enumerate-and-read",
+  "token-handshake",
+  "random-name-unreachable",
+];
+const report = {
+  script: "windows-named-pipe-acl.mjs",
+  platform: process.platform,
+  osRelease:
+    process.platform === "win32"
+      ? (process.env.OS ?? "Windows")
+      : process.platform,
+  nodeVersion: process.versions.node,
+  probes: {},
+};
+for (const probe of PROBES) {
+  log(`=== probe: ${probe} ===`);
+  report.probes[probe] = await runServerProbe(probe);
+}
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);


### PR DESCRIPTION
## What

#263 第一部分（可重复执行交付物）：

- `scripts/poc/windows-named-pipe-acl.mjs`：Windows named pipe 攻击面自包含探针。服务端+无关子进程客户端双进程设计，五个探针：
  - **P1 枚举**：仅凭前缀从 \\\\.\\pipe\\ 目录列举能否发现服务管道（决定「不可猜管道名」是否构成机密性控制）
  - **P2 未认证读**：无 token 直连能否读到服务端问候帧（默认 DACL 暴露面的直接测量）
  - **P3 ACL 控制面**：Node net.Server 公开 API 表面是否存在任何 security/DACL 成员（验证「Node 无法收紧 ACL」约束）
  - **P4 应用层 token 握手**：错 token / 缺 token 拒绝 + 正 token 放行的端到端证明（候选补偿控制）
  - **P5 基线**：未知 128 位管道名不可达
  - stdout 输出机器可读 JSON verdict；非 Windows 主机 exit 2 no-op
- `.github/workflows/poc-named-pipe.yml`：workflow_dispatch（手动触发，非发布门禁），windows-latest 运行探针并上传 verdict artifact

## 不改任何产品行为（纯 spike）

零 src/ 改动、零依赖变化、workflow 仅手动触发。

## 已知限制（诚实记录，将写入研究文档）

CI runner 单用户——跨**用户**读取无法在 CI 复现，将标记 UNVERIFIED；P1/P2 以无关进程（非无关用户）验证机制本身。跨用户残余风险在决策文档中按 Microsoft 文档佐证 + 保守假设处理。

## 后续

合入后 dispatch workflow 采集一手数据，第二笔 PR 交付研究文档 + 补偿控制 vs 回环 TCP 决策。

## 验证

node --check 通过、eslint 0 警告、prettier 通过；worktree 内 ci:check 10/11（唯一失败 test:python:unit 为 worktree 缺未跟踪 .venv 的环境问题，与本次 2 个文件无关——远端 CI Python 依赖步骤完整）。