### PR TITLE
refactor: 转写域服务化 — TRANSCRIBE_FILE/DIARIZE/MODELS.CHECK 收拢为无窗口服务函数 (Spec #258 #261, closes #261)

### DIFF
--- a/src/helpers/ipc/modelHandlers.ts
+++ b/src/helpers/ipc/modelHandlers.ts
@@ -1,5 +1,11 @@
 // [20260724_TS_BigBang_ModelHandlers] Migrated from .js to .ts (ADR-010).
 import * as C from "../ipc-contracts";
+// [20260912_Refactor_261_TranscriptionService] Ticket #261 (spec #258
+// Phase 0): the MODELS.CHECK engine-status probe moved into
+// checkEngineStatusService (src/helpers/services/transcriptionService.ts)
+// so it is callable without a renderer/window/sender. The handler stays a
+// thin shell that forwards its funasrManager via the deps bag.
+import { checkEngineStatusService } from "../services/transcriptionService";
 
 interface FunasrManager {
   checkModelFiles(): Promise<
@@ -20,7 +26,9 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   const { funasrManager } = managers;
 
   ipcMain.handle(C.MODELS.CHECK, async () => {
-    return await funasrManager.checkModelFiles();
+    // [20260912_Refactor_261_TranscriptionService] Thin shell delegating to
+    // the extracted service function (pure pass-through to checkModelFiles).
+    return await checkEngineStatusService({ funasrManager });
   });
 
   ipcMain.handle(C.MODELS.DOWNLOAD, async (event) => {

--- a/src/helpers/ipc/transcriptionHandlers.ts
+++ b/src/helpers/ipc/transcriptionHandlers.ts
@@ -9,76 +9,21 @@ import type { TranscriptionForExport } from "../exportFormatters";
 // the AI_REVIEW entry now passes its mode/template explicitly into the shared
 // polish orchestrator (aiHandlers), which owns prompt building.
 import { validateAudioPath } from "../audioPathValidator";
-import { cleanTranscriptionText } from "../transcriptCleaner";
-import { sanitizeHotwordInput } from "../hotwords";
-
-// [20260819_T10_CleanerWiring] Ticket #188 (spec #177 T10): clean ASR
-// output at the two transcription seams (mic AUDIO + file TRANSCRIBE_FILE).
-// The response carries CLEANED text/raw_text/segments (AI polish and the UI
-// consume cleaned content) PLUS original_text = the PRE-CLEAN text, which
-// the file path persists into the DB raw_text column and the mic path
-// forwards via the renderer — wrongly-folded text stays recoverable.
-// The generic SAVE channel and the AI review channel are deliberately NOT
-// cleaned (user edits / AI output must never be re-cleaned — locked by
-// tests). v1 cleaner rules are fold-only, so a non-empty input can never
-// clean to empty; the || original fail-safe below makes that invariant
-// hold even if future rules regress it.
-interface CleanableTranscriptionResult {
-  success?: boolean;
-  text?: string;
-  raw_text?: string;
-  original_text?: string;
-  segments?: Array<{ start_ms: number; end_ms: number; text: string }>;
-}
-
-function applyTranscriptionCleaning(result: unknown, logger: Logger): void {
-  const cleanable = result as CleanableTranscriptionResult | null;
-  if (!cleanable || !cleanable.success || !cleanable.text) return;
-
-  const originalText = cleanable.text;
-  const rawCleaned = cleanTranscriptionText(originalText);
-  // Fail-safe: a non-empty input must never clean to empty. v1 rules are
-  // fold-only (property-tested), so this is unreachable defensive depth —
-  // but if a future rule regresses the invariant, WARN loudly instead of
-  // silently no-op'ing. [T10 review fixup]
-  let cleanedText = rawCleaned;
-  if (!cleanedText) {
-    logger.warn?.("清洗产生空文本，回退原文（清洗器规则回归信号）", {
-      original: originalText,
-    });
-    cleanedText = originalText;
-  }
-  const cleanedRaw = cleanable.raw_text
-    ? cleanTranscriptionText(cleanable.raw_text) || cleanable.raw_text
-    : undefined;
-
-  if (
-    cleanedText !== originalText ||
-    (cleanedRaw !== undefined && cleanedRaw !== cleanable.raw_text)
-  ) {
-    logger.debug?.("转录文本清洗", {
-      before: originalText,
-      after: cleanedText,
-    });
-  }
-
-  cleanable.original_text = originalText;
-  cleanable.text = cleanedText;
-  if (cleanedRaw !== undefined) cleanable.raw_text = cleanedRaw;
-  if (Array.isArray(cleanable.segments)) {
-    cleanable.segments = cleanable.segments.map((seg) => ({
-      ...seg,
-      text: cleanTranscriptionText(seg.text) || seg.text,
-    }));
-  }
-}
-
-interface Logger {
-  info?(message: string, ...args: unknown[]): void;
-  warn?(message: string, ...args: unknown[]): void;
-  error?(message: string, ...args: unknown[]): void;
-  debug?(message: string, ...args: unknown[]): void;
-}
+// [20260912_Refactor_261_TranscriptionService] Ticket #261 (spec #258
+// Phase 0): the transcription-domain logic — the TRANSCRIBE_FILE body,
+// the DIARIZE body, the hotword injection/fallback helpers, and the
+// output cleaning — moved to src/helpers/services/transcriptionService.ts
+// so it can run without a renderer/window/sender. This handler file keeps
+// only channel registration, envelopes, and the event.sender progress
+// wiring (passed to the service as the optional onProgress callback).
+import {
+  applyTranscriptionCleaning,
+  diarizeTranscriptionService,
+  injectStoredHotwords,
+  transcribeFileService,
+  withHotwordFallback,
+  type Logger,
+} from "../services/transcriptionService";
 
 interface TranscriptionRow {
   text?: string;
@@ -136,6 +81,14 @@ interface FunasrManager {
   }>;
   cancelTranscription(): Promise<unknown>;
   diarizeAudio(audioPath: string, segments: unknown[]): Promise<unknown>;
+  // [20260912_Refactor_261_TranscriptionService] Echoed from the real
+  // manager surface (it already has this method — modelHandlers calls it):
+  // the extracted service's deps bag is typed with the full manager shape,
+  // so this interface must carry checkModelFiles for the deps object to be
+  // assignable. This handler itself never calls it.
+  checkModelFiles(): Promise<
+    { models_downloaded: boolean } & Record<string, unknown>
+  >;
 }
 
 type ProcessTextWithAI = (
@@ -157,86 +110,28 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   const { funasrManager, databaseManager, logger, processTextWithAI } =
     managers;
 
-  // [20260820_T14_Hotwords] Main-process hotword injection (preload/IPC
-  // signatures untouched): read the stored list, sanitize at this boundary,
-  // and inject into the request options. Empty/invalid → options returned
-  // as-is (no hotword field — byte-identical to pre-T14 traffic). An
-  // explicit caller-provided hotword wins over the stored list. A settings
-  // read failure must never block transcription.
-  const injectStoredHotwords = async (
-    options: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> => {
-    // [T14 review MINOR] Caller wins over the stored list, but does NOT
-    // bypass hygiene: an explicit hotword is sanitized too (a broken
-    // renderer must not feed garbage straight to the protocol). Identity
-    // is preserved when sanitizing is a no-op, so caller-hotword requests
-    // stay non-injected (no retry) as designed.
-    if (typeof options.hotword === "string" && options.hotword.trim()) {
-      const sanitized = sanitizeHotwordInput(options.hotword);
-      if (sanitized === options.hotword) return options;
-      if (!sanitized) {
-        const { hotword: _dropped, ...rest } = options;
-        return rest;
-      }
-      return { ...options, hotword: sanitized };
-    }
-    try {
-      const stored = await databaseManager.getSetting("hotwords");
-      const hotword = sanitizeHotwordInput(stored);
-      if (!hotword) return options;
-      return { ...options, hotword };
-    } catch (error) {
-      logger.warn?.("读取热词设置失败，跳过注入", error);
-      return options;
-    }
-  };
-
-  // [20260820_T14_Hotwords] Empty-hotword retry: if a hotword-injected
-  // request fails, retry ONCE with the original (hotword-free) options —
-  // a bad hotword list must not brick transcription. Success on the retry
-  // surfaces hotword_degraded=true so the UI can point at the settings.
-  // [T14 review BLOCKER] The real transcribeAudio THROWS on failure (only
-  // success resolves) — rejections are normalized here so the retry fires
-  // under the real contract, not just under {success:false} mocks.
-  // [T14 review MAJOR-1] A user CANCEL is never retryable: the Python
-  // entry clears cancel_event, so a retry would restart the transcription
-  // the user just aborted.
-  const withHotwordFallback = async (
-    baseOptions: Record<string, unknown>,
-    hotwordOptions: Record<string, unknown>,
-    run: (options: Record<string, unknown>) => Promise<unknown>,
-  ): Promise<unknown> => {
-    const normalize = async (p: Promise<unknown>): Promise<unknown> => {
-      try {
-        return await p;
-      } catch (error) {
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-    };
-    const injected = hotwordOptions !== baseOptions;
-    const first = await normalize(run(hotwordOptions));
-    if (!injected) return first;
-    if ((first as { canceled?: boolean }).canceled === true) return first;
-    const failed = !first || (first as { success?: boolean }).success === false;
-    if (!failed) return first;
-    logger.warn?.("热词转写失败，以空热词重试一次");
-    const retry = await normalize(run(baseOptions));
-    if (retry && (retry as { success?: boolean }).success) {
-      return { ...(retry as object), hotword_degraded: true };
-    }
-    return retry;
-  };
+  // [20260912_Refactor_261_TranscriptionService] Deps bag forwarded to the
+  // extracted service functions (they take collaborators as a parameter
+  // instead of closing over the managers — no renderer/window/sender
+  // dependency). The two hotword helper closures (injectStoredHotwords /
+  // withHotwordFallback) moved verbatim into
+  // src/helpers/services/transcriptionService.ts, now taking this bag as
+  // their first argument.
+  const transcriptionDeps = { funasrManager, databaseManager, logger };
 
   ipcMain.handle(
     C.TRANSCRIPTION.AUDIO,
     async (_event, audioData: unknown, options: unknown) => {
       // [20260820_T14_Hotwords] Mic seam: inject then run with fallback.
+      // [20260912_Refactor_261_TranscriptionService] The helpers are now
+      // imported from the service module; call shapes are unchanged.
       const baseOptions = (options ?? {}) as Record<string, unknown>;
-      const withHotword = await injectStoredHotwords(baseOptions);
+      const withHotword = await injectStoredHotwords(
+        transcriptionDeps,
+        baseOptions,
+      );
       const result = (await withHotwordFallback(
+        transcriptionDeps,
         baseOptions,
         withHotword,
         (opts) =>
@@ -313,57 +208,21 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   ipcMain.handle(
     C.TRANSCRIPTION.TRANSCRIBE_FILE,
     async (event, audioPath: string, options: Record<string, unknown> = {}) => {
-      const validation = validateAudioPath(audioPath);
-      if (!validation.valid) {
-        return { success: false, error: validation.error };
-      }
-      // [20260820_T14_Hotwords] File seam: same injection + fallback as the
-      // mic seam (hotwords apply to imports too — long files are where
-      // proper nouns live).
-      const baseOptions: Record<string, unknown> = {
-        ...options,
-        onProgress: (progress: unknown) => {
+      // [20260912_Refactor_261_TranscriptionService] Thin shell: validation,
+      // hotword injection/fallback, transcription, cleaning, and the DB
+      // persist moved into transcribeFileService unchanged. The only
+      // renderer coupling left here is the progress wiring — the
+      // event.sender.send closure is handed to the service as its optional
+      // onProgress callback (a headless caller would omit it; the returned
+      // result is unaffected).
+      return await transcribeFileService(
+        transcriptionDeps,
+        audioPath,
+        options,
+        (progress: unknown) => {
           event.sender.send(C.EVENTS.FILE_TRANSCRIPTION_PROGRESS, progress);
         },
-      };
-      const withHotword = await injectStoredHotwords(baseOptions);
-      // [20260820_T14_Hotwords] withHotwordFallback returns unknown; the
-      // file path below reads the transcription shape through this view.
-      const result = (await withHotwordFallback(
-        baseOptions,
-        withHotword,
-        (opts) =>
-          funasrManager.transcribeFile(audioPath, opts) as Promise<unknown>,
-      )) as CleanableTranscriptionResult & { id?: number; duration?: number };
-      // [20260819_T10_CleanerWiring] File seam: clean response (text /
-      // raw_text / segments), keep the pre-clean original for the DB.
-      applyTranscriptionCleaning(result, logger);
-
-      if (result.success && result.text) {
-        try {
-          // [20260819_T10_CleanerWiring] original_text is added by
-          // applyTranscriptionCleaning; read it through the typed view.
-          const dbResult = databaseManager.saveTranscription({
-            text: result.text,
-            // [20260819_T10_CleanerWiring] raw_text column keeps the
-            // PRE-CLEAN text (recovery); processed_text keeps the cleaned
-            // raw output (previously this column stored the uncleaned raw).
-            raw_text: result.original_text || null,
-            processed_text: result.raw_text || result.text,
-            source_type: "file",
-            source_file_path: audioPath,
-            segments: result.segments ? JSON.stringify(result.segments) : null,
-            duration: result.duration || null,
-          });
-          if (dbResult && dbResult.lastInsertRowid) {
-            result.id = Number(dbResult.lastInsertRowid);
-          }
-        } catch (dbErr) {
-          logger.error?.("保存转录结果到数据库失败:", dbErr);
-        }
-      }
-
-      return result;
+      );
     },
   );
 
@@ -372,30 +231,11 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   });
 
   ipcMain.handle(C.TRANSCRIPTION.DIARIZE, async (_event, id: number) => {
-    try {
-      const row = databaseManager.getTranscriptionById(id);
-      if (!row) return { success: false, error: "转录记录不存在" };
-
-      let segments: unknown[] = [];
-      if (row.segments) {
-        try {
-          segments = JSON.parse(row.segments);
-        } catch {}
-      }
-      if (!segments.length) return { success: false, error: "无分段数据" };
-
-      const audioPath = row.source_file_path || row.audio_path;
-      if (!audioPath) return { success: false, error: "音频文件不存在" };
-
-      const result = await funasrManager.diarizeAudio(
-        audioPath,
-        segments as unknown[],
-      );
-      return result;
-    } catch (err) {
-      logger.error?.("说话人分离失败:", err);
-      return { success: false, error: (err as Error).message };
-    }
+    // [20260912_Refactor_261_TranscriptionService] Thin shell: the record
+    // lookup, segments JSON parsing, audio-path resolution, and the
+    // diarizeAudio delegation moved into diarizeTranscriptionService
+    // unchanged (same {success:false, error} envelopes).
+    return await diarizeTranscriptionService(transcriptionDeps, id);
   });
 
   ipcMain.handle(

--- a/src/helpers/services/transcriptionService.ts
+++ b/src/helpers/services/transcriptionService.ts
@@ -1,0 +1,389 @@
+// [20260912_Refactor_261_TranscriptionService] Ticket #261 (spec #258
+// Phase 0 — 转写域服务化): transcription-domain service extraction. The
+// TRANSCRIBE_FILE and DIARIZE handler bodies (transcriptionHandlers.ts)
+// and the MODELS.CHECK engine-status probe (modelHandlers.ts) move here
+// as plain main-process functions that receive every collaborator through
+// a `TranscriptionServiceDeps` bag and depend on NO renderer, window, or
+// event sender. The IPC handlers stay thin shells: same channels, same
+// envelopes, with the `event.sender.send` progress wiring translated into
+// this module's optional `onProgress` callback (a sender-less caller
+// simply omits it; the returned result is unaffected). Behavior is
+// byte-identical to the pre-extraction handlers — locked by the
+// unmodified tests/unit/transcriptionHandlers.test.ts; new headless seam
+// coverage lives in tests/unit/transcriptionService.test.ts. Comments and
+// log strings copied from the handlers are kept verbatim (Chinese log
+// strings are pre-existing diagnostics).
+
+import { validateAudioPath } from "../audioPathValidator";
+import { cleanTranscriptionText } from "../transcriptCleaner";
+import { sanitizeHotwordInput } from "../hotwords";
+
+// [20260912_Refactor_261_TranscriptionService] Structural types echoed
+// from the handler files — the minimal surface the services touch. No
+// Electron types here: the seam exists so these functions run headless
+// (background jobs, tests) with plain mock deps.
+
+/** Logger surface used for diagnostics; every method is optional. */
+export interface Logger {
+  info?(message: string, ...args: unknown[]): void;
+  warn?(message: string, ...args: unknown[]): void;
+  error?(message: string, ...args: unknown[]): void;
+  debug?(message: string, ...args: unknown[]): void;
+}
+
+/** DB row subset read by the diarize service (diagnostics fields omitted). */
+interface TranscriptionRow {
+  segments?: string;
+  source_file_path?: string;
+  audio_path?: string;
+  [key: string]: unknown;
+}
+
+/** Collaborator bag injected into every service function below. */
+export interface TranscriptionServiceDeps {
+  funasrManager: {
+    transcribeFile(
+      audioPath: string,
+      options: Record<string, unknown>,
+    ): Promise<{
+      success: boolean;
+      text?: string;
+      raw_text?: string;
+      segments?: unknown[];
+      duration?: number;
+      id?: number | bigint;
+    }>;
+    diarizeAudio(audioPath: string, segments: unknown[]): Promise<unknown>;
+    checkModelFiles(): Promise<
+      { models_downloaded: boolean } & Record<string, unknown>
+    >;
+  };
+  databaseManager: {
+    saveTranscription(data: Record<string, unknown>): {
+      lastInsertRowid?: number | bigint;
+      changes?: number;
+    };
+    // Synchronous settings read (hotword injection).
+    getSetting(key: string, defaultValue?: unknown): unknown;
+    getTranscriptionById(id: number): TranscriptionRow | null;
+  };
+  logger: Logger;
+}
+// [20260912_Refactor_261_TranscriptionService] END
+
+// [20260912_Refactor_261_TranscriptionService] Moved verbatim from
+// transcriptionHandlers.ts (was the [20260819_T10_CleanerWiring] block).
+// Ticket #188 (spec #177 T10): clean ASR output at the two transcription
+// seams (mic AUDIO + file TRANSCRIBE_FILE). The response carries CLEANED
+// text/raw_text/segments (AI polish and the UI consume cleaned content)
+// PLUS original_text = the PRE-CLEAN text, which the file path persists
+// into the DB raw_text column and the mic path forwards via the renderer
+// — wrongly-folded text stays recoverable. The generic SAVE channel and
+// the AI review channel are deliberately NOT cleaned (user edits / AI
+// output must never be re-cleaned — locked by tests). v1 cleaner rules
+// are fold-only, so a non-empty input can never clean to empty; the
+// || original fail-safe below makes that invariant hold even if future
+// rules regress it.
+interface CleanableTranscriptionResult {
+  success?: boolean;
+  text?: string;
+  raw_text?: string;
+  original_text?: string;
+  segments?: Array<{ start_ms: number; end_ms: number; text: string }>;
+}
+
+export function applyTranscriptionCleaning(
+  result: unknown,
+  logger: Logger,
+): void {
+  const cleanable = result as CleanableTranscriptionResult | null;
+  if (!cleanable || !cleanable.success || !cleanable.text) return;
+
+  const originalText = cleanable.text;
+  const rawCleaned = cleanTranscriptionText(originalText);
+  // Fail-safe: a non-empty input must never clean to empty. v1 rules are
+  // fold-only (property-tested), so this is unreachable defensive depth —
+  // but if a future rule regresses the invariant, WARN loudly instead of
+  // silently no-op'ing. [T10 review fixup]
+  let cleanedText = rawCleaned;
+  if (!cleanedText) {
+    logger.warn?.("清洗产生空文本，回退原文（清洗器规则回归信号）", {
+      original: originalText,
+    });
+    cleanedText = originalText;
+  }
+  const cleanedRaw = cleanable.raw_text
+    ? cleanTranscriptionText(cleanable.raw_text) || cleanable.raw_text
+    : undefined;
+
+  if (
+    cleanedText !== originalText ||
+    (cleanedRaw !== undefined && cleanedRaw !== cleanable.raw_text)
+  ) {
+    logger.debug?.("转录文本清洗", {
+      before: originalText,
+      after: cleanedText,
+    });
+  }
+
+  cleanable.original_text = originalText;
+  cleanable.text = cleanedText;
+  if (cleanedRaw !== undefined) cleanable.raw_text = cleanedRaw;
+  if (Array.isArray(cleanable.segments)) {
+    cleanable.segments = cleanable.segments.map((seg) => ({
+      ...seg,
+      text: cleanTranscriptionText(seg.text) || seg.text,
+    }));
+  }
+}
+// [20260912_Refactor_261_TranscriptionService] END
+
+// [20260912_Refactor_261_TranscriptionService] The two hotword helpers
+// moved verbatim from inside transcriptionHandlers.register() (the
+// [20260820_T14_Hotwords] closures) — they are domain logic, so they
+// live in the service module now and take `deps` instead of closing
+// over the managers bag. END
+
+/**
+ * Main-process hotword injection (preload/IPC signatures untouched):
+ * read the stored list, sanitize at this boundary, and inject into the
+ * request options. Empty/invalid → options returned as-is (no hotword
+ * field — byte-identical to pre-T14 traffic). An explicit caller-provided
+ * hotword wins over the stored list. A settings read failure must never
+ * block transcription.
+ */
+export async function injectStoredHotwords(
+  // [20260912_Fix_261_Review_DepsSlices] Review MINOR: each service takes
+  // only the deps slice it uses (indexed-access Picks), so a headless
+  // hotword-only caller can supply just the settings reader + logger.
+  deps: {
+    databaseManager: Pick<
+      TranscriptionServiceDeps["databaseManager"],
+      "getSetting"
+    >;
+    logger: Logger;
+  },
+  options: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const { databaseManager, logger } = deps;
+  // [T14 review MINOR] Caller wins over the stored list, but does NOT
+  // bypass hygiene: an explicit hotword is sanitized too (a broken
+  // renderer must not feed garbage straight to the protocol). Identity
+  // is preserved when sanitizing is a no-op, so caller-hotword requests
+  // stay non-injected (no retry) as designed.
+  if (typeof options.hotword === "string" && options.hotword.trim()) {
+    const sanitized = sanitizeHotwordInput(options.hotword);
+    if (sanitized === options.hotword) return options;
+    if (!sanitized) {
+      const { hotword: _dropped, ...rest } = options;
+      return rest;
+    }
+    return { ...options, hotword: sanitized };
+  }
+  try {
+    const stored = await databaseManager.getSetting("hotwords");
+    const hotword = sanitizeHotwordInput(stored);
+    if (!hotword) return options;
+    return { ...options, hotword };
+  } catch (error) {
+    logger.warn?.("读取热词设置失败，跳过注入", error);
+    return options;
+  }
+}
+
+/**
+ * Empty-hotword retry: if a hotword-injected request fails, retry ONCE
+ * with the original (hotword-free) options — a bad hotword list must not
+ * brick transcription. Success on the retry surfaces hotword_degraded=true
+ * so the UI can point at the settings.
+ *
+ * [T14 review BLOCKER] The real transcribeAudio THROWS on failure (only
+ * success resolves) — rejections are normalized here so the retry fires
+ * under the real contract, not just under {success:false} mocks.
+ *
+ * [T14 review MAJOR-1] A user CANCEL is never retryable: the Python
+ * entry clears cancel_event, so a retry would restart the transcription
+ * the user just aborted.
+ */
+export async function withHotwordFallback(
+  // [20260912_Fix_261_Review_DepsSlices] Retry orchestration needs the
+  // logger only.
+  deps: { logger: Logger },
+  baseOptions: Record<string, unknown>,
+  hotwordOptions: Record<string, unknown>,
+  run: (options: Record<string, unknown>) => Promise<unknown>,
+): Promise<unknown> {
+  const { logger } = deps;
+  const normalize = async (p: Promise<unknown>): Promise<unknown> => {
+    try {
+      return await p;
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  };
+  const injected = hotwordOptions !== baseOptions;
+  const first = await normalize(run(hotwordOptions));
+  if (!injected) return first;
+  if ((first as { canceled?: boolean }).canceled === true) return first;
+  const failed = !first || (first as { success?: boolean }).success === false;
+  if (!failed) return first;
+  logger.warn?.("热词转写失败，以空热词重试一次");
+  const retry = await normalize(run(baseOptions));
+  if (retry && (retry as { success?: boolean }).success) {
+    return { ...(retry as object), hotword_degraded: true };
+  }
+  return retry;
+}
+// [20260912_Refactor_261_TranscriptionService] END
+
+/**
+ * File transcription pipeline (the TRANSCRIBE_FILE handler body):
+ * validate → hotword injection + fallback → transcription → cleaning →
+ * DB persist. `onProgress` is OPTIONAL — the IPC handler passes the
+ * `event.sender.send` wiring; headless callers omit it entirely (the
+ * progress callback never affects the returned result).
+ */
+export async function transcribeFileService(
+  // [20260912_Fix_261_Review_DepsSlices] Review MINOR: the file seam uses
+  // transcribeFile + settings/save reads only — no diarize/checkModelFiles
+  // surface required from callers.
+  deps: {
+    funasrManager: Pick<
+      TranscriptionServiceDeps["funasrManager"],
+      "transcribeFile"
+    >;
+    databaseManager: Pick<
+      TranscriptionServiceDeps["databaseManager"],
+      "getSetting" | "saveTranscription"
+    >;
+    logger: Logger;
+  },
+  audioPath: string,
+  options: Record<string, unknown> = {},
+  onProgress?: (progress: unknown) => void,
+): Promise<unknown> {
+  const { funasrManager, databaseManager, logger } = deps;
+  const validation = validateAudioPath(audioPath);
+  if (!validation.valid) {
+    return { success: false, error: validation.error };
+  }
+  // [20260912_Refactor_261_TranscriptionService] The handler built
+  // `baseOptions` with an inline `event.sender.send` progress callback.
+  // The sender coupling now stays in the handler: onProgress is merged
+  // into baseOptions here ONLY when provided, so sender-less callers
+  // get byte-identical options to a handler call minus the callback.
+  // [20260820_T14_Hotwords] File seam: same injection + fallback as the
+  // mic seam (hotwords apply to imports too — long files are where
+  // proper nouns live).
+  const baseOptions: Record<string, unknown> = { ...options };
+  if (onProgress) {
+    baseOptions.onProgress = onProgress;
+  }
+  const withHotword = await injectStoredHotwords(deps, baseOptions);
+  // [20260820_T14_Hotwords] withHotwordFallback returns unknown; the
+  // file path below reads the transcription shape through this view.
+  const result = (await withHotwordFallback(
+    deps,
+    baseOptions,
+    withHotword,
+    (opts) => funasrManager.transcribeFile(audioPath, opts) as Promise<unknown>,
+  )) as CleanableTranscriptionResult & { id?: number; duration?: number };
+  // [20260819_T10_CleanerWiring] File seam: clean response (text /
+  // raw_text / segments), keep the pre-clean original for the DB.
+  applyTranscriptionCleaning(result, logger);
+
+  if (result.success && result.text) {
+    try {
+      // [20260819_T10_CleanerWiring] original_text is added by
+      // applyTranscriptionCleaning; read it through the typed view.
+      const dbResult = databaseManager.saveTranscription({
+        text: result.text,
+        // [20260819_T10_CleanerWiring] raw_text column keeps the
+        // PRE-CLEAN text (recovery); processed_text keeps the cleaned
+        // raw output (previously this column stored the uncleaned raw).
+        raw_text: result.original_text || null,
+        processed_text: result.raw_text || result.text,
+        source_type: "file",
+        source_file_path: audioPath,
+        segments: result.segments ? JSON.stringify(result.segments) : null,
+        duration: result.duration || null,
+      });
+      if (dbResult && dbResult.lastInsertRowid) {
+        result.id = Number(dbResult.lastInsertRowid);
+      }
+    } catch (dbErr) {
+      logger.error?.("保存转录结果到数据库失败:", dbErr);
+    }
+  }
+
+  return result;
+}
+// [20260912_Refactor_261_TranscriptionService] END
+
+/**
+ * Speaker diarization (the DIARIZE handler body): load the record, parse
+ * its stored segments JSON, resolve the audio path, delegate to the ASR
+ * engine. Errors surface through the same {success:false, error} envelope.
+ */
+export async function diarizeTranscriptionService(
+  // [20260912_Fix_261_Review_DepsSlices] Review MINOR: diarization needs
+  // only the record reader and the ASR diarize entry.
+  deps: {
+    funasrManager: Pick<
+      TranscriptionServiceDeps["funasrManager"],
+      "diarizeAudio"
+    >;
+    databaseManager: Pick<
+      TranscriptionServiceDeps["databaseManager"],
+      "getTranscriptionById"
+    >;
+    logger: Logger;
+  },
+  id: number,
+): Promise<unknown> {
+  const { funasrManager, databaseManager, logger } = deps;
+  try {
+    const row = databaseManager.getTranscriptionById(id);
+    if (!row) return { success: false, error: "转录记录不存在" };
+
+    let segments: unknown[] = [];
+    if (row.segments) {
+      try {
+        segments = JSON.parse(row.segments);
+      } catch {}
+    }
+    if (!segments.length) return { success: false, error: "无分段数据" };
+
+    const audioPath = row.source_file_path || row.audio_path;
+    if (!audioPath) return { success: false, error: "音频文件不存在" };
+
+    const result = await funasrManager.diarizeAudio(
+      audioPath,
+      segments as unknown[],
+    );
+    return result;
+  } catch (err) {
+    logger.error?.("说话人分离失败:", err);
+    return { success: false, error: (err as Error).message };
+  }
+}
+// [20260912_Refactor_261_TranscriptionService] END
+
+/**
+ * Engine status probe (the MODELS.CHECK handler body): a pure pass-through
+ * to funasrManager.checkModelFiles(), callable without a renderer/sender.
+ * Takes only the checkModelFiles slice of the manager — callers carry the
+ * rest of the surface (e.g. downloadModels in modelHandlers) untouched.
+ */
+export async function checkEngineStatusService(deps: {
+  funasrManager: Pick<
+    TranscriptionServiceDeps["funasrManager"],
+    "checkModelFiles"
+  >;
+}): Promise<{ models_downloaded: boolean } & Record<string, unknown>> {
+  return await deps.funasrManager.checkModelFiles();
+}
+// [20260912_Refactor_261_TranscriptionService] END

--- a/tests/unit/transcriptionService.test.ts
+++ b/tests/unit/transcriptionService.test.ts
@@ -1,0 +1,236 @@
+// [20260912_Refactor_261_TranscriptionService] Seam tests for the
+// transcription-domain services extracted in ticket #261 (spec #258
+// Phase 0). Deps are plain vi.fn() bags — no Electron import anywhere:
+// the point of the seam is that transcribeFileService /
+// diarizeTranscriptionService / checkEngineStatusService run headless.
+// Behavior parity with the IPC handlers is locked by the unmodified
+// tests/unit/transcriptionHandlers.test.ts.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// [20260912_Refactor_261_TranscriptionService] The pure helpers are mocked
+// for determinism (same pattern as transcriptionHandlers.test.ts): path
+// validation is controlled per-test, the cleaner is identity. The hotword
+// sanitizer is used FOR REAL — its trim/control-char rules are part of the
+// injection contract under test.
+vi.mock("../../src/helpers/audioPathValidator", () => ({
+  validateAudioPath: vi.fn(() => ({
+    valid: true,
+    ext: ".wav",
+    resolved: "/fake/path.wav",
+  })),
+}));
+
+vi.mock("../../src/helpers/transcriptCleaner", () => ({
+  cleanTranscriptionText: (text: string) => text,
+}));
+
+import { validateAudioPath } from "../../src/helpers/audioPathValidator";
+import {
+  checkEngineStatusService,
+  diarizeTranscriptionService,
+  transcribeFileService,
+  type TranscriptionServiceDeps,
+} from "../../src/helpers/services/transcriptionService";
+
+// [20260912_Refactor_261_TranscriptionService] Loosely-typed mocks
+// (ReturnType<typeof vi.fn>, the established pattern in
+// transcriptionHandlers.test.ts) so per-test overrides like
+// mockResolvedValueOnce / mockRejectedValueOnce typecheck without `any`.
+type MockFn = ReturnType<typeof vi.fn>;
+
+interface MockDeps {
+  funasrManager: {
+    transcribeFile: MockFn;
+    diarizeAudio: MockFn;
+    checkModelFiles: MockFn;
+  };
+  databaseManager: {
+    saveTranscription: MockFn;
+    getSetting: MockFn;
+    getTranscriptionById: MockFn;
+  };
+  logger: Record<string, MockFn>;
+}
+
+describe("transcriptionService (headless seam, ticket #261)", () => {
+  let deps: TranscriptionServiceDeps;
+  let mockDeps: MockDeps;
+
+  beforeEach(() => {
+    mockDeps = {
+      funasrManager: {
+        transcribeFile: vi.fn(async () => ({
+          success: true,
+          text: "文件转录",
+          raw_text: "raw",
+          segments: [],
+        })),
+        diarizeAudio: vi.fn(async () => ({ success: true })),
+        checkModelFiles: vi.fn(async () => ({ models_downloaded: true })),
+      },
+      databaseManager: {
+        saveTranscription: vi.fn(() => ({ lastInsertRowid: 42n, changes: 1 })),
+        getSetting: vi.fn(() => null),
+        getTranscriptionById: vi.fn(() => null),
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    };
+    // [20260912_Refactor_261_TranscriptionService] `unknown` bridge (no
+    // `any`), the established pattern from modelHandlers.test.ts: the
+    // loosely-typed vi.fn mocks are structurally stubbed, not the full
+    // production types.
+    deps = mockDeps as unknown as TranscriptionServiceDeps;
+  });
+
+  describe("transcribeFileService", () => {
+    it("rejects an invalid audio path without touching funasrManager", async () => {
+      vi.mocked(validateAudioPath).mockReturnValueOnce({
+        valid: false,
+        error: "非法路径",
+      });
+      const result = (await transcribeFileService(
+        deps,
+        "/bad/path.xyz",
+      )) as Record<string, unknown>;
+      expect(result).toEqual({ success: false, error: "非法路径" });
+      expect(mockDeps.funasrManager.transcribeFile).not.toHaveBeenCalled();
+      expect(mockDeps.databaseManager.saveTranscription).not.toHaveBeenCalled();
+    });
+
+    it("sanitizes and injects the stored hotword into transcribeFile options", async () => {
+      mockDeps.databaseManager.getSetting.mockReturnValue("  张三  ");
+      await transcribeFileService(deps, "/fake/audio.wav");
+      const opts = mockDeps.funasrManager.transcribeFile.mock
+        .calls[0]![1] as Record<string, unknown>;
+      expect(opts.hotword).toBe("张三");
+      expect(mockDeps.databaseManager.getSetting).toHaveBeenCalledWith(
+        "hotwords",
+      );
+    });
+
+    it("retries once without the hotword on failure and flags hotword_degraded", async () => {
+      mockDeps.databaseManager.getSetting.mockReturnValue("张三");
+      mockDeps.funasrManager.transcribeFile
+        .mockRejectedValueOnce(new Error("hotword boom"))
+        .mockResolvedValueOnce({
+          success: true,
+          text: "重试成功",
+          raw_text: "r",
+          segments: [],
+        });
+      const result = (await transcribeFileService(deps, "/fake/audio.wav")) as {
+        success: boolean;
+        text?: string;
+        hotword_degraded?: boolean;
+      };
+      expect(mockDeps.funasrManager.transcribeFile).toHaveBeenCalledTimes(2);
+      const firstOpts = mockDeps.funasrManager.transcribeFile.mock
+        .calls[0]![1] as Record<string, unknown>;
+      const secondOpts = mockDeps.funasrManager.transcribeFile.mock
+        .calls[1]![1] as Record<string, unknown>;
+      expect(firstOpts.hotword).toBe("张三");
+      expect(secondOpts).not.toHaveProperty("hotword");
+      expect(result.success).toBe(true);
+      expect(result.text).toBe("重试成功");
+      expect(result.hotword_degraded).toBe(true);
+    });
+
+    it("wires a provided onProgress callback into transcribeFile options", async () => {
+      const onProgress = vi.fn();
+      await transcribeFileService(deps, "/fake/audio.wav", {}, onProgress);
+      const opts = mockDeps.funasrManager.transcribeFile.mock.calls[0]![1] as {
+        onProgress?: unknown;
+      };
+      expect(opts.onProgress).toBe(onProgress);
+    });
+
+    it("completes without onProgress and persists the result with the DB rowid", async () => {
+      const segments = [{ start_ms: 0, end_ms: 1, text: "段落" }];
+      mockDeps.funasrManager.transcribeFile.mockResolvedValueOnce({
+        success: true,
+        text: "正文",
+        raw_text: "原始",
+        segments,
+        duration: 3.2,
+      });
+      const result = (await transcribeFileService(deps, "/fake/audio.wav")) as {
+        success: boolean;
+        id?: number;
+        text?: string;
+        original_text?: string;
+      };
+      const opts = mockDeps.funasrManager.transcribeFile.mock
+        .calls[0]![1] as Record<string, unknown>;
+      // Sender-less scenario: no progress callback reaches the engine.
+      expect(opts).not.toHaveProperty("onProgress");
+      expect(mockDeps.databaseManager.saveTranscription).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "正文",
+          raw_text: "正文",
+          processed_text: "原始",
+          source_type: "file",
+          source_file_path: "/fake/audio.wav",
+          segments: JSON.stringify(segments),
+          duration: 3.2,
+        }),
+      );
+      expect(result.success).toBe(true);
+      expect(result.id).toBe(42); // Number(lastInsertRowid: 42n)
+      expect(result.original_text).toBe("正文");
+    });
+  });
+
+  describe("diarizeTranscriptionService", () => {
+    it("returns an error when the transcription record does not exist", async () => {
+      const result = (await diarizeTranscriptionService(deps, 999)) as Record<
+        string,
+        unknown
+      >;
+      expect(result).toEqual({ success: false, error: "转录记录不存在" });
+      expect(mockDeps.funasrManager.diarizeAudio).not.toHaveBeenCalled();
+    });
+
+    it("returns an error when the record has no usable segments", async () => {
+      mockDeps.databaseManager.getTranscriptionById.mockReturnValueOnce({
+        id: 7,
+        text: "x",
+        segments: "[]",
+      });
+      const result = (await diarizeTranscriptionService(deps, 7)) as Record<
+        string,
+        unknown
+      >;
+      expect(result).toEqual({ success: false, error: "无分段数据" });
+      expect(mockDeps.funasrManager.diarizeAudio).not.toHaveBeenCalled();
+    });
+
+    it("diarizes with the stored audio path and parsed segments", async () => {
+      const segments = [{ start_ms: 0, end_ms: 1, text: "x" }];
+      mockDeps.databaseManager.getTranscriptionById.mockReturnValueOnce({
+        id: 7,
+        segments: JSON.stringify(segments),
+        source_file_path: "/a.wav",
+      });
+      const result = await diarizeTranscriptionService(deps, 7);
+      expect(mockDeps.funasrManager.diarizeAudio).toHaveBeenCalledWith(
+        "/a.wav",
+        segments,
+      );
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe("checkEngineStatusService", () => {
+    it("passes the engine status through from funasrManager.checkModelFiles", async () => {
+      const status = {
+        models_downloaded: true,
+        models: [{ name: "paraformer" }],
+      };
+      mockDeps.funasrManager.checkModelFiles.mockResolvedValueOnce(status);
+      const result = await checkEngineStatusService(deps);
+      expect(result).toEqual(status);
+      expect(mockDeps.funasrManager.checkModelFiles).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+// [20260912_Refactor_261_TranscriptionService] END


### PR DESCRIPTION
## What

Spec #258 Phase 0 前置重构：文件转写 / 说话人分离 / 引擎状态从 IPC handler 收拢为不依赖渲染进程/窗口/事件发送者的服务函数（`src/helpers/services/transcriptionService.ts`），handler 变薄壳。GUI 行为零变化。

## 接缝设计

- **进度回调**：`event.sender.send` 闭包留在 handler，作为可选 `onProgress` 参数传入服务；缺省时 options 不含该键（`funasrServer.ts` 对 absent/undefined/null 等价处理，已核实）——满足 AC「无事件发送者场景可缺省」
- **deps 切片**：各服务按 `Pick<TranscriptionServiceDeps[key], ...>` 只声明所需能力面，无窗口的 diarize-only 调用方无需 stub 转写方法
- 热词注入/降级重试/清洗器（T14/T10 逻辑）整体移入服务，中文日志串逐字保留

## 行为锁定（AC）

- 既有 `transcriptionHandlers.test.ts` **零修改**（`git diff HEAD` 为空），71 用例全绿
- 新增服务级测试 9 用例（无 electron 导入——接缝价值本身）
- 评审以空白归一化 diff 机械核对移动代码：清洗器/热词助手/TRANSCRIBE_FILE/DIARIZE 逐字节一致（含错误串、null 处理、spread 顺序、Number() 归一）

## 独立 code-review

APPROVE（0 MAJOR / 2 MINOR / 2 NIT）：MINOR-1 deps 过宽已修（Pick 切片）；MINOR-2 服务级边界测试（canceled 短路、重试双败等）评审确认可延后——handler 级 `hotword-injection.test.ts` 经薄壳覆盖同一代码路径，随 #262 补；NIT 空 catch 为 HEAD 原样保留（surgical 规则）。

## 风险声明

- 移动式重构主要风险是行为漂移——已用机械 diff + 零修改既有测试双保险
- `FunasrManager` 局部接口增补 `checkModelFiles` 成员（真实 manager 本就有）：仅为 deps bag 结构相容，handler 不调用

## 验证

vitest 92 相关用例全绿（71 既有 + 9 服务 + 12 关联）；`pnpm lint`/`typecheck`/`typecheck:tests` 全过

Closes #261