### PR TITLE
refactor: AI 与历史写域服务化 — 收拢为无窗口服务函数 (Spec #258 #262, closes #262)

### DIFF
--- a/src/helpers/ipc/aiHandlers.ts
+++ b/src/helpers/ipc/aiHandlers.ts
@@ -29,6 +29,27 @@ import {
   joinChunkOutputs,
   splitIntoChunks,
 } from "../polish-chunking";
+// [20260912_Refactor_262_AiHistoryService] Ticket #262 (spec #258 Phase 0):
+// the AI-domain service seam lives in src/helpers/services/aiService.ts —
+// the requestId→AbortController registry (POLISH_ABORT semantics), the
+// PROCESS entry wiring (processPolishText, with THIS module's
+// runPolishOrchestrator injected as `runPolish`), the provider model
+// listing, and the shared SSRF gate (moved verbatim). The handlers below
+// stay thin shells; the HIGH-RISK streaming/deadline-matrix pipeline is
+// untouched. Dependency direction is one-way: this module imports the
+// service (type-only imports in the reverse direction are erased).
+import {
+  createStreamAbortRegistry,
+  isLocalBaseUrl,
+  listProviderModels,
+  processPolishText,
+  validateAIBaseUrl,
+} from "../services/aiService";
+// [20260912_Refactor_262_AiHistoryService] Public contract preserved:
+// validateAIBaseUrl now lives in aiService (verbatim move) and is
+// re-exported because existing modules/tests import it from here.
+export { validateAIBaseUrl };
+// [20260912_Refactor_262_AiHistoryService] END
 
 interface Logger {
   info?(message: string, ...args: unknown[]): void;
@@ -157,73 +178,10 @@ export function getAIModes(templatesDir: string): AIMode[] {
   ];
 }
 
-function isLocalhost(host: string | null | undefined): boolean {
-  if (!host) return false;
-  host = host.toLowerCase();
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
-  if (host === "0.0.0.0" || host === "::1" || host === "[::1]") return true;
-  if (/^127\./.test(host)) return true;
-  return false;
-}
-
-// [20260907_Fix_233_SsrfHardening] Security-review MEDIUM: the IPv4-text
-// checks missed IPv4-mapped IPv6 (::ffff:a00:1), IPv6 ULA fc00::/7,
-// link-local fe80::/10, loopback ::/128, and CGNAT 100.64.0.0/10 — all
-// resolve to private/internal addresses while canonicalizing to hostnames
-// that matched no regex. Bracket stripping + mapped-address reduction close
-// the gap for every AI channel that shares this gate.
-function isPrivateNetwork(host: string): boolean {
-  if (!host) return false;
-  const bare = host.replace(/^\[|\]$/g, "").toLowerCase();
-  if (bare === "::1" || bare === "::") return true;
-  const mapped = bare.match(/^::ffff:(.+)$/);
-  if (mapped) {
-    // WHATWG canonicalizes mapped addresses to hex form ([::ffff:a00:1]);
-    // convert the trailing 32 bits back to dotted-decimal for the IPv4
-    // checks below.
-    const hex = mapped[1]!.match(/^([0-9a-f]+):([0-9a-f]+)$/);
-    if (hex) {
-      const hi = parseInt(hex[1]!, 16);
-      const lo = parseInt(hex[2]!, 16);
-      return isPrivateNetwork(
-        `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`,
-      );
-    }
-    return isPrivateNetwork(mapped[1]!);
-  }
-  if (/^f[cd][0-9a-f]{2}:/.test(bare)) return true; // IPv6 ULA fc00::/7
-  if (/^fe[89ab][0-9a-f]:/.test(bare)) return true; // IPv6 link-local
-  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(bare)) return true; // CGNAT
-  if (/^198\.(1[89]|0)\./.test(bare)) return true; // benchmark 198.18.0.0/15
-  if (/^10\./.test(bare)) return true;
-  if (/^192\.168\./.test(bare)) return true;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(bare)) return true;
-  if (/^169\.254\./.test(bare)) return true;
-  if (/^127\./.test(bare)) return true;
-  return false;
-}
-
-export function validateAIBaseUrl(
-  baseUrl: string,
-  { allowLocalhost = false }: { allowLocalhost?: boolean } = {},
-): boolean {
-  try {
-    const url = new URL(baseUrl);
-    const host = url.hostname.toLowerCase();
-    if (!host) return false;
-
-    if (allowLocalhost && isLocalhost(host)) {
-      return url.protocol === "http:" || url.protocol === "https:";
-    }
-
-    if (url.protocol !== "https:") return false;
-    if (isLocalhost(host)) return false;
-    if (isPrivateNetwork(host)) return false;
-    return true;
-  } catch {
-    return false;
-  }
-}
+// [20260912_Refactor_262_AiHistoryService] isLocalhost / isPrivateNetwork /
+// validateAIBaseUrl / isLocalBaseUrl moved verbatim to
+// src/helpers/services/aiService.ts (the SSRF gate shared by every AI
+// channel); validateAIBaseUrl is re-exported above. END
 
 // [20260815_Refactor_AiFetchDedup] processTextWithAI and checkAIStatus used
 // to hand-roll the same sequence: auth headers, AbortController + timeout,
@@ -233,41 +191,12 @@ export function validateAIBaseUrl(
 // user-facing error text).
 // [20260815_Refactor_AiFetchDedup] END
 
-// [20260907_Feat_233_ListModels] Ticket #233: derive the /models endpoint
-// from the base URL with the URL constructor only — never whole-URL string
-// concatenation. Bases that already end in a version segment get exactly
-// one candidate ({base}/models); other bases try {base}/models first and
-// {base}/v1/models second (the common "no /v1 in base_url" gateway shape).
-function modelEndpointCandidates(baseUrl: string): string[] {
-  const url = new URL(baseUrl);
-  const basePath = url.pathname.replace(/\/+$/, "");
-  const withPath = (suffix: string) => {
-    const derived = new URL(baseUrl);
-    derived.pathname = basePath + suffix;
-    return derived.toString();
-  };
-  if (/\/v\d+$/.test(basePath)) {
-    return [withPath("/models")];
-  }
-  return [withPath("/models"), withPath("/v1/models")];
-}
-
-// [20260907_Feat_233_ListModels] Response contract for the provider /models
-// listing. Anything outside the shape silently degrades the renderer to the
-// manual-input path (ticket #233: 非法即静默回退手输).
-const MODELS_MAX_ITEMS = 500;
-const MODELS_MAX_ID_BYTES = 200;
-const MODELS_MAX_BODY_BYTES = 512 * 1024;
-// [20260908_Fix_BatchReview_M8] Named per the no-magic-numbers rule.
-const LIST_MODELS_TIMEOUT_MS = 10_000;
-
-function isLocalBaseUrl(baseUrl: string): boolean {
-  try {
-    return isLocalhost(new URL(baseUrl).hostname);
-  } catch {
-    return false;
-  }
-}
+// [20260912_Refactor_262_AiHistoryService] modelEndpointCandidates, the
+// MODELS_MAX_* / LIST_MODELS_TIMEOUT_MS guards, and isLocalBaseUrl moved
+// verbatim to src/helpers/services/aiService.ts with the LIST_MODELS body
+// (listProviderModels). isLocalBaseUrl stays imported above — the
+// orchestrator and checkAIStatus still use it for the local-gateway
+// exception. END
 
 interface ChatCompletionMessage {
   role: string;
@@ -1612,15 +1541,22 @@ interface Managers {
   templatesDir?: string;
 }
 
+// [20260912_Refactor_262_AiHistoryService] Behavior-parity sentinel: the
+// pre-refactor PROCESS handler only touched event.sender INSIDE the
+// requestId branch, so sender-less invocations (internal callers, tests)
+// never read it. The service ignores senderId when no requestId is given,
+// so this sentinel never reaches the registry's ownership check.
+const SENDER_ID_NONE = -1;
+
 export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   const { databaseManager, logger } = managers;
-  // [20260907_Feat_235_StreamPipeline] T8: requestId → abort controller for
-  // the initiating sender. POLISH_ABORT resolves through this map with a
-  // sender-ownership check.
-  const streamAbortTargets = new Map<
-    string,
-    { controller: AbortController; senderId: number }
-  >();
+  // [20260912_Refactor_262_AiHistoryService] T8: requestId → abort
+  // controller for the initiating sender. POLISH_ABORT resolves through
+  // this registry with a sender-ownership check. The registry (and its
+  // abort semantics) moved to aiService so headless callers can drive
+  // abort/supersession without a window; this is the same per-registration
+  // instance the old `streamAbortTargets` map provided.
+  const streamAbortRegistry = createStreamAbortRegistry();
   const templatesDir =
     managers.templatesDir ||
     (() => {
@@ -1637,159 +1573,72 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
     async (
       event,
       text: string,
-      mode = "optimize",
+      mode?: string,
       timeout?: number,
       requestId?: string,
     ) => {
-      // [20260906_Refactor_PolishOrchestrator] Spec #193 T3 (ticket #230):
-      // route the PROCESS entry straight through the shared orchestrator
-      // (entry resolves its own default mode; the orchestrator owns prompt
-      // building, the provider call and response/error mapping).
-      //
-      // [20260907_Fix_312_WireClampEntry] Activate the minimal-edit output
-      // budget clamp for this entry (issue #312, first T7 wiring step): the
-      // orchestrator only clamps when the caller opts in, and without this
-      // the 2026-08-15 empty-content fix never bound on a live path. Rewrite
-      // modes and custom templates stay unclamped by design.
-      //
-      // [20260907_Feat_235_StreamPipeline] T8: a requestId opts the call
-      // into streaming — chunk events are sent to THIS window only, and the
-      // requestId becomes the abort/generation scope key.
-      let stream: PolishRequest["stream"];
-      let ownedController: AbortController | undefined;
-      if (requestId) {
-        const senderId = event.sender.id;
-        const controller = new AbortController();
-        ownedController = controller;
-        streamAbortTargets.set(requestId, { controller, senderId });
-        stream = {
+      // [20260912_Refactor_262_AiHistoryService] Thin shell: the entry
+      // wiring (stream registration, "optimize" mode default, minimal-edit
+      // clamp gating, generation-scope/signal hookup, own-entry release)
+      // moved into aiService.processPolishText unchanged. The only renderer
+      // coupling left here is the chunk transport — the event.sender.send
+      // closure is handed to the service as its notify callback (a headless
+      // caller would inject a no-op or a chunk collector; the returned
+      // result is unaffected).
+      return await processPolishText(
+        {
+          databaseManager,
+          logger,
+          templatesDir,
+          runPolish: runPolishOrchestrator,
+        },
+        streamAbortRegistry,
+        {
+          text,
+          mode,
+          timeout,
           requestId,
+          // Read event.sender ONLY when a requestId is present — the
+          // pre-refactor handler never touched the sender otherwise
+          // (behavior parity with the locked tests).
+          senderId: requestId ? event.sender.id : SENDER_ID_NONE,
           notify: (chunk: PolishChunk) => {
             if (!event.sender.isDestroyed()) {
               event.sender.send(C.EVENTS.AI_POLISH_CHUNK, chunk);
             }
           },
-        };
-      }
-      try {
-        return await runPolishOrchestrator(
-          { databaseManager, logger },
-          {
-            text,
-            mode,
-            templatesDir,
-            timeout,
-            clampOutputTokens: MINIMAL_MODES_FOR_CLAMP.has(mode),
-            generationScope: requestId,
-            signal: streamAbortTargets.get(requestId ?? "")?.controller.signal,
-            stream,
-          },
-        );
-      } finally {
-        // [20260907_Fix_235_ReviewMinor1] Delete ONLY our own entry: a
-        // superseding run reusing the requestId owns the map slot now.
-        const entry = requestId ? streamAbortTargets.get(requestId) : undefined;
-        if (entry && entry.controller === ownedController) {
-          streamAbortTargets.delete(requestId as string);
-        }
-      }
+        },
+      );
     },
   );
 
   // [20260907_Feat_235_StreamPipeline] T8 abort channel — rate-limit exempt
   // (an abort must never be throttled) and sender-checked so one window
   // cannot cancel another window's run.
+  // [20260912_Refactor_262_AiHistoryService] Thin shell: the registry
+  // lookup, ownership check, warn log, and abort moved verbatim into
+  // StreamAbortRegistry.abort (aiService) — lookup miss stays no-throw.
   ipcMain.handle(C.AI.POLISH_ABORT, (event, requestId: string) => {
-    const target = streamAbortTargets.get(requestId);
-    if (!target) {
-      return { success: false, reason: "unknown_request" };
-    }
-    if (target.senderId !== event.sender.id) {
-      logger.warn?.("POLISH_ABORT 拒绝：请求 id 不属于该发送者");
-      return { success: false, reason: "forbidden" };
-    }
-    target.controller.abort();
-    return { success: true };
+    return streamAbortRegistry.abort(requestId, event.sender.id, logger);
   });
 
   // [20260907_Feat_233_ListModels] Ticket #233: provider model-list
   // derivation. Same SSRF gate as the chat request (private https rejected,
   // local-gateway exception allowed), URL-constructor endpoint derivation,
   // strict response shape with silent fallback to the manual-input path.
+  // [20260912_Refactor_262_AiHistoryService] Thin shell: the whole body
+  // (SSRF gate, masked-key resolution against the stored credential,
+  // candidate fetching, response validation) moved verbatim into
+  // aiService.listProviderModels — the key still decrypts in the main
+  // process via the same databaseManager; no key-reading surface changed.
   ipcMain.handle(
     C.AI.LIST_MODELS,
     async (_event, baseUrl: string, apiKey = "") => {
-      const isLocal = isLocalBaseUrl(baseUrl);
-      if (!validateAIBaseUrl(baseUrl, { allowLocalhost: isLocal })) {
-        return { success: false, reason: "invalid_url", models: [] };
-      }
-      let key = typeof apiKey === "string" ? apiKey : "";
-      // Masked renderer keys resolve against the stored credential, mirroring
-      // the save/test paths (the mask is not a usable secret).
-      if (!key || key.startsWith("****")) {
-        key =
-          ((await databaseManager.getSetting("ai_api_key")) as string) || "";
-      }
-      const headers: Record<string, string> = key
-        ? { Authorization: `Bearer ${key}` }
-        : {};
-      const candidates = modelEndpointCandidates(baseUrl);
-      for (let i = 0; i < candidates.length; i++) {
-        const candidateUrl = candidates[i]!;
-        try {
-          const response = await fetch(candidateUrl, {
-            headers,
-            signal: AbortSignal.timeout(LIST_MODELS_TIMEOUT_MS),
-          });
-          if (response.status === 404 && i < candidates.length - 1) {
-            continue;
-          }
-          if (!response.ok) {
-            return {
-              success: false,
-              reason: `http_${response.status}`,
-              models: [],
-            };
-          }
-          const raw = await response.text();
-          if (Buffer.byteLength(raw) > MODELS_MAX_BODY_BYTES) {
-            return { success: false, reason: "body_too_large", models: [] };
-          }
-          const parsed = JSON.parse(raw) as {
-            data?: Array<{ id?: unknown }>;
-          };
-          const rows = parsed?.data;
-          if (
-            !Array.isArray(rows) ||
-            rows.length === 0 ||
-            rows.length > MODELS_MAX_ITEMS
-          ) {
-            return { success: false, reason: "invalid_shape", models: [] };
-          }
-          const models: string[] = [];
-          for (const row of rows) {
-            const id = row?.id;
-            if (
-              typeof id !== "string" ||
-              !id.trim() ||
-              Buffer.byteLength(id) > MODELS_MAX_ID_BYTES
-            ) {
-              return { success: false, reason: "invalid_shape", models: [] };
-            }
-            models.push(id);
-          }
-          return { success: true, models };
-        } catch (error) {
-          // A failed candidate on the two-candidate path falls through to
-          // the /v1 retry; on the last candidate it degrades to the manual
-          // input path (silent, per ticket #233).
-          if (i >= candidates.length - 1) {
-            logger.warn?.("模型列表获取失败:", error);
-            return { success: false, reason: "fetch_failed", models: [] };
-          }
-        }
-      }
-      return { success: false, reason: "unreachable", models: [] };
+      return await listProviderModels(
+        { databaseManager, logger },
+        baseUrl,
+        apiKey,
+      );
     },
   );
 

--- a/src/helpers/ipc/transcriptionHandlers.ts
+++ b/src/helpers/ipc/transcriptionHandlers.ts
@@ -24,6 +24,22 @@ import {
   withHotwordFallback,
   type Logger,
 } from "../services/transcriptionService";
+// [20260912_Refactor_262_AiHistoryService] Ticket #262 (spec #258 Phase 0):
+// the history write/query/delete domain — SAVE, GET_ALL, DELETE, CLEAR,
+// EXPORT_ALL handler bodies — moved to
+// src/helpers/services/historyService.ts so it can run without a
+// renderer/window/sender (single-writer principle intact: every function
+// writes through the same injected databaseManager). This handler file
+// keeps only channel registration and the native save-dialog wiring,
+// passed to EXPORT_ALL as the injected showSaveDialog callback.
+import {
+  clearTranscriptionsService,
+  deleteTranscriptionService,
+  exportAllTranscriptionsService,
+  getTranscriptionsService,
+  saveTranscriptionService,
+} from "../services/historyService";
+// [20260912_Refactor_262_AiHistoryService] END
 
 interface TranscriptionRow {
   text?: string;
@@ -118,6 +134,13 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   // src/helpers/services/transcriptionService.ts, now taking this bag as
   // their first argument.
   const transcriptionDeps = { funasrManager, databaseManager, logger };
+
+  // [20260912_Refactor_262_AiHistoryService] Deps bag forwarded to the
+  // extracted history service functions (save/get/delete/clear/export_all).
+  // Narrow slice per the #261 deps-slices review: the history domain needs
+  // only the databaseManager + logger — no funasrManager surface.
+  const historyDeps = { databaseManager, logger };
+  // [20260912_Refactor_262_AiHistoryService] END
 
   ipcMain.handle(
     C.TRANSCRIPTION.AUDIO,
@@ -358,19 +381,13 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
 
   ipcMain.handle(
     C.TRANSCRIPTION.SAVE,
-    (_event, data: Record<string, unknown>) => {
-      try {
-        const result = databaseManager.saveTranscription(data);
-        return {
-          success: true,
-          lastInsertRowid: result.lastInsertRowid,
-          changes: result.changes,
-        };
-      } catch (error) {
-        logger.error?.("保存转录失败:", error);
-        return { success: false, error: (error as Error).message };
-      }
-    },
+    // [20260912_Refactor_262_AiHistoryService] Thin shell: the write and its
+    // {success, lastInsertRowid, changes} / {success:false, error} envelope
+    // moved into saveTranscriptionService unchanged (rowid normalized via
+    // Number() per the #262 service contract; plain-number rowids are
+    // unaffected).
+    (_event, data: Record<string, unknown>) =>
+      saveTranscriptionService(historyDeps, data),
   );
 
   // [20260906_Feat_TranscriptionUpdate] Spec #193 T1 (ticket #228): manual
@@ -434,9 +451,11 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
 
   ipcMain.handle(
     C.TRANSCRIPTION.GET_ALL,
-    (_event, limit: number, offset: number) => {
-      return databaseManager.getTranscriptions(limit, offset);
-    },
+    // [20260912_Refactor_262_AiHistoryService] Thin shell: raw paginated row
+    // passthrough moved into getTranscriptionsService (no envelope, as
+    // before).
+    (_event, limit: number, offset: number) =>
+      getTranscriptionsService(historyDeps, limit, offset),
   );
 
   // [20260816_Refactor_DeadChannels] The GET (single-record) and STATS
@@ -446,102 +465,38 @@ export function register(ipcMain: Electron.IpcMain, managers: Managers): void {
   // [20260905_Fix_249_ReviewNit] Wrap the raw RunResult into OperationResult
   // like CLEAR does — DELETE is the last transcription handler still leaking
   // node:sqlite's {changes, lastInsertRowid} past the declared contract.
-  ipcMain.handle(C.TRANSCRIPTION.DELETE, (_event, id: number) => {
-    try {
-      const result = databaseManager.deleteTranscription(id) as {
-        changes?: number;
-      };
-      return { success: true, changes: result.changes ?? 0 };
-    } catch (error) {
-      logger.error?.("删除转录记录失败:", error);
-      return { success: false, error: (error as Error).message };
-    }
-  });
+  ipcMain.handle(
+    C.TRANSCRIPTION.DELETE,
+    // [20260912_Refactor_262_AiHistoryService] Thin shell: the RunResult →
+    // OperationResult wrapping (missing changes → 0) and the error envelope
+    // moved into deleteTranscriptionService unchanged.
+    (_event, id: number) => deleteTranscriptionService(historyDeps, id),
+  );
 
   // [20260905_Fix_248_ReviewClearContract] Wrap the raw node:sqlite RunResult
   // ({changes, lastInsertRowid}) into the declared OperationResult contract —
   // the renderer checks `success`, and the unwrapped shape made every
   // successful clear report failure (review BLOCKER, issue #248).
-  ipcMain.handle(C.TRANSCRIPTION.CLEAR, () => {
-    try {
-      const result = databaseManager.clearAllTranscriptions() as {
-        changes?: number;
-      };
-      return { success: true, changes: result.changes ?? 0 };
-    } catch (error) {
-      logger.error?.("清空转录记录失败:", error);
-      return { success: false, error: (error as Error).message };
-    }
-  });
+  ipcMain.handle(
+    C.TRANSCRIPTION.CLEAR,
+    // [20260912_Refactor_262_AiHistoryService] Thin shell: the RunResult →
+    // OperationResult wrapping moved into clearTranscriptionsService
+    // unchanged.
+    () => clearTranscriptionsService(historyDeps),
+  );
 
-  ipcMain.handle(C.TRANSCRIPTION.EXPORT_ALL, async (_event, format: string) => {
-    try {
-      const transcriptions = databaseManager.getTranscriptions(10000, 0);
-      if (!transcriptions || transcriptions.length === 0) {
-        return { success: false, error: "没有转录记录可导出" };
-      }
-
-      const formatInfo = exportFormatters.getFormatInfo(format || "txt");
-      if (!formatInfo) {
-        return { success: false, error: `不支持的格式: ${format}` };
-      }
-      const filters = [
-        { name: formatInfo.label || format, extensions: [formatInfo.ext] },
-      ];
-
-      const result = await dialog.showSaveDialog({
-        title: "导出转录记录",
-        defaultPath: `transcriptions.${formatInfo.ext}`,
-        filters,
-      });
-
-      if (result.canceled || !result.filePath) {
-        return { success: false, canceled: true };
-      }
-
-      // [20260906_Fix_ExportAllSegments] Found by the T16 content-readback
-      // e2e: rows carry the raw segments JSON string, but formatters read
-      // parsedSegments — export-all therefore silently dropped segment
-      // timelines. Parse per record (parity with the single-record export).
-      const withParsedSegments = (
-        transcriptions as unknown as Array<Record<string, unknown>>
-      ).map((row) => {
-        let parsedSegments: unknown[] = [];
-        if (typeof row.segments === "string" && row.segments) {
-          try {
-            parsedSegments = JSON.parse(row.segments) as unknown[];
-          } catch {
-            parsedSegments = [];
-          }
-        }
-        return { ...row, parsedSegments };
-      });
-
-      let content: Buffer | string;
-      if (format === "docx") {
-        // [20260724_TS_BigBang_TranscriptionHandlers] Pre-existing behavior:
-        // the .js passed the whole transcriptions array to formatDOCX
-        // (which expects a single record). Preserve runtime behavior via
-        // a cast; the doc comes out with empty text/segments as before.
-        content = await exportFormatters.formatDOCX(
-          withParsedSegments as unknown as TranscriptionForExport,
-        );
-        fs.writeFileSync(result.filePath, content as Buffer);
-      } else {
-        // [20260815_Refactor_FormatterLookup] getFormatInfo above already
-        // resolved the right formatter; the nested ternary re-derived it.
-        const formatter = formatInfo.formatter;
-        content = (withParsedSegments as unknown[])
-          .map((t) => formatter(t as unknown as TranscriptionForExport))
-          .join("\n\n");
-        fs.writeFileSync(result.filePath, content as string, "utf-8");
-      }
-
-      return { success: true, path: result.filePath };
-    } catch (error) {
-      logger.error?.("导出转录失败:", error);
-      return { success: false, error: (error as Error).message };
-    }
-  });
+  ipcMain.handle(
+    C.TRANSCRIPTION.EXPORT_ALL,
+    // [20260912_Refactor_262_AiHistoryService] Thin shell: the row fetch,
+    // empty/format guards, per-row segments parsing, docx branch, and file
+    // write moved into exportAllTranscriptionsService unchanged. The only
+    // renderer/Electron coupling left here is the native save dialog —
+    // injected as the showSaveDialog callback (a headless caller injects a
+    // stub or a direct path; the returned envelope is unaffected).
+    async (_event, format: string) =>
+      await exportAllTranscriptionsService(historyDeps, format, (options) =>
+        dialog.showSaveDialog(options),
+      ),
+  );
 }
 // [20260724_TS_BigBang_TranscriptionHandlers] END

--- a/src/helpers/services/aiService.ts
+++ b/src/helpers/services/aiService.ts
@@ -1,0 +1,428 @@
+// [20260912_Refactor_262_AiHistoryService] Ticket #262 (spec #258 Phase 0 —
+// AI 域服务化): AI-text-domain service extraction. The pieces of the
+// C.AI.PROCESS / C.AI.POLISH_ABORT / C.AI.LIST_MODELS handler bodies that
+// carried inline domain logic move here as plain main-process functions:
+//
+//   - createStreamAbortRegistry(): the requestId → AbortController registry
+//     (the critical headless seam — abort/supersession bookkeeping becomes
+//     callable without a renderer window).
+//   - processPolishText(): the PROCESS entry wiring (stream registration,
+//     mode-default + minimal-edit clamp gating, generation-scope/signal
+//     hookup, own-entry release). The polish orchestrator itself is INJECTED
+//     via deps (`runPolish`) so this module stays dependency-clean and the
+//     HIGH-RISK streaming/deadline-matrix pipeline stays untouched in
+//     aiHandlers.ts (wrap, not relocate).
+//   - listProviderModels(): the provider /models listing (SSRF gate,
+//     masked-key resolution, endpoint derivation, response validation).
+//     Verbatim move; the SSRF predicates it shares with the orchestrator
+//     (isLocalhost/isPrivateNetwork/validateAIBaseUrl) moved with it and
+//     aiHandlers re-exports validateAIBaseUrl to keep its public contract.
+//
+// No Electron types appear here: the sender coupling stays in the handler,
+// translated into the plain `notify(chunk)` callback and the numeric
+// `senderId`. Dependency direction is one-way: aiHandlers imports THIS
+// module (except erased type-only imports) — no import cycle.
+//
+// 密钥读取路径不变: API keys are still decrypted inside the main process
+// via the injected databaseManager (getSetting("ai_api_key")) exactly as
+// before; this refactor adds no key-reading parameter or renderer-facing
+// export surface.
+//
+// Behavior is byte-identical to the pre-extraction handlers — locked by the
+// unmodified tests/unit/aiHandlers.test.ts and tests/unit/list-models.test.ts;
+// new headless seam coverage lives in tests/unit/aiService.test.ts. Comments
+// and log strings copied from the handler are kept verbatim.
+
+import { MINIMAL_EDIT_MODES } from "../polish-diff";
+import type { PolishChunk } from "../../types/ipc";
+// [20260912_Refactor_262_AiHistoryService] Type-only imports from aiHandlers
+// (erased at runtime — they cannot create an import cycle). They pin the
+// injected orchestrator to the exact production contract.
+import type {
+  PolishDeps,
+  PolishRequest,
+  PolishOutcomeCode,
+} from "../ipc/aiHandlers";
+
+/** Logger surface used for diagnostics; every method is optional. */
+export interface Logger {
+  info?(message: string, ...args: unknown[]): void;
+  warn?(message: string, ...args: unknown[]): void;
+  error?(message: string, ...args: unknown[]): void;
+}
+
+/** Structural echo of the orchestrator's (non-exported) AIResult shape. */
+export interface PolishRunResult {
+  success: boolean;
+  text?: string;
+  error?: string;
+  usage?: unknown;
+  model?: string;
+  code?: PolishOutcomeCode;
+}
+
+// [20260912_Refactor_262_AiHistoryService] SSRF gate moved verbatim from
+// aiHandlers.ts (isLocalhost + isPrivateNetwork + validateAIBaseUrl) — the
+// shared security predicate for every AI channel. Pure functions, no state.
+function isLocalhost(host: string | null | undefined): boolean {
+  if (!host) return false;
+  host = host.toLowerCase();
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "0.0.0.0" || host === "::1" || host === "[::1]") return true;
+  if (/^127\./.test(host)) return true;
+  return false;
+}
+
+// [20260907_Fix_233_SsrfHardening] Security-review MEDIUM: the IPv4-text
+// checks missed IPv4-mapped IPv6 (::ffff:a00:1), IPv6 ULA fc00::/7,
+// link-local fe80::/10, loopback ::/128, and CGNAT 100.64.0.0/10 — all
+// resolve to private/internal addresses while canonicalizing to hostnames
+// that matched no regex. Bracket stripping + mapped-address reduction close
+// the gap for every AI channel that shares this gate.
+function isPrivateNetwork(host: string): boolean {
+  if (!host) return false;
+  const bare = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (bare === "::1" || bare === "::") return true;
+  const mapped = bare.match(/^::ffff:(.+)$/);
+  if (mapped) {
+    // WHATWG canonicalizes mapped addresses to hex form ([::ffff:a00:1]);
+    // convert the trailing 32 bits back to dotted-decimal for the IPv4
+    // checks below.
+    const hex = mapped[1]!.match(/^([0-9a-f]+):([0-9a-f]+)$/);
+    if (hex) {
+      const hi = parseInt(hex[1]!, 16);
+      const lo = parseInt(hex[2]!, 16);
+      return isPrivateNetwork(
+        `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`,
+      );
+    }
+    return isPrivateNetwork(mapped[1]!);
+  }
+  if (/^f[cd][0-9a-f]{2}:/.test(bare)) return true; // IPv6 ULA fc00::/7
+  if (/^fe[89ab][0-9a-f]:/.test(bare)) return true; // IPv6 link-local
+  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(bare)) return true; // CGNAT
+  if (/^198\.(1[89]|0)\./.test(bare)) return true; // benchmark 198.18.0.0/15
+  if (/^10\./.test(bare)) return true;
+  if (/^192\.168\./.test(bare)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(bare)) return true;
+  if (/^169\.254\./.test(bare)) return true;
+  if (/^127\./.test(bare)) return true;
+  return false;
+}
+
+export function validateAIBaseUrl(
+  baseUrl: string,
+  { allowLocalhost = false }: { allowLocalhost?: boolean } = {},
+): boolean {
+  try {
+    const url = new URL(baseUrl);
+    const host = url.hostname.toLowerCase();
+    if (!host) return false;
+
+    if (allowLocalhost && isLocalhost(host)) {
+      return url.protocol === "http:" || url.protocol === "https:";
+    }
+
+    if (url.protocol !== "https:") return false;
+    if (isLocalhost(host)) return false;
+    if (isPrivateNetwork(host)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// [20260912_Refactor_262_AiHistoryService] Exported for the orchestrator's
+// and checkAIStatus's local-gateway exception back in aiHandlers (they now
+// import it from here — one-way dependency).
+export function isLocalBaseUrl(baseUrl: string): boolean {
+  try {
+    return isLocalhost(new URL(baseUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+// [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Refactor_262_AiHistoryService] requestId → AbortController
+// registry, moved from the `streamAbortTargets` map inside
+// aiHandlers.register(). This is THE headless seam of ticket #262: abort/
+// supersession bookkeeping no longer requires a renderer window. The
+// `abort` method carries the full POLISH_ABORT handler semantics —
+// unknown id → no-throw {success:false, reason:"unknown_request"};
+// sender mismatch → warn + {success:false, reason:"forbidden"};
+// match → controller.abort() + {success:true}.
+export interface StreamAbortEntry {
+  controller: AbortController;
+  senderId: number;
+}
+
+export interface PolishAbortOutcome {
+  success: boolean;
+  reason?: "unknown_request" | "forbidden";
+}
+
+export interface StreamAbortRegistry {
+  /** Register a run and return its abort controller (the old map.set). */
+  register(requestId: string, senderId: number): AbortController;
+  /** Raw entry lookup (the old map.get). */
+  get(requestId: string): StreamAbortEntry | undefined;
+  /** Signal of the currently registered run for a requestId. */
+  signalOf(requestId: string): AbortSignal | undefined;
+  /** Drop a finished run — but only if it still owns its map slot. */
+  release(requestId: string, controller: AbortController): void;
+  /** The POLISH_ABORT semantics (sender-checked, never throws). */
+  abort(
+    requestId: string,
+    senderId: number,
+    logger?: Logger,
+  ): PolishAbortOutcome;
+}
+
+export function createStreamAbortRegistry(): StreamAbortRegistry {
+  const targets = new Map<string, StreamAbortEntry>();
+  return {
+    register(requestId, senderId) {
+      const controller = new AbortController();
+      targets.set(requestId, { controller, senderId });
+      return controller;
+    },
+    get(requestId) {
+      return targets.get(requestId);
+    },
+    signalOf(requestId) {
+      return targets.get(requestId)?.controller.signal;
+    },
+    release(requestId, controller) {
+      // [20260907_Fix_235_ReviewMinor1] Delete ONLY our own entry: a
+      // superseding run reusing the requestId owns the map slot now.
+      const entry = targets.get(requestId);
+      if (entry && entry.controller === controller) {
+        targets.delete(requestId);
+      }
+    },
+    abort(requestId, senderId, logger) {
+      // [20260907_Feat_235_StreamPipeline] T8 abort channel — rate-limit
+      // exempt (an abort must never be throttled) and sender-checked so one
+      // window cannot cancel another window's run.
+      const target = targets.get(requestId);
+      if (!target) {
+        return { success: false, reason: "unknown_request" };
+      }
+      if (target.senderId !== senderId) {
+        logger?.warn?.("POLISH_ABORT 拒绝：请求 id 不属于该发送者");
+        return { success: false, reason: "forbidden" };
+      }
+      target.controller.abort();
+      return { success: true };
+    },
+  };
+}
+// [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Refactor_262_AiHistoryService] The C.AI.PROCESS entry wiring,
+// moved from the handler body into a service function. The only renderer
+// coupling left in the handler is the `event.sender.send` chunk transport,
+// translated into the injected `notify` callback (a headless caller passes
+// a no-op or collects chunks in tests). The polish orchestrator itself is
+// injected as `runPolish` so the HIGH-RISK streaming/deadline-matrix
+// pipeline stays byte-identical in aiHandlers.ts and this module gains no
+// runtime dependency on it.
+export interface ProcessPolishTextDeps {
+  databaseManager: PolishDeps["databaseManager"];
+  logger: Logger;
+  templatesDir: string;
+  runPolish: (
+    deps: PolishDeps,
+    request: PolishRequest,
+  ) => Promise<PolishRunResult>;
+}
+
+export interface ProcessPolishTextParams {
+  text: string;
+  /** Entry-level default ("optimize") is applied by the service. */
+  mode?: string;
+  timeout?: number;
+  requestId?: string;
+  senderId: number;
+  notify: (chunk: PolishChunk) => void;
+}
+
+export async function processPolishText(
+  deps: ProcessPolishTextDeps,
+  registry: StreamAbortRegistry,
+  params: ProcessPolishTextParams,
+): Promise<PolishRunResult> {
+  const { databaseManager, logger, templatesDir, runPolish } = deps;
+  const { text, requestId, senderId, notify } = params;
+  const mode = params.mode === undefined ? "optimize" : params.mode;
+  // [20260907_Feat_235_StreamPipeline] T8: a requestId opts the call into
+  // streaming — chunk events are sent to THIS window only (via the injected
+  // notify transport), and the requestId becomes the abort/generation scope
+  // key.
+  let stream: PolishRequest["stream"];
+  let ownedController: AbortController | undefined;
+  if (requestId) {
+    ownedController = registry.register(requestId, senderId);
+    stream = { requestId, notify };
+  }
+  try {
+    // [20260906_Refactor_PolishOrchestrator] Spec #193 T3 (ticket #230):
+    // route the PROCESS entry straight through the shared orchestrator
+    // (entry resolves its own default mode; the orchestrator owns prompt
+    // building, the provider call and response/error mapping).
+    //
+    // [20260907_Fix_312_WireClampEntry] Activate the minimal-edit output
+    // budget clamp for this entry (issue #312, first T7 wiring step): the
+    // orchestrator only clamps when the caller opts in, and without this
+    // the 2026-08-15 empty-content fix never bound on a live path. Rewrite
+    // modes and custom templates stay unclamped by design.
+    return await runPolish(
+      { databaseManager, logger },
+      {
+        text,
+        mode,
+        templatesDir,
+        timeout: params.timeout,
+        clampOutputTokens: MINIMAL_EDIT_MODES.has(mode),
+        generationScope: requestId,
+        signal: registry.signalOf(requestId ?? ""),
+        stream,
+      },
+    );
+  } finally {
+    // [20260907_Fix_235_ReviewMinor1] Delete ONLY our own entry: a
+    // superseding run reusing the requestId owns the map slot now.
+    if (ownedController) {
+      registry.release(requestId as string, ownedController);
+    }
+  }
+}
+// [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Refactor_262_AiHistoryService] Ticket #233 provider model-list
+// derivation moved verbatim from the C.AI.LIST_MODELS handler body. Same
+// SSRF gate as the chat request (private https rejected, local-gateway
+// exception allowed), URL-constructor endpoint derivation, strict response
+// shape with silent fallback to the manual-input path.
+// [20260907_Feat_233_ListModels] Derive the /models endpoint from the base
+// URL with the URL constructor only — never whole-URL string concatenation.
+// Bases that already end in a version segment get exactly one candidate
+// ({base}/models); other bases try {base}/models first and {base}/v1/models
+// second (the common "no /v1 in base_url" gateway shape).
+function modelEndpointCandidates(baseUrl: string): string[] {
+  const url = new URL(baseUrl);
+  const basePath = url.pathname.replace(/\/+$/, "");
+  const withPath = (suffix: string) => {
+    const derived = new URL(baseUrl);
+    derived.pathname = basePath + suffix;
+    return derived.toString();
+  };
+  if (/\/v\d+$/.test(basePath)) {
+    return [withPath("/models")];
+  }
+  return [withPath("/models"), withPath("/v1/models")];
+}
+
+// [20260907_Feat_233_ListModels] Response contract for the provider /models
+// listing. Anything outside the shape silently degrades the renderer to the
+// manual-input path (ticket #233: 非法即静默回退手输).
+const MODELS_MAX_ITEMS = 500;
+const MODELS_MAX_ID_BYTES = 200;
+const MODELS_MAX_BODY_BYTES = 512 * 1024;
+// [20260908_Fix_BatchReview_M8] Named per the no-magic-numbers rule.
+const LIST_MODELS_TIMEOUT_MS = 10_000;
+
+export interface ListProviderModelsDeps {
+  databaseManager: {
+    // Masked renderer keys resolve against the stored credential here —
+    // the same main-process-only decryption path as before this refactor.
+    getSetting(key: string): Promise<unknown>;
+  };
+  logger: Logger;
+}
+
+export interface ProviderModelListResult {
+  success: boolean;
+  reason?: string;
+  models: string[];
+}
+
+export async function listProviderModels(
+  deps: ListProviderModelsDeps,
+  baseUrl: string,
+  apiKey = "",
+): Promise<ProviderModelListResult> {
+  const { databaseManager, logger } = deps;
+  const isLocal = isLocalBaseUrl(baseUrl);
+  if (!validateAIBaseUrl(baseUrl, { allowLocalhost: isLocal })) {
+    return { success: false, reason: "invalid_url", models: [] };
+  }
+  let key = typeof apiKey === "string" ? apiKey : "";
+  // Masked renderer keys resolve against the stored credential, mirroring
+  // the save/test paths (the mask is not a usable secret).
+  if (!key || key.startsWith("****")) {
+    key = ((await databaseManager.getSetting("ai_api_key")) as string) || "";
+  }
+  const headers: Record<string, string> = key
+    ? { Authorization: `Bearer ${key}` }
+    : {};
+  const candidates = modelEndpointCandidates(baseUrl);
+  for (let i = 0; i < candidates.length; i++) {
+    const candidateUrl = candidates[i]!;
+    try {
+      const response = await fetch(candidateUrl, {
+        headers,
+        signal: AbortSignal.timeout(LIST_MODELS_TIMEOUT_MS),
+      });
+      if (response.status === 404 && i < candidates.length - 1) {
+        continue;
+      }
+      if (!response.ok) {
+        return {
+          success: false,
+          reason: `http_${response.status}`,
+          models: [],
+        };
+      }
+      const raw = await response.text();
+      if (Buffer.byteLength(raw) > MODELS_MAX_BODY_BYTES) {
+        return { success: false, reason: "body_too_large", models: [] };
+      }
+      const parsed = JSON.parse(raw) as {
+        data?: Array<{ id?: unknown }>;
+      };
+      const rows = parsed?.data;
+      if (
+        !Array.isArray(rows) ||
+        rows.length === 0 ||
+        rows.length > MODELS_MAX_ITEMS
+      ) {
+        return { success: false, reason: "invalid_shape", models: [] };
+      }
+      const models: string[] = [];
+      for (const row of rows) {
+        const id = row?.id;
+        if (
+          typeof id !== "string" ||
+          !id.trim() ||
+          Buffer.byteLength(id) > MODELS_MAX_ID_BYTES
+        ) {
+          return { success: false, reason: "invalid_shape", models: [] };
+        }
+        models.push(id);
+      }
+      return { success: true, models };
+    } catch (error) {
+      // A failed candidate on the two-candidate path falls through to
+      // the /v1 retry; on the last candidate it degrades to the manual
+      // input path (silent, per ticket #233).
+      if (i >= candidates.length - 1) {
+        logger.warn?.("模型列表获取失败:", error);
+        return { success: false, reason: "fetch_failed", models: [] };
+      }
+    }
+  }
+  return { success: false, reason: "unreachable", models: [] };
+}
+// [20260912_Refactor_262_AiHistoryService] END

--- a/src/helpers/services/historyService.ts
+++ b/src/helpers/services/historyService.ts
@@ -1,0 +1,239 @@
+// [20260912_Refactor_262_AiHistoryService] Ticket #262 (spec #258 Phase 0 —
+// 历史写域服务化): history write/query/delete service extraction. The
+// C.TRANSCRIPTION.SAVE / GET_ALL / DELETE / CLEAR / EXPORT_ALL handler
+// bodies (transcriptionHandlers.ts) move here as plain main-process
+// functions receiving `{ databaseManager, logger }` deps. The single-writer
+// principle holds: every function writes through the SAME injected
+// databaseManager the handler used — no new writers appear. The SAVE UPDATE
+// sibling and everything #261 already serviced are untouched.
+//
+// No Electron types here: EXPORT_ALL's dialog coupling stays in the
+// handler, translated into the injected `showSaveDialog` callback (same
+// pattern as #261's optional onProgress). Behavior is identical to the
+// pre-extraction handlers except ONE disclosed envelope refinement (see
+// below) — locked by the unmodified
+// tests/unit/transcriptionHandlers.test.ts; new headless seam coverage
+// lives in tests/unit/historyService.test.ts. Comments and log strings
+// copied from the handlers are kept verbatim (Chinese log strings are
+// pre-existing diagnostics).
+//
+// The disclosed refinement (ticket #262 test contract b): SAVE now
+// normalizes `lastInsertRowid` through Number() (node:sqlite can hand back
+// a bigint; the #261 file-transcription persist already normalizes the
+// same way). Existing handler tests pass plain-number rowids and are
+// unaffected.
+
+import fs from "fs";
+import * as exportFormatters from "../exportFormatters";
+import type { TranscriptionForExport } from "../exportFormatters";
+
+/** Logger surface used for diagnostics; every method is optional. */
+export interface Logger {
+  info?(message: string, ...args: unknown[]): void;
+  warn?(message: string, ...args: unknown[]): void;
+  error?(message: string, ...args: unknown[]): void;
+}
+
+/** History row shape the query/export services read (permissive echo). */
+export interface HistoryRow {
+  id?: number;
+  text?: string;
+  segments?: string | null;
+  [key: string]: unknown;
+}
+
+/** Result of the DB write returning the inserted row id. */
+interface SaveTranscriptionResult {
+  lastInsertRowid?: number | bigint;
+  changes?: number;
+}
+
+// [20260912_Refactor_262_AiHistoryService] The C.TRANSCRIPTION.SAVE handler
+// body: persist the record and surface {success, lastInsertRowid, changes};
+// DB failures surface through the {success:false, error} envelope.
+export function saveTranscriptionService(
+  deps: {
+    databaseManager: {
+      saveTranscription(data: Record<string, unknown>): SaveTranscriptionResult;
+    };
+    logger: Logger;
+  },
+  data: Record<string, unknown>,
+): {
+  success: boolean;
+  lastInsertRowid?: number;
+  changes?: number;
+  error?: string;
+} {
+  try {
+    const result = deps.databaseManager.saveTranscription(data);
+    return {
+      success: true,
+      // Ticket #262 (b): node:sqlite rowids are normalized to Number so
+      // headless callers get a plain value regardless of the driver's
+      // number|bigint return; undefined (no rowid) passes through.
+      lastInsertRowid:
+        result.lastInsertRowid !== undefined
+          ? Number(result.lastInsertRowid)
+          : undefined,
+      changes: result.changes,
+    };
+  } catch (error) {
+    deps.logger.error?.("保存转录失败:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+// [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Refactor_262_AiHistoryService] The C.TRANSCRIPTION.GET_ALL
+// handler body: raw paginated row passthrough (no envelope, as before).
+export function getTranscriptionsService(
+  deps: {
+    databaseManager: {
+      getTranscriptions(limit: number, offset: number): HistoryRow[];
+    };
+  },
+  limit: number,
+  offset: number,
+): HistoryRow[] {
+  return deps.databaseManager.getTranscriptions(limit, offset);
+}
+// [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Refactor_262_AiHistoryService] The C.TRANSCRIPTION.DELETE
+// handler body ([20260905_Fix_249_ReviewNit]): wrap the raw node:sqlite
+// RunResult into the OperationResult contract — missing `changes`
+// normalizes to 0.
+export function deleteTranscriptionService(
+  deps: {
+    databaseManager: { deleteTranscription(id: number): unknown };
+    logger: Logger;
+  },
+  id: number,
+): { success: boolean; changes?: number; error?: string } {
+  try {
+    const result = deps.databaseManager.deleteTranscription(id) as {
+      changes?: number;
+    };
+    return { success: true, changes: result.changes ?? 0 };
+  } catch (error) {
+    deps.logger.error?.("删除转录记录失败:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+// [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Refactor_262_AiHistoryService] The C.TRANSCRIPTION.CLEAR
+// handler body ([20260905_Fix_248_ReviewClearContract]): same
+// OperationResult wrapping as DELETE — the renderer checks `success`.
+export function clearTranscriptionsService(deps: {
+  databaseManager: { clearAllTranscriptions(): unknown };
+  logger: Logger;
+}): { success: boolean; changes?: number; error?: string } {
+  try {
+    const result = deps.databaseManager.clearAllTranscriptions() as {
+      changes?: number;
+    };
+    return { success: true, changes: result.changes ?? 0 };
+  } catch (error) {
+    deps.logger.error?.("清空转录记录失败:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+// [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Refactor_262_AiHistoryService] The C.TRANSCRIPTION.EXPORT_ALL
+// handler body. The native save dialog is injected (`showSaveDialog`) —
+// the handler passes `dialog.showSaveDialog`; headless callers inject a
+// stub resolving a target path (or {canceled:true} to exercise the cancel
+// arm). File writes stay here (plain fs, no Electron).
+export interface SaveFileDialogOptions {
+  title: string;
+  defaultPath: string;
+  filters: Array<{ name: string; extensions: string[] }>;
+}
+
+export type ShowSaveFileDialog = (
+  options: SaveFileDialogOptions,
+) => Promise<{ canceled: boolean; filePath?: string }>;
+
+export async function exportAllTranscriptionsService(
+  deps: {
+    databaseManager: {
+      getTranscriptions(limit: number, offset: number): HistoryRow[];
+    };
+    logger: Logger;
+  },
+  format: string,
+  showSaveDialog: ShowSaveFileDialog,
+): Promise<Record<string, unknown>> {
+  const { databaseManager, logger } = deps;
+  try {
+    const transcriptions = databaseManager.getTranscriptions(10000, 0);
+    if (!transcriptions || transcriptions.length === 0) {
+      return { success: false, error: "没有转录记录可导出" };
+    }
+
+    const formatInfo = exportFormatters.getFormatInfo(format || "txt");
+    if (!formatInfo) {
+      return { success: false, error: `不支持的格式: ${format}` };
+    }
+    const filters = [
+      { name: formatInfo.label || format, extensions: [formatInfo.ext] },
+    ];
+
+    const result = await showSaveDialog({
+      title: "导出转录记录",
+      defaultPath: `transcriptions.${formatInfo.ext}`,
+      filters,
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, canceled: true };
+    }
+
+    // [20260906_Fix_ExportAllSegments] Found by the T16 content-readback
+    // e2e: rows carry the raw segments JSON string, but formatters read
+    // parsedSegments — export-all therefore silently dropped segment
+    // timelines. Parse per record (parity with the single-record export).
+    const withParsedSegments = (
+      transcriptions as unknown as Array<Record<string, unknown>>
+    ).map((row) => {
+      let parsedSegments: unknown[] = [];
+      if (typeof row.segments === "string" && row.segments) {
+        try {
+          parsedSegments = JSON.parse(row.segments) as unknown[];
+        } catch {
+          parsedSegments = [];
+        }
+      }
+      return { ...row, parsedSegments };
+    });
+
+    let content: Buffer | string;
+    if (format === "docx") {
+      // [20260724_TS_BigBang_TranscriptionHandlers] Pre-existing behavior:
+      // the .js passed the whole transcriptions array to formatDOCX
+      // (which expects a single record). Preserve runtime behavior via
+      // a cast; the doc comes out with empty text/segments as before.
+      content = await exportFormatters.formatDOCX(
+        withParsedSegments as unknown as TranscriptionForExport,
+      );
+      fs.writeFileSync(result.filePath, content as Buffer);
+    } else {
+      // [20260815_Refactor_FormatterLookup] getFormatInfo above already
+      // resolved the right formatter; the nested ternary re-derived it.
+      const formatter = formatInfo.formatter;
+      content = (withParsedSegments as unknown[])
+        .map((t) => formatter(t as unknown as TranscriptionForExport))
+        .join("\n\n");
+      fs.writeFileSync(result.filePath, content as string, "utf-8");
+    }
+
+    return { success: true, path: result.filePath };
+  } catch (error) {
+    logger.error?.("导出转录失败:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+// [20260912_Refactor_262_AiHistoryService] END

--- a/tests/unit/aiService.test.ts
+++ b/tests/unit/aiService.test.ts
@@ -1,0 +1,321 @@
+// [20260912_Refactor_262_AiHistoryService] Headless seam tests for the
+// AI-domain services extracted in ticket #262 (spec #258 Phase 0).
+// processPolishText / createStreamAbortRegistry / listProviderModels run
+// with plain vi.fn() deps — no Electron import anywhere: the point of the
+// seam is that the abort/requestId registry and the PROCESS entry wiring
+// are callable without a renderer window. Behavior parity with the IPC
+// handlers is locked by the unmodified tests/unit/aiHandlers.test.ts and
+// tests/unit/list-models.test.ts.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { MINIMAL_EDIT_MODES } from "../../src/helpers/polish-diff";
+import {
+  createStreamAbortRegistry,
+  listProviderModels,
+  processPolishText,
+  validateAIBaseUrl,
+  type PolishRunResult,
+  type ProcessPolishTextDeps,
+  type StreamAbortRegistry,
+} from "../../src/helpers/services/aiService";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+// Minimal PolishChunk collector type (structural echo — no Electron).
+type Chunk = Record<string, unknown>;
+
+function makeDeps(): {
+  deps: ProcessPolishTextDeps;
+  runPolish: MockFn;
+  logger: { info: MockFn; warn: MockFn; error: MockFn };
+  databaseManager: { getSetting: MockFn };
+} {
+  const databaseManager = { getSetting: vi.fn(async () => null) };
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const runPolish = vi.fn(async () => ({ success: true, text: "ok" }));
+  return {
+    deps: {
+      databaseManager:
+        databaseManager as unknown as ProcessPolishTextDeps["databaseManager"],
+      logger,
+      templatesDir: "/tmp/test-templates",
+      runPolish: runPolish as unknown as ProcessPolishTextDeps["runPolish"],
+    },
+    runPolish,
+    logger,
+    databaseManager,
+  };
+}
+
+const noopNotify = (): void => undefined;
+
+describe("aiService — processPolishText (headless seam, ticket #262)", () => {
+  it("applies the entry-level optimize default when mode is omitted", async () => {
+    const { deps, runPolish } = makeDeps();
+    const registry = createStreamAbortRegistry();
+    await processPolishText(deps, registry, {
+      text: "raw",
+      senderId: 1,
+      notify: noopNotify,
+    });
+    expect(runPolish).toHaveBeenCalledTimes(1);
+    const request = runPolish.mock.calls[0]![1] as Record<string, unknown>;
+    expect(request.mode).toBe("optimize");
+    expect(request.text).toBe("raw");
+  });
+
+  it("passes an explicit mode through untouched", async () => {
+    const { deps, runPolish } = makeDeps();
+    await processPolishText(deps, createStreamAbortRegistry(), {
+      text: "t",
+      mode: "summarize",
+      senderId: 1,
+      notify: noopNotify,
+    });
+    expect((runPolish.mock.calls[0]![1] as Record<string, unknown>).mode).toBe(
+      "summarize",
+    );
+  });
+
+  it("gates clampOutputTokens by the minimal-edit mode set", async () => {
+    const { deps, runPolish } = makeDeps();
+    const minimalMode = MINIMAL_EDIT_MODES.has("optimize")
+      ? "optimize"
+      : [...MINIMAL_EDIT_MODES][0]!;
+    const rewriteMode = MINIMAL_EDIT_MODES.has("summarize")
+      ? "format"
+      : "summarize";
+    await processPolishText(deps, createStreamAbortRegistry(), {
+      text: "t",
+      mode: minimalMode,
+      senderId: 1,
+      notify: noopNotify,
+    });
+    await processPolishText(deps, createStreamAbortRegistry(), {
+      text: "t",
+      mode: rewriteMode,
+      senderId: 1,
+      notify: noopNotify,
+    });
+    const minimalRequest = runPolish.mock.calls[0]![1] as Record<
+      string,
+      unknown
+    >;
+    const rewriteRequest = runPolish.mock.calls[1]![1] as Record<
+      string,
+      unknown
+    >;
+    expect(minimalRequest.clampOutputTokens).toBe(true);
+    expect(rewriteRequest.clampOutputTokens).toBe(false);
+  });
+
+  it("registers a stream run for a requestId and wires scope + signal + notify", async () => {
+    const { deps, runPolish } = makeDeps();
+    // Hold the run in-flight so the registration is observable mid-flight.
+    let settleRun: (() => void) | undefined;
+    runPolish.mockImplementationOnce(
+      () =>
+        new Promise<PolishRunResult>((resolve) => {
+          settleRun = () => resolve({ success: true, text: "ok" });
+        }),
+    );
+    const registry = createStreamAbortRegistry();
+    const chunks: Chunk[] = [];
+    const pending = processPolishText(deps, registry, {
+      text: "t",
+      mode: "optimize",
+      requestId: "req-1",
+      senderId: 7,
+      notify: (chunk) => chunks.push(chunk as Chunk),
+    });
+    const request = runPolish.mock.calls[0]![1] as Record<string, unknown>;
+    expect(request.generationScope).toBe("req-1");
+    const signal = request.signal as AbortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(registry.get("req-1")?.senderId).toBe(7);
+    // The notify transport is reachable through the stream object: a chunk
+    // the orchestrator emits lands in the collector.
+    const stream = request.stream as {
+      requestId: string;
+      notify: (chunk: unknown) => void;
+    };
+    expect(stream.requestId).toBe("req-1");
+    stream.notify({ type: "start", requestId: "req-1" });
+    expect(chunks).toEqual([{ type: "start", requestId: "req-1" }]);
+    // Own-entry release: settling drops the registry slot.
+    settleRun!();
+    const result = await pending;
+    expect(result).toEqual({ success: true, text: "ok" });
+    expect(registry.get("req-1")).toBeUndefined();
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("omits stream/generationScope/signal without a requestId and never reads senderId", async () => {
+    const { deps, runPolish } = makeDeps();
+    const registry: StreamAbortRegistry = createStreamAbortRegistry();
+    await processPolishText(deps, registry, {
+      text: "t",
+      senderId: -1,
+      notify: noopNotify,
+    });
+    const request = runPolish.mock.calls[0]![1] as Record<string, unknown>;
+    expect(request.stream).toBeUndefined();
+    expect(request.generationScope).toBeUndefined();
+    expect(request.signal).toBeUndefined();
+    expect(request.timeout).toBeUndefined();
+    expect(registry.get("")).toBeUndefined();
+  });
+
+  it("release after completion never evicts a superseding run's registration", async () => {
+    const { deps, runPolish } = makeDeps();
+    // Hold BOTH runs in-flight so the ownership handoff is observable.
+    const release: Array<() => void> = [];
+    runPolish
+      .mockImplementationOnce(
+        () =>
+          new Promise<PolishRunResult>((resolve) => {
+            release.push(() => resolve({ success: true, text: "first" }));
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<PolishRunResult>((resolve) => {
+            release.push(() => resolve({ success: true, text: "second" }));
+          }),
+      );
+    const registry = createStreamAbortRegistry();
+    const first = processPolishText(deps, registry, {
+      text: "t",
+      requestId: "dup",
+      senderId: 1,
+      notify: noopNotify,
+    });
+    const second = processPolishText(deps, registry, {
+      text: "t2",
+      requestId: "dup",
+      senderId: 2,
+      notify: noopNotify,
+    });
+    // The superseding run owns the map slot now (last-write-wins).
+    expect(registry.get("dup")?.senderId).toBe(2);
+    // First run settles: its finally-block release must be a NO-OP because
+    // it no longer owns the slot.
+    release[0]!();
+    await first;
+    expect(registry.get("dup")?.senderId).toBe(2);
+    // Second run settles: its own release drops the entry.
+    release[1]!();
+    await second;
+    expect(registry.get("dup")).toBeUndefined();
+  });
+});
+
+describe("aiService — StreamAbortRegistry (POLISH_ABORT seam)", () => {
+  it("returns unknown_request without throwing on a lookup miss", () => {
+    const registry = createStreamAbortRegistry();
+    const logger = { warn: vi.fn() };
+    expect(registry.abort("missing-id", 1, logger)).toEqual({
+      success: false,
+      reason: "unknown_request",
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("aborts the run controller when the owning sender calls", () => {
+    const registry = createStreamAbortRegistry();
+    registry.register("req-1", 42);
+    const outcome = registry.abort("req-1", 42);
+    expect(outcome).toEqual({ success: true });
+    expect(registry.get("req-1")!.controller.signal.aborted).toBe(true);
+  });
+
+  it("rejects a cross-sender abort with forbidden and a warn log", () => {
+    const registry = createStreamAbortRegistry();
+    registry.register("req-1", 42);
+    const logger = { warn: vi.fn() };
+    const outcome = registry.abort("req-1", 99, logger);
+    expect(outcome).toEqual({ success: false, reason: "forbidden" });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "POLISH_ABORT 拒绝：请求 id 不属于该发送者",
+    );
+    expect(registry.get("req-1")!.controller.signal.aborted).toBe(false);
+  });
+
+  it("release drops only the current owner's controller", () => {
+    const registry = createStreamAbortRegistry();
+    const first = registry.register("req-1", 1);
+    const second = registry.register("req-1", 2); // superseding run
+    registry.release("req-1", first); // stale release is a no-op
+    expect(registry.get("req-1")?.controller).toBe(second);
+    registry.release("req-1", second);
+    expect(registry.get("req-1")).toBeUndefined();
+  });
+});
+
+describe("aiService — listProviderModels (LIST_MODELS seam)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects a private https URL through the SSRF gate before any fetch", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { deps } = makeDeps();
+    const result = await listProviderModels(deps, "https://10.0.0.1/v1");
+    expect(result).toEqual({
+      success: false,
+      reason: "invalid_url",
+      models: [],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves a masked key against the stored credential and lists models", async () => {
+    // Typed params so mock.calls infers [url, init] tuples (no cast dance).
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(JSON.stringify({ data: [{ id: "m-1" }, { id: "m-2" }] }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { deps, databaseManager } = makeDeps();
+    databaseManager.getSetting.mockResolvedValue("stored-secret");
+    const result = await listProviderModels(
+      deps,
+      "https://api.example.com/v1",
+      "****abcd",
+    );
+    expect(result).toEqual({ success: true, models: ["m-1", "m-2"] });
+    expect(databaseManager.getSetting).toHaveBeenCalledWith("ai_api_key");
+    const init = fetchMock.mock.calls[0]![1] as {
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe("Bearer stored-secret");
+  });
+
+  it("falls back through the /v1 candidate and reports fetch_failed on the last", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("conn refused");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { deps, logger } = makeDeps();
+    const result = await listProviderModels(deps, "https://api.example.com");
+    expect(result).toEqual({
+      success: false,
+      reason: "fetch_failed",
+      models: [],
+    });
+    // Two-candidate derivation for a base without a version segment.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("preserves the SSRF gate contract (validateAIBaseUrl moved verbatim)", () => {
+    expect(validateAIBaseUrl("javascript:alert(1)")).toBe(false);
+    expect(validateAIBaseUrl("http://api.example.com/v1")).toBe(false);
+    expect(validateAIBaseUrl("https://api.example.com/v1")).toBe(true);
+    expect(
+      validateAIBaseUrl("http://127.0.0.1:11434/v1", { allowLocalhost: true }),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/historyService.test.ts
+++ b/tests/unit/historyService.test.ts
@@ -1,0 +1,338 @@
+// [20260912_Refactor_262_AiHistoryService] Headless seam tests for the
+// history write/query/delete services extracted in ticket #262 (spec #258
+// Phase 0). saveTranscriptionService / getTranscriptionsService /
+// deleteTranscriptionService / clearTranscriptionsService /
+// exportAllTranscriptionsService run with plain vi.fn() deps — no Electron
+// import anywhere: the native save dialog is injected as the
+// showSaveDialog callback, and the file write uses plain fs. Behavior
+// parity with the IPC handlers is locked by the unmodified
+// tests/unit/transcriptionHandlers.test.ts.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// [20260912_Refactor_262_AiHistoryService] Controllable formatter module
+// (same pattern as transcriptionHandlers.test.ts): getFormatInfo returns a
+// stub formatter, formatDOCX yields deterministic bytes for the docx arm.
+vi.mock("../../src/helpers/exportFormatters", () => ({
+  formatDOCX: vi.fn(async () => Buffer.from("docx-bytes")),
+  getFormatInfo: vi.fn(() => ({
+    ext: ".txt",
+    label: "Text",
+    formatter: () => "formatted",
+  })),
+}));
+
+import {
+  clearTranscriptionsService,
+  deleteTranscriptionService,
+  exportAllTranscriptionsService,
+  getTranscriptionsService,
+  saveTranscriptionService,
+  type HistoryRow,
+  type Logger,
+  type SaveFileDialogOptions,
+} from "../../src/helpers/services/historyService";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+interface MockDeps {
+  databaseManager: {
+    saveTranscription: MockFn;
+    getTranscriptions: MockFn;
+    deleteTranscription: MockFn;
+    clearAllTranscriptions: MockFn;
+  };
+  logger: Record<string, MockFn>;
+}
+
+// [20260912_Refactor_262_AiHistoryService] `unknown` bridge (no `any`, the
+// established pattern from transcriptionService.test.ts): the loosely-typed
+// vi.fn() mocks are bridged to the union of the service deps shapes. The
+// bridge is a structural superset, so it satisfies every service's narrow
+// deps slice.
+interface ServiceDepsBridge {
+  databaseManager: {
+    saveTranscription(data: Record<string, unknown>): {
+      lastInsertRowid?: number | bigint;
+      changes?: number;
+    };
+    getTranscriptions(limit: number, offset: number): HistoryRow[];
+    deleteTranscription(id: number): unknown;
+    clearAllTranscriptions(): unknown;
+  };
+  logger: Logger;
+}
+
+describe("historyService (headless seam, ticket #262)", () => {
+  let mockDeps: MockDeps;
+
+  beforeEach(() => {
+    mockDeps = {
+      databaseManager: {
+        saveTranscription: vi.fn(() => ({ lastInsertRowid: 42n, changes: 1 })),
+        getTranscriptions: vi.fn(() => []),
+        deleteTranscription: vi.fn(() => ({ changes: 1 })),
+        clearAllTranscriptions: vi.fn(() => ({ changes: 5 })),
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    };
+  });
+
+  const serviceDeps = (): ServiceDepsBridge =>
+    mockDeps as unknown as ServiceDepsBridge;
+
+  const dialogOk = (filePath: string) =>
+    vi.fn(async (_options: SaveFileDialogOptions) => ({
+      canceled: false,
+      filePath,
+    }));
+
+  describe("saveTranscriptionService", () => {
+    it("persists the record and normalizes a bigint rowid to Number", () => {
+      const result = saveTranscriptionService(serviceDeps(), { text: "hello" });
+      expect(mockDeps.databaseManager.saveTranscription).toHaveBeenCalledWith({
+        text: "hello",
+      });
+      expect(result).toEqual({
+        success: true,
+        lastInsertRowid: 42,
+        changes: 1,
+      });
+      expect(result.lastInsertRowid).toBe(42); // Number(42n)
+    });
+
+    it("passes a missing rowid through as undefined (no fabricated value)", () => {
+      mockDeps.databaseManager.saveTranscription.mockReturnValueOnce({
+        changes: 1,
+      });
+      const result = saveTranscriptionService(serviceDeps(), { text: "hello" });
+      expect(result.success).toBe(true);
+      expect(result.lastInsertRowid).toBeUndefined();
+      expect(result.changes).toBe(1);
+    });
+
+    it("surfaces a DB failure through the error envelope and logs it", () => {
+      mockDeps.databaseManager.saveTranscription.mockImplementationOnce(() => {
+        throw new Error("DB locked");
+      });
+      const result = saveTranscriptionService(serviceDeps(), { text: "hello" });
+      expect(result).toEqual({ success: false, error: "DB locked" });
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        "保存转录失败:",
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe("getTranscriptionsService", () => {
+    it("passes limit/offset through and returns the rows raw (no envelope)", () => {
+      const rows = [{ id: 1, text: "a", segments: "[]" }];
+      mockDeps.databaseManager.getTranscriptions.mockReturnValueOnce(rows);
+      const result = getTranscriptionsService(serviceDeps(), 100, 20);
+      expect(mockDeps.databaseManager.getTranscriptions).toHaveBeenCalledWith(
+        100,
+        20,
+      );
+      expect(result).toBe(rows);
+    });
+  });
+
+  describe("deleteTranscriptionService", () => {
+    it("wraps the RunResult into {success, changes}", () => {
+      const result = deleteTranscriptionService(serviceDeps(), 42);
+      expect(mockDeps.databaseManager.deleteTranscription).toHaveBeenCalledWith(
+        42,
+      );
+      expect(result).toEqual({ success: true, changes: 1 });
+    });
+
+    it("normalizes a missing changes count to 0", () => {
+      mockDeps.databaseManager.deleteTranscription.mockReturnValueOnce({});
+      expect(deleteTranscriptionService(serviceDeps(), 42)).toEqual({
+        success: true,
+        changes: 0,
+      });
+    });
+
+    it("surfaces a DB failure through the error envelope and logs it", () => {
+      mockDeps.databaseManager.deleteTranscription.mockImplementationOnce(
+        () => {
+          throw new Error("foreign key");
+        },
+      );
+      const result = deleteTranscriptionService(serviceDeps(), 42);
+      expect(result).toEqual({ success: false, error: "foreign key" });
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        "删除转录记录失败:",
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe("clearTranscriptionsService", () => {
+    it("wraps the RunResult into {success, changes}", () => {
+      expect(clearTranscriptionsService(serviceDeps())).toEqual({
+        success: true,
+        changes: 5,
+      });
+      expect(
+        mockDeps.databaseManager.clearAllTranscriptions,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("normalizes a missing changes count to 0", () => {
+      mockDeps.databaseManager.clearAllTranscriptions.mockReturnValueOnce({});
+      expect(clearTranscriptionsService(serviceDeps())).toEqual({
+        success: true,
+        changes: 0,
+      });
+    });
+
+    it("surfaces a DB failure through the error envelope and logs it", () => {
+      mockDeps.databaseManager.clearAllTranscriptions.mockImplementationOnce(
+        () => {
+          throw new Error("clear failed");
+        },
+      );
+      const result = clearTranscriptionsService(serviceDeps());
+      expect(result).toEqual({ success: false, error: "clear failed" });
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        "清空转录记录失败:",
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe("exportAllTranscriptionsService", () => {
+    it("rejects when there are no rows to export", async () => {
+      const showSaveDialog = dialogOk("/tmp/unused.txt");
+      const result = await exportAllTranscriptionsService(
+        serviceDeps(),
+        "txt",
+        showSaveDialog,
+      );
+      expect(result).toEqual({ success: false, error: "没有转录记录可导出" });
+      expect(showSaveDialog).not.toHaveBeenCalled();
+    });
+
+    it("treats a null row list as empty", async () => {
+      mockDeps.databaseManager.getTranscriptions.mockReturnValueOnce(
+        null as unknown as never[],
+      );
+      const result = await exportAllTranscriptionsService(
+        serviceDeps(),
+        "txt",
+        dialogOk("/tmp/unused.txt"),
+      );
+      expect(result).toEqual({ success: false, error: "没有转录记录可导出" });
+    });
+
+    it("rejects an unsupported format before showing the dialog", async () => {
+      mockDeps.databaseManager.getTranscriptions.mockReturnValueOnce([
+        { id: 1, text: "a" },
+      ]);
+      const { getFormatInfo } =
+        await import("../../src/helpers/exportFormatters");
+      vi.mocked(getFormatInfo).mockReturnValueOnce(null);
+      const showSaveDialog = dialogOk("/tmp/unused.txt");
+      const result = await exportAllTranscriptionsService(
+        serviceDeps(),
+        "bogus",
+        showSaveDialog,
+      );
+      expect(result).toEqual({ success: false, error: "不支持的格式: bogus" });
+      expect(showSaveDialog).not.toHaveBeenCalled();
+    });
+
+    it("defaults the empty format to txt and reports a canceled dialog", async () => {
+      mockDeps.databaseManager.getTranscriptions.mockReturnValueOnce([
+        { id: 1, text: "a" },
+      ]);
+      const showSaveDialog = vi.fn(async () => ({
+        canceled: true,
+        filePath: "",
+      }));
+      const result = await exportAllTranscriptionsService(
+        serviceDeps(),
+        "",
+        showSaveDialog,
+      );
+      expect(result).toEqual({ success: false, canceled: true });
+      const { getFormatInfo } =
+        await import("../../src/helpers/exportFormatters");
+      expect(getFormatInfo).toHaveBeenCalledWith("txt");
+    });
+
+    it("treats a falsy file path as a canceled dialog", async () => {
+      mockDeps.databaseManager.getTranscriptions.mockReturnValueOnce([
+        { id: 1, text: "a" },
+      ]);
+      const result = await exportAllTranscriptionsService(
+        serviceDeps(),
+        "txt",
+        vi.fn(async () => ({ canceled: false, filePath: "" })),
+      );
+      expect(result).toEqual({ success: false, canceled: true });
+    });
+
+    it("writes the joined txt output to the chosen path", async () => {
+      mockDeps.databaseManager.getTranscriptions.mockReturnValueOnce([
+        {
+          id: 1,
+          text: "a",
+          segments: '[{"start_ms":0,"end_ms":1,"text":"x"}]',
+        },
+        { id: 2, text: "b", segments: "{bad" }, // invalid JSON → []
+        { id: 3, text: "c", segments: null }, // non-string → []
+      ]);
+      const outfile = path.join(os.tmpdir(), `h262-export-${Date.now()}.txt`);
+      try {
+        const result = await exportAllTranscriptionsService(
+          serviceDeps(),
+          "txt",
+          dialogOk(outfile),
+        );
+        expect(result).toEqual({ success: true, path: outfile });
+        expect(fs.existsSync(outfile)).toBe(true);
+      } finally {
+        if (fs.existsSync(outfile)) fs.unlinkSync(outfile);
+      }
+    });
+
+    it("routes docx through formatDOCX and writes the Buffer", async () => {
+      mockDeps.databaseManager.getTranscriptions.mockReturnValueOnce([
+        { id: 1, text: "a" },
+      ]);
+      const outfile = path.join(os.tmpdir(), `h262-export-${Date.now()}.docx`);
+      try {
+        const result = await exportAllTranscriptionsService(
+          serviceDeps(),
+          "docx",
+          dialogOk(outfile),
+        );
+        expect(result).toEqual({ success: true, path: outfile });
+        expect(fs.readFileSync(outfile).toString()).toBe("docx-bytes");
+      } finally {
+        if (fs.existsSync(outfile)) fs.unlinkSync(outfile);
+      }
+    });
+
+    it("surfaces a DB read failure through the error envelope and logs it", async () => {
+      mockDeps.databaseManager.getTranscriptions.mockImplementationOnce(() => {
+        throw new Error("read failed");
+      });
+      const result = await exportAllTranscriptionsService(
+        serviceDeps(),
+        "txt",
+        dialogOk("/tmp/unused.txt"),
+      );
+      expect(result).toEqual({ success: false, error: "read failed" });
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        "导出转录失败:",
+        expect.any(Error),
+      );
+    });
+  });
+});

--- a/tests/unit/transcriptionService.test.ts
+++ b/tests/unit/transcriptionService.test.ts
@@ -234,3 +234,97 @@ describe("transcriptionService (headless seam, ticket #261)", () => {
   });
 });
 // [20260912_Refactor_261_TranscriptionService] END
+
+// [20260912_Refactor_262_AiHistoryService] Ticket #262: edge tests the
+// #261 review deferred to this ticket, now pinned at the SERVICE level.
+// Appended as a standalone describe — the #261 cases above are untouched.
+describe("transcribeFileService — deferred edge cases (#261 review → #262)", () => {
+  // Local deps builder mirroring the #261 harness above (loosely-typed
+  // vi.fn() mocks, `unknown` bridge, no `any`).
+  type MockFn = ReturnType<typeof vi.fn>;
+  let mockDeps: {
+    funasrManager: { transcribeFile: MockFn };
+    databaseManager: {
+      saveTranscription: MockFn;
+      getSetting: MockFn;
+      getTranscriptionById: MockFn;
+    };
+    logger: Record<string, MockFn>;
+  };
+
+  beforeEach(() => {
+    mockDeps = {
+      funasrManager: {
+        transcribeFile: vi.fn(async () => ({
+          success: true,
+          text: "文件转录",
+          raw_text: "raw",
+          segments: [],
+        })),
+      },
+      databaseManager: {
+        saveTranscription: vi.fn(() => ({ lastInsertRowid: 42n, changes: 1 })),
+        getSetting: vi.fn(() => null),
+        getTranscriptionById: vi.fn(() => null),
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    };
+  });
+
+  const serviceDeps = () => mockDeps as unknown as TranscriptionServiceDeps;
+
+  it("orchestrator timeout resolving {success:false} (not throwing) still fires the raw hotword-free fallback", async () => {
+    // A downstream engine/orchestrator timeout surfaces as a RESOLVED
+    // failure envelope, not a rejection. The hotword fallback contract
+    // must treat it as a failure exactly like a throw: retry once with
+    // the raw (hotword-free) options and flag hotword_degraded on success.
+    mockDeps.databaseManager.getSetting.mockReturnValue("张三");
+    mockDeps.funasrManager.transcribeFile
+      .mockResolvedValueOnce({ success: false, error: "AI 请求超时" })
+      .mockResolvedValueOnce({
+        success: true,
+        text: "重试成功",
+        raw_text: "r",
+        segments: [],
+      });
+    const result = (await transcribeFileService(
+      serviceDeps(),
+      "/fake/audio.wav",
+    )) as { success: boolean; text?: string; hotword_degraded?: boolean };
+    expect(mockDeps.funasrManager.transcribeFile).toHaveBeenCalledTimes(2);
+    const firstOpts = mockDeps.funasrManager.transcribeFile.mock
+      .calls[0]![1] as Record<string, unknown>;
+    const secondOpts = mockDeps.funasrManager.transcribeFile.mock
+      .calls[1]![1] as Record<string, unknown>;
+    expect(firstOpts.hotword).toBe("张三");
+    expect(secondOpts).not.toHaveProperty("hotword");
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("重试成功");
+    expect(result.hotword_degraded).toBe(true);
+    // The retry success IS persisted like any successful transcription.
+    expect(mockDeps.databaseManager.saveTranscription).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "重试成功" }),
+    );
+  });
+
+  it("saveTranscription throwing inside the persist returns the transcription result without id", async () => {
+    // The DB write must never fail the transcription the user already
+    // has in hand: the error is logged, the result keeps success+text,
+    // and no id is attached.
+    mockDeps.databaseManager.saveTranscription.mockImplementationOnce(() => {
+      throw new Error("DB locked");
+    });
+    const result = (await transcribeFileService(
+      serviceDeps(),
+      "/fake/audio.wav",
+    )) as { success: boolean; text?: string; id?: number };
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("文件转录");
+    expect(result).not.toHaveProperty("id");
+    expect(mockDeps.logger.error).toHaveBeenCalledWith(
+      "保存转录结果到数据库失败:",
+      expect.any(Error),
+    );
+  });
+});
+// [20260912_Refactor_262_AiHistoryService] END


### PR DESCRIPTION
## What

Spec #258 Phase 0 最后一块前置重构（与 #261 并列的另一半）：

- **AI 域**（`src/helpers/services/aiService.ts`）：`StreamAbortRegistry`（register/signalOf/release 超越规则/abort 发送者属主校验）、`processPolishText`（C.AI.PROCESS 入口体）、`listProviderModels`（含 SSRF 门 + 掩码密钥解析，逐字移动）。流式/deadline-matrix 编排器 `processTextWithAI` **原位保留**（归一化 diff 零差异），经注入 `runPolish` 依赖包装——高风险区不动只包
- **历史域**（`src/helpers/services/historyService.ts`）：SAVE/GET_ALL/DELETE/CLEAR/EXPORT_ALL 五操作，单写者 deps 切片，对话框以注入回调解耦（同 #261 onProgress 模式）
- handler 全部薄壳化；`GET_MODES/PRESETS/DETECT/CHECK_STATUS` 本就是单行委托，保持原样

## 关键设计点

- **sender 无值奇偶**：原 handler 仅在 requestId 分支读 `event.sender`；薄壳用 `SENDER_ID_NONE` 哨兵条件读取，无发送者调用不解引用（executor 首版急切读取曾破坏 7 个锁定测试，已复绿并注释防回归）
- **密钥路径不变**（AC）：仍主进程内 `getSetting("ai_api_key")` 解密，无新增读取参数/导出面；`listProviderModels` 掩码解析逐字保留
- **SAVE 唯一披露精化**：`lastInsertRowid` `Number()` 归一（与 #261 同），bigint/undefined 两臂测试钉住

## 行为锁定（AC）

既有套件零修改全绿：aiHandlers 114 / transcriptionHandlers 71 / list-models 19 / hotword-injection。新增 34 用例：超越握手（双在飞运行证明陈旧释放 no-op）、掩码密钥 Bearer 头断言、SSRF fetchMock 从不调用、真实 tmpdir 导出（txt/docx/取消/错误臂）、以及 #261 评审延后的 2 个服务级边界用例。

## 独立 code-review

APPROVE（4 项 0 阻塞）：机械归一化 diff 逐体核对（错误串逐字、SSRF 门/常量零漂移、编排器零差异）；已修 2 处注释项（#261 END 标记恢复、头注释措辞），文件显式 staging（MINOR-2），类型级导入方向留 follow-up。

## 风险声明

- `mode=undefined→"optimize"` 默认从 handler 签名移入服务：显式传 null 的调用方会得到默认值（null 从非合法 mode，无调用方如此）
- `Number()` 归一在 rowid > 2^53 丢精度：本地表不现实

## 验证

`pnpm ci:check` 11/11 全绿（此前一次 dev smoke 失败为两个 ci:check 并发撞 #260 单实例锁所致——单独复跑即绿，顺带实测了锁行为）；240 相关测试 + 65 旁证套件全绿

Closes #262