### PR TITLE
feat: murmur CLI 骨架 — config get/set 白名单 + history list 只读直连 (Spec #258 #264, closes #264)

### DIFF
--- a/cli/lib/cliRunner.mjs
+++ b/cli/lib/cliRunner.mjs
@@ -16,6 +16,10 @@ import { readConfig, writeConfig } from "./configStore.mjs";
 import { DEFAULT_HISTORY_LIMIT, listTranscriptions } from "./historyReader.mjs";
 import os from "node:os";
 
+// [20260912_Fix_264_ReviewFollowups] Mirrors validateSetting's
+// MAX_VALUE_LENGTH in src/helpers/ipc/settingsHandlers.ts (boundary parity).
+const MAX_VALUE_LENGTH = 10000;
+
 export const EXIT_OK = 0;
 export const EXIT_RUNTIME_ERROR = 1;
 export const EXIT_USAGE_ERROR = 2; // 4 is reserved for future use, unused here.
@@ -157,6 +161,15 @@ function runConfigSet(argv, ctx) {
 
   const [key, rawValue] = parsed.positionals;
   if (!isConfigKey(key)) return usageError(`config: key not allowed: ${key}`);
+  // [20260912_Fix_264_ReviewFollowups] Boundary parity with the IPC
+  // settings path: values longer than MAX_VALUE_LENGTH are rejected there
+  // (settingsHandlers validateSetting); the CLI must not accept what the
+  // app's own write boundary would refuse.
+  if (typeof rawValue === "string" && rawValue.length > MAX_VALUE_LENGTH) {
+    return usageError(
+      `config set: value exceeds ${MAX_VALUE_LENGTH} characters`,
+    );
+  }
   const value = parseSettingValue(rawValue);
 
   try {

--- a/cli/lib/cliRunner.mjs
+++ b/cli/lib/cliRunner.mjs
@@ -1,0 +1,285 @@
+// [20260912_Feat_CliSkeleton] Core argv->result runner for the murmur CLI
+// (ticket #264, spec #258). Pure-ish function level: runCli(argv, options)
+// returns { code, stdout, stderr } — the entry point (cli/murmur.mjs) only
+// wires process streams and process.exit onto that result. This shape keeps
+// the locked CLI conventions structural and unit-testable without spawning a
+// process:
+//   - `--json` switches stdout to a stable JSON schema (per subcommand)
+//   - exit codes: 0 success / 1 runtime error / 2 usage error (4 reserved)
+//   - logs, progress and error text go to stderr only; stdout carries results
+//   - no prompts, no spinners: every code path either prints and exits
+// Local subcommands only (the app does NOT need to be running):
+//   murmur config get <key> | config set <key> <value> | history list
+import { resolveConfigPath, resolveDatabasePath } from "./paths.mjs";
+import { isConfigKey } from "./configKeys.mjs";
+import { readConfig, writeConfig } from "./configStore.mjs";
+import { DEFAULT_HISTORY_LIMIT, listTranscriptions } from "./historyReader.mjs";
+import os from "node:os";
+
+export const EXIT_OK = 0;
+export const EXIT_RUNTIME_ERROR = 1;
+export const EXIT_USAGE_ERROR = 2; // 4 is reserved for future use, unused here.
+
+/** Long preview cap for text-mode history lines (not applied to --json). */
+const TEXT_PREVIEW_MAX_CHARS = 120;
+const TEXT_PREVIEW_ELLIPSIS = "…";
+
+const USAGE = `murmur — Murmur command line interface
+
+Usage:
+  murmur config get <key>              Read a whitelisted setting from murmur.json
+  murmur config set <key> <value>      Write a whitelisted setting to murmur.json
+  murmur history list [--query <text>] [--limit N] [--json]
+                                       List transcriptions directly from SQLite (read-only)
+
+Global options:
+  --json                               Structured JSON output on stdout
+  --version                            Print the CLI version
+  --help                               Show this help
+
+Notes:
+  - Whitelisted keys are the same list the app enforces for settings.
+  - exit codes: 0 success, 1 runtime error, 2 usage error.
+  - Logs and errors go to stderr; results go to stdout.`;
+
+function ok(stdout = "", stderr = "") {
+  return { code: EXIT_OK, stdout, stderr };
+}
+
+function usageError(message) {
+  return {
+    code: EXIT_USAGE_ERROR,
+    stdout: "",
+    stderr: `${message}\n\n${USAGE}\n`,
+  };
+}
+
+function runtimeError(context, message) {
+  return {
+    code: EXIT_RUNTIME_ERROR,
+    stdout: "",
+    stderr: `murmur ${context}: ${message}\n`,
+  };
+}
+
+/** Parse a CLI value the same way the app's JSON settings store would round-trip it. */
+function parseSettingValue(rawValue) {
+  try {
+    return JSON.parse(rawValue);
+  } catch {
+    // Not valid JSON — store the literal string (e.g. `config set theme dark`).
+    return rawValue;
+  }
+}
+
+/** Format a setting value for text-mode stdout: strings bare, rest as JSON. */
+function formatSettingValue(value) {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/** Single-line preview for text-mode history output (never applied to --json). */
+function previewText(text) {
+  const flat = String(text).replace(/\s+/g, " ").trim();
+  if (flat.length <= TEXT_PREVIEW_MAX_CHARS) return flat;
+  return flat.slice(0, TEXT_PREVIEW_MAX_CHARS) + TEXT_PREVIEW_ELLIPSIS;
+}
+
+/**
+ * Split argv into a global-flag map and the positional tokens.
+ * Accepts both `--flag value` and `--flag=value`. Unknown flags surface as
+ * { unknown: true } so subcommand parsers can reject them as usage errors.
+ */
+function parseArgs(argv, knownFlags) {
+  const flags = {};
+  const positionals = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+
+    const eqIndex = token.indexOf("=");
+    const name = eqIndex === -1 ? token : token.slice(0, eqIndex);
+    if (!knownFlags.has(name)) return { unknown: name };
+
+    const takesValue = name !== "--json";
+    if (!takesValue) {
+      flags[name] = true;
+      continue;
+    }
+    if (eqIndex !== -1) {
+      flags[name] = token.slice(eqIndex + 1);
+      continue;
+    }
+    i += 1;
+    // A following token that looks like another flag is never a value —
+    // e.g. `--query --limit 5` must not search for the text "--limit".
+    if (i >= argv.length || argv[i].startsWith("--")) return { missing: name };
+    flags[name] = argv[i];
+  }
+  return { flags, positionals };
+}
+
+function runConfigGet(argv, ctx) {
+  const parsed = parseArgs(argv, new Set());
+  if (parsed.unknown)
+    return usageError(`config get: unknown flag ${parsed.unknown}`);
+  if (parsed.missing)
+    return usageError(`config get: ${parsed.missing} requires a value`);
+  if (parsed.positionals.length === 0)
+    return usageError("config get: missing <key>");
+  if (parsed.positionals.length > 1)
+    return usageError("config get: unexpected extra arguments");
+
+  const key = parsed.positionals[0];
+  if (!isConfigKey(key)) return usageError(`config: key not allowed: ${key}`);
+
+  const config = readConfig(ctx.configPath);
+  const value = key in config ? config[key] : null;
+
+  if (ctx.json) {
+    return ok(`${JSON.stringify({ key, value })}\n`);
+  }
+  return ok(`${formatSettingValue(value)}\n`);
+}
+
+function runConfigSet(argv, ctx) {
+  const parsed = parseArgs(argv, new Set());
+  if (parsed.unknown)
+    return usageError(`config set: unknown flag ${parsed.unknown}`);
+  if (parsed.missing)
+    return usageError(`config set: ${parsed.missing} requires a value`);
+  if (parsed.positionals.length < 2)
+    return usageError("config set: missing <key> and/or <value>");
+  if (parsed.positionals.length > 2)
+    return usageError("config set: unexpected extra arguments");
+
+  const [key, rawValue] = parsed.positionals;
+  if (!isConfigKey(key)) return usageError(`config: key not allowed: ${key}`);
+  const value = parseSettingValue(rawValue);
+
+  try {
+    // Read-modify-write keeps every other whitelisted key in the file
+    // (mirrors the app's syncToFileConfig behaviour).
+    const config = readConfig(ctx.configPath);
+    config[key] = value;
+    writeConfig(ctx.configPath, config);
+  } catch (error) {
+    return runtimeError(
+      `config set ${key}`,
+      `cannot write ${ctx.configPath}: ${error.message}`,
+    );
+  }
+
+  if (ctx.json) {
+    return ok(`${JSON.stringify({ success: true, key, value })}\n`);
+  }
+  return ok();
+}
+
+function runHistoryList(argv, ctx) {
+  const parsed = parseArgs(argv, new Set(["--query", "--limit"]));
+  if (parsed.unknown)
+    return usageError(`history list: unknown flag ${parsed.unknown}`);
+  if (parsed.missing)
+    return usageError(`history list: ${parsed.missing} requires a value`);
+  if (parsed.positionals.length > 0)
+    return usageError("history list: unexpected extra arguments");
+
+  let limit = DEFAULT_HISTORY_LIMIT;
+  if (parsed.flags["--limit"] !== undefined) {
+    const rawLimit = parsed.flags["--limit"];
+    if (!/^\d+$/.test(String(rawLimit)) || Number(rawLimit) < 1) {
+      return usageError(
+        `history list: --limit must be a positive integer, got ${rawLimit}`,
+      );
+    }
+    limit = Number(rawLimit);
+  }
+
+  let records;
+  try {
+    records = listTranscriptions(ctx.dbPath, {
+      query: parsed.flags["--query"] ?? null,
+      limit,
+    });
+  } catch (error) {
+    return runtimeError(
+      "history list",
+      `cannot read database at ${ctx.dbPath}: ${error.message}`,
+    );
+  }
+
+  if (ctx.json) {
+    return ok(`${JSON.stringify({ records })}\n`);
+  }
+
+  const lines = records.map(
+    (record) =>
+      `#${record.id}\t${record.created_at ?? ""}\t${previewText(record.text)}`,
+  );
+  return ok(lines.length > 0 ? `${lines.join("\n")}\n` : "");
+}
+
+/**
+ * Run one CLI invocation. argv excludes the node/electron and script paths.
+ *
+ * @param {string[]} argv
+ * @param {object} [options]
+ * @param {Record<string, string | undefined>} [options.env] Environment (defaults to process.env).
+ * @param {string} [options.platform] Platform (defaults to process.platform).
+ * @param {() => string} [options.homedir] Home dir resolver (defaults to os.homedir).
+ * @param {string} [options.configPath] Explicit murmur.json path (skips env derivation).
+ * @param {string} [options.dbPath] Explicit SQLite path (skips env derivation).
+ * @param {string} [options.version] Version string for --version.
+ * @returns {{ code: number, stdout: string, stderr: string }}
+ */
+export function runCli(argv, options = {}) {
+  // `--json` is a global flag honoured at any position (locked convention:
+  // "--json structured output on stdout"), so strip it before command
+  // dispatch — subcommand parsers never see it.
+  const json = argv.includes("--json");
+  const dispatch = argv.filter((token) => token !== "--json");
+  const ctx = {
+    configPath:
+      options.configPath ??
+      resolveConfigPath({
+        env: options.env ?? process.env,
+        platform: options.platform ?? process.platform,
+        homedir: options.homedir ?? os.homedir,
+      }),
+    dbPath:
+      options.dbPath ??
+      resolveDatabasePath({
+        env: options.env ?? process.env,
+        platform: options.platform ?? process.platform,
+        homedir: options.homedir ?? os.homedir,
+      }),
+    json,
+    version: options.version ?? "",
+  };
+
+  if (dispatch.includes("--version")) {
+    return ok(`${ctx.version || "unknown"}\n`);
+  }
+  if (dispatch.includes("--help")) {
+    return ok(`${USAGE}\n`);
+  }
+
+  const [command, subcommand, ...rest] = dispatch;
+  if (command === undefined) return usageError("missing command");
+  if (command !== "config" && command !== "history") {
+    return usageError(`unknown command: ${command}`);
+  }
+
+  if (command === "config") {
+    if (subcommand === "get") return runConfigGet(rest, ctx);
+    if (subcommand === "set") return runConfigSet(rest, ctx);
+    return usageError(`unknown config subcommand: ${String(subcommand)}`);
+  }
+
+  // command === "history": the only subcommand in this batch is `list`.
+  if (subcommand === "list") return runHistoryList(rest, ctx);
+  return usageError(`unknown history subcommand: ${String(subcommand)}`);
+}

--- a/cli/lib/configKeys.mjs
+++ b/cli/lib/configKeys.mjs
@@ -1,36 +1,32 @@
 // [20260912_Feat_CliSkeleton] murmur CLI config whitelist (ticket #264).
 //
-// This list MUST stay in sync with ALLOWED_SETTING_KEYS in
-// src/helpers/ipc/settingsHandlers.ts — the same key list semantics as the
-// IPC settings boundary. The CLI cannot import TypeScript at runtime (it
-// runs as a zero-dependency .mjs under ELECTRON_RUN_AS_NODE), so the list is
-// mirrored here; tests/unit/cli-config.test.ts imports both modules and
-// asserts set equality in both directions, so any drift fails CI.
+// [20260912_Fix_264_ConfigWhitelistScope] This list mirrors
+// FILE_CONFIGURABLE_KEYS in src/helpers/fileConfig.ts — the keys murmur.json
+// ACTUALLY honors on load — not the broader IPC settings allowlist. Two
+// reasons:
+//   1. Effectiveness: the app filters murmur.json through this narrower list
+//      (fileConfig.ts load/save both gate on it), so `config set` on any
+//      other key would write a value the app silently ignores.
+//   2. Secret hygiene: ai_api_key is deliberately ABSENT from the file
+//      whitelist ("colleague names / keys must not land in a plaintext
+//      dotfile" — fileConfig.ts header); an IPC-derived list would have let
+//      the CLI write the decrypted key into plaintext murmur.json.
+// The CLI cannot import TypeScript at runtime (zero-dependency .mjs under
+// ELECTRON_RUN_AS_NODE), so the list is mirrored; tests/unit/cli-config.test.ts
+// asserts set equality against fileConfig's export in both directions, so any
+// drift fails CI.
 export const CONFIG_KEYS = Object.freeze([
-  "ai_api_key",
   "ai_base_url",
   "ai_model",
   "ai_temperature",
   "ai_max_tokens",
-  "enable_ai_optimization",
-  // [20260905_Fix_249_DefaultModeUi] Default AI processing mode (issue #249).
-  "default_mode",
-  "window_always_on_top",
-  "auto_paste",
-  "close_behavior",
-  "theme",
   "hotkey",
   "language",
+  "theme",
+  "auto_paste",
   "auto_start",
   "minimize_to_tray",
   "show_notifications",
-  "model_download_path",
-  // [20260820_T14_Hotwords] Hotword list (sanitized at the app boundaries).
-  "hotwords",
-  // [20260905_Feat_BloubSettings] bot mascot catalogue keys (spec #224).
-  "bot_shape",
-  "bot_color",
-  "bot_expression",
 ]);
 
 const CONFIG_KEY_SET = new Set(CONFIG_KEYS);

--- a/cli/lib/configKeys.mjs
+++ b/cli/lib/configKeys.mjs
@@ -1,0 +1,41 @@
+// [20260912_Feat_CliSkeleton] murmur CLI config whitelist (ticket #264).
+//
+// This list MUST stay in sync with ALLOWED_SETTING_KEYS in
+// src/helpers/ipc/settingsHandlers.ts — the same key list semantics as the
+// IPC settings boundary. The CLI cannot import TypeScript at runtime (it
+// runs as a zero-dependency .mjs under ELECTRON_RUN_AS_NODE), so the list is
+// mirrored here; tests/unit/cli-config.test.ts imports both modules and
+// asserts set equality in both directions, so any drift fails CI.
+export const CONFIG_KEYS = Object.freeze([
+  "ai_api_key",
+  "ai_base_url",
+  "ai_model",
+  "ai_temperature",
+  "ai_max_tokens",
+  "enable_ai_optimization",
+  // [20260905_Fix_249_DefaultModeUi] Default AI processing mode (issue #249).
+  "default_mode",
+  "window_always_on_top",
+  "auto_paste",
+  "close_behavior",
+  "theme",
+  "hotkey",
+  "language",
+  "auto_start",
+  "minimize_to_tray",
+  "show_notifications",
+  "model_download_path",
+  // [20260820_T14_Hotwords] Hotword list (sanitized at the app boundaries).
+  "hotwords",
+  // [20260905_Feat_BloubSettings] bot mascot catalogue keys (spec #224).
+  "bot_shape",
+  "bot_color",
+  "bot_expression",
+]);
+
+const CONFIG_KEY_SET = new Set(CONFIG_KEYS);
+
+/** True when the key may be read/written by `murmur config`. */
+export function isConfigKey(key) {
+  return CONFIG_KEY_SET.has(key);
+}

--- a/cli/lib/configStore.mjs
+++ b/cli/lib/configStore.mjs
@@ -1,0 +1,57 @@
+// [20260912_Feat_CliSkeleton] murmur.json reader/writer for the CLI
+// (ticket #264). Mirrors the app's src/helpers/fileConfig.ts semantics so the
+// CLI and the app agree on the same file: unknown keys are filtered out on
+// read AND on write (loadFileConfig/saveFileConfig behaviour), invalid or
+// missing files read as {}, and the file is pretty-printed with 2-space
+// indent exactly like saveFileConfig. The key whitelist itself lives in
+// configKeys.mjs.
+import fs from "node:fs";
+import path from "node:path";
+import { CONFIG_KEYS } from "./configKeys.mjs";
+
+const JSON_INDENT_SPACES = 2;
+
+/**
+ * Load the whitelist-filtered settings from murmur.json.
+ * Returns {} when the file is missing, unreadable, or not a JSON object —
+ * the same contract as the app's loadFileConfig (which swallows every error).
+ */
+export function readConfig(configPath) {
+  try {
+    if (!fs.existsSync(configPath)) return {};
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+      return {};
+
+    const filtered = {};
+    for (const key of Object.keys(parsed)) {
+      if (CONFIG_KEYS.includes(key)) filtered[key] = parsed[key];
+    }
+    return filtered;
+  } catch {
+    // Mirror the app: a broken config file degrades to {} rather than
+    // failing the read path.
+    return {};
+  }
+}
+
+/**
+ * Persist a whitelist-filtered settings record to murmur.json, creating
+ * parent directories as needed (saveFileConfig behaviour). Throws on real
+ * write errors (permissions, disk) — the CLI maps those to exit code 1.
+ */
+export function writeConfig(configPath, settings) {
+  const filtered = {};
+  for (const key of Object.keys(settings)) {
+    if (CONFIG_KEYS.includes(key)) filtered[key] = settings[key];
+  }
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(filtered, null, JSON_INDENT_SPACES),
+    "utf-8",
+  );
+  return filtered;
+}

--- a/cli/lib/historyReader.mjs
+++ b/cli/lib/historyReader.mjs
@@ -1,0 +1,59 @@
+// [20260912_Feat_CliSkeleton] Read-only transcriptions reader for the murmur
+// CLI (ticket #264). Opens the same SQLite file the app creates
+// (src/helpers/database.ts, node:sqlite per spec #226) with
+// `new DatabaseSync(path, { readOnly: true })`: SQLite read-only mode never
+// takes the writer lock, so a running Murmur instance is never blocked, and
+// a missing database fails the open instead of being created as a side
+// effect. The column list mirrors the app's transcriptions schema
+// (database.ts createTables + _migrateSchema).
+import { DatabaseSync } from "node:sqlite";
+
+/** Default page size — mirrors getTranscriptions(limit = 50) in database.ts. */
+export const DEFAULT_HISTORY_LIMIT = 50;
+
+const LIST_COLUMNS =
+  "id, text, processed_text, language, duration, source_type, created_at";
+
+/**
+ * Escape LIKE wildcards so --query matches literally, for use with the
+ * `ESCAPE '\'` clause in the statements below.
+ */
+function escapeLikePattern(text) {
+  return text.replace(/[\\%_]/g, (char) => `\\${char}`);
+}
+
+/**
+ * List transcription records, newest first (same ORDER BY as
+ * getTranscriptions). `query` does a literal substring match over text and
+ * processed_text; `limit` must be a positive integer.
+ *
+ * Throws when the database cannot be opened or queried — the CLI maps that
+ * to exit code 1 (runtime error).
+ */
+export function listTranscriptions(
+  dbPath,
+  { query = null, limit = DEFAULT_HISTORY_LIMIT } = {},
+) {
+  // [20260912_Feat_CliSkeleton] readOnly: true is the whole point of the
+  // direct-read design (see file header). Open/close per invocation: a CLI
+  // run is one-shot, there is nothing to pool.
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    if (query === null) {
+      const stmt = db.prepare(
+        `SELECT ${LIST_COLUMNS} FROM transcriptions ORDER BY created_at DESC LIMIT ?`,
+      );
+      return stmt.all(limit);
+    }
+
+    const pattern = `%${escapeLikePattern(query)}%`;
+    const stmt = db.prepare(
+      `SELECT ${LIST_COLUMNS} FROM transcriptions
+       WHERE text LIKE ? ESCAPE '\\' OR processed_text LIKE ? ESCAPE '\\'
+       ORDER BY created_at DESC LIMIT ?`,
+    );
+    return stmt.all(pattern, pattern, limit);
+  } finally {
+    db.close();
+  }
+}

--- a/cli/lib/paths.mjs
+++ b/cli/lib/paths.mjs
@@ -1,0 +1,75 @@
+// [20260912_Feat_CliSkeleton] Path resolution for the murmur CLI (ticket #264,
+// spec #258). Replicates — in plain ESM, because cli/ must run with zero deps
+// under ELECTRON_RUN_AS_NODE — the exact derivations used by the app:
+//   - data directory: src/helpers/environment.ts getDataDirectory()
+//   - ELECTRON_USER_DATA override: main.ts sets it before spawning children
+//   - murmur.json location: main.ts (dataDirectory + "murmur.json")
+//   - database location + MURMUR_DB_PATH override: src/helpers/database.ts
+//     initialize() (MURMUR_DB_PATH || dataDirectory/transcriptions.db)
+// tests/unit/cli.test.ts locks the derivation shape per platform.
+import path from "node:path";
+
+const APP_DATA_DIR_NAME = "Murmur";
+const CONFIG_FILE_NAME = "murmur.json";
+const DATABASE_FILE_NAME = "transcriptions.db";
+
+/** Environment variable overrides honoured by the CLI (same names the app uses). */
+export const ENV_USER_DATA = "ELECTRON_USER_DATA";
+export const ENV_DB_PATH = "MURMUR_DB_PATH";
+
+/**
+ * @typedef {object} PathContext
+ * @property {Record<string, string | undefined>} [env] Environment (defaults to process.env).
+ * @property {string} [platform] Platform identifier (defaults to process.platform).
+ * @property {() => string} [homedir] Home directory resolver (defaults to os.homedir).
+ */
+
+/**
+ * Resolve the Murmur data directory.
+ *
+ * Precedence: ELECTRON_USER_DATA env (set by the app for its children; also
+ * lets tests/dev shells redirect everything) -> platform default mirroring
+ * environment.ts exactly (win32: AppData/Roaming, darwin: Application Support,
+ * linux: .config, other: ~/.murmur).
+ *
+ * @param {PathContext} [context]
+ * @returns {string}
+ */
+export function resolveDataDirectory(context = {}) {
+  const env = context.env ?? process.env;
+  const platform = context.platform ?? process.platform;
+  const homedir = context.homedir ?? (() => "");
+  const override = env[ENV_USER_DATA];
+  if (override) return override;
+
+  switch (platform) {
+    case "win32":
+      return path.join(homedir(), "AppData", "Roaming", APP_DATA_DIR_NAME);
+    case "darwin":
+      return path.join(
+        homedir(),
+        "Library",
+        "Application Support",
+        APP_DATA_DIR_NAME,
+      );
+    case "linux":
+      return path.join(homedir(), ".config", APP_DATA_DIR_NAME);
+    default:
+      return path.join(homedir(), `.${APP_DATA_DIR_NAME.toLowerCase()}`);
+  }
+}
+
+/** Resolve the murmur.json path (main.ts: dataDirectory + "murmur.json"). */
+export function resolveConfigPath(context = {}) {
+  return path.join(resolveDataDirectory(context), CONFIG_FILE_NAME);
+}
+
+/**
+ * Resolve the SQLite database path (database.ts initialize():
+ * MURMUR_DB_PATH env wins, else dataDirectory/transcriptions.db).
+ */
+export function resolveDatabasePath(context = {}) {
+  const override = context.env?.[ENV_DB_PATH];
+  if (override) return override;
+  return path.join(resolveDataDirectory(context), DATABASE_FILE_NAME);
+}

--- a/cli/lib/paths.mjs
+++ b/cli/lib/paths.mjs
@@ -7,6 +7,7 @@
 //   - database location + MURMUR_DB_PATH override: src/helpers/database.ts
 //     initialize() (MURMUR_DB_PATH || dataDirectory/transcriptions.db)
 // tests/unit/cli.test.ts locks the derivation shape per platform.
+import os from "node:os";
 import path from "node:path";
 
 const APP_DATA_DIR_NAME = "Murmur";
@@ -32,13 +33,24 @@ export const ENV_DB_PATH = "MURMUR_DB_PATH";
  * environment.ts exactly (win32: AppData/Roaming, darwin: Application Support,
  * linux: .config, other: ~/.murmur).
  *
+ * [20260912_Fix_264_ReviewFollowups] Known dev-mode caveat (pre-existing app
+ * quirk, zero impact on packaged builds): in dev, ELECTRON_USER_DATA points
+ * at app.getPath("userData") (lowercase "murmur" from package.json name)
+ * while the app's data actually lives under the capital-M "Murmur" dir that
+ * environment.ensureDataDirectory() creates. A CLI spawned by a dev-run app
+ * should therefore prefer MURMUR_DB_PATH / an explicit config path override
+ * until the app unifies the two derivations (tracked for #265).
+ *
  * @param {PathContext} [context]
  * @returns {string}
  */
 export function resolveDataDirectory(context = {}) {
   const env = context.env ?? process.env;
   const platform = context.platform ?? process.platform;
-  const homedir = context.homedir ?? (() => "");
+  // [20260912_Fix_264_ReviewFollowups] Default to the real homedir (the
+  // JSDoc contract); the previous empty-string default would yield
+  // root-relative paths if a caller omitted the context.
+  const homedir = context.homedir ?? os.homedir;
   const override = env[ENV_USER_DATA];
   if (override) return override;
 

--- a/cli/lib/version.mjs
+++ b/cli/lib/version.mjs
@@ -1,0 +1,33 @@
+// [20260912_Feat_CliSkeleton] --version support for the murmur CLI
+// (ticket #264). Resolves the repo/package version by walking up from the
+// CLI script directory to the nearest package.json. Under a packaged app the
+// script lives inside app.asar, so the nearest package.json is the app's own
+// (Electron's fs transparently reads asar archives); under `pnpm dev` / git
+// checkout it is the repository package.json. Kept dependency-free and
+// bounded: the walk stops at the filesystem root.
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Read the nearest package.json version walking up from startDir.
+ * Returns "" when no package.json is found or it carries no version — the
+ * caller renders that as "unknown".
+ */
+export function resolveCliVersion(startDir) {
+  let dir = path.resolve(startDir);
+  for (;;) {
+    const candidate = path.join(dir, "package.json");
+    try {
+      const raw = fs.readFileSync(candidate, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.version === "string" && parsed.version.length > 0) {
+        return parsed.version;
+      }
+    } catch {
+      // No readable package.json here — keep walking up.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return "";
+    dir = parent;
+  }
+}

--- a/cli/murmur.mjs
+++ b/cli/murmur.mjs
@@ -7,7 +7,7 @@
 // cli/lib/cliRunner.mjs — this file only wires argv in and streams/exit out.
 //
 // Production invocation shape (packaged app):
-//   ELECTRON_RUN_AS_NODE=1 <electron> <app>/cli/murmur.mur.mjs ... (bin shim)
+//   ELECTRON_RUN_AS_NODE=1 <electron> <app>/cli/murmur.mjs ...
 // i.e. process.versions.electron is set. Running the script with a bare
 // electron binary WITHOUT ELECTRON_RUN_AS_NODE would boot the GUI app
 // instead of the CLI — that mis-invocation is rejected below with a clear

--- a/cli/murmur.mjs
+++ b/cli/murmur.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// [20260912_Feat_CliSkeleton] murmur CLI entry point (ticket #264, spec #258).
+// Distributed with the app and run through the Electron binary in
+// ELECTRON_RUN_AS_NODE mode (no system Node dependency at runtime), while
+// staying a zero-dependency plain-ESM script that also works under plain
+// `node` for development and tests. All real behaviour lives in
+// cli/lib/cliRunner.mjs — this file only wires argv in and streams/exit out.
+//
+// Production invocation shape (packaged app):
+//   ELECTRON_RUN_AS_NODE=1 <electron> <app>/cli/murmur.mur.mjs ... (bin shim)
+// i.e. process.versions.electron is set. Running the script with a bare
+// electron binary WITHOUT ELECTRON_RUN_AS_NODE would boot the GUI app
+// instead of the CLI — that mis-invocation is rejected below with a clear
+// message rather than silently launching a window.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCli } from "./lib/cliRunner.mjs";
+import { resolveCliVersion } from "./lib/version.mjs";
+
+const EXIT_RUNTIME_ERROR = 1;
+
+/** True when the runtime is Electron's Node (ELECTRON_RUN_AS_NODE or a shell). */
+function isElectronRuntime() {
+  return process.versions.electron !== undefined;
+}
+
+function main() {
+  if (isElectronRuntime() && !process.env.ELECTRON_RUN_AS_NODE) {
+    process.stderr.write(
+      "murmur: refusing to run inside the Electron GUI runtime. " +
+        "Set ELECTRON_RUN_AS_NODE=1, or launch the Murmur app directly.\n",
+    );
+    process.exit(EXIT_RUNTIME_ERROR);
+  }
+
+  // fileURLToPath (not URL.pathname): pathname yields "/C:/..." on Windows.
+  const cliDir = path.dirname(fileURLToPath(import.meta.url));
+  const version = resolveCliVersion(cliDir);
+  const result = runCli(process.argv.slice(2), { version });
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.code);
+}
+
+main();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,10 @@ export default tseslint.config(
       "preload.ts",
       "tests/**/*.{js,ts}",
       "scripts/**/*.js",
+      // [20260912_Feat_CliSkeleton] the murmur CLI is plain ESM .mjs
+      // (zero deps, runs under ELECTRON_RUN_AS_NODE) — same node-globals
+      // treatment as scripts/*.js.
+      "cli/**/*.mjs",
       "src/helpers/**/*.{js,ts}",
       "src/utils/**/*.{js,ts}",
     ],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.5.1",
   "description": "Murmur - 基于FunASR和可配置AI模型的中文优化语音转文字应用",
   "main": "dist-main/main.js",
+  "bin": {
+    "murmur": "cli/murmur.mjs"
+  },
   "private": true,
   "scripts": {
     "start": "electron .",
@@ -41,8 +44,8 @@
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
     "typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json",
-    "format": "prettier --write \"*.{js,json,md,yml}\" \"src/**/*.{js,jsx,ts,tsx,css}\" \"tests/**/*.{js,ts}\" \"scripts/**/*.js\"",
-    "format:check": "prettier --check \"*.{js,json,md,yml}\" \"src/**/*.{js,jsx,ts,tsx,css}\" \"tests/**/*.{js,ts}\" \"scripts/**/*.js\"",
+    "format": "prettier --write \"*.{js,json,md,yml}\" \"src/**/*.{js,jsx,ts,tsx,css}\" \"tests/**/*.{js,ts}\" \"scripts/**/*.js\" \"cli/**/*.mjs\"",
+    "format:check": "prettier --check \"*.{js,json,md,yml}\" \"src/**/*.{js,jsx,ts,tsx,css}\" \"tests/**/*.{js,ts}\" \"scripts/**/*.js\" \"cli/**/*.mjs\"",
     "license:check": "license-checker --failOn \"GPL-*;AGPL-*\" --excludePrivatePackages",
     "ci:check": "node scripts/ci-check.js",
     "ci:fix": "node scripts/ci-check.js --fix",
@@ -135,6 +138,7 @@
     "files": [
       "dist-main/main.js",
       "dist-preload/preload.js",
+      "cli/**/*.mjs",
       "funasr_server.py",
       "audio_preprocessing.py",
       "download_models.py",

--- a/src/helpers/ipc/settingsHandlers.ts
+++ b/src/helpers/ipc/settingsHandlers.ts
@@ -37,7 +37,12 @@ interface Managers {
   trayManager?: TrayManager;
 }
 
-const ALLOWED_SETTING_KEYS = new Set<string>([
+// [20260912_Feat_CliSkeleton] Exported for the murmur CLI (ticket #264): the
+// CLI's config get/set whitelist must reuse the same key list semantics as
+// the IPC settings boundary. The CLI keeps a plain-JS mirror (cli/lib cannot
+// import TS at runtime); tests/unit/cli-config.test.ts locks the two lists
+// to set equality so drift fails CI.
+export const ALLOWED_SETTING_KEYS = new Set<string>([
   "ai_api_key",
   "ai_base_url",
   "ai_model",

--- a/tests/unit/cli-config.test.ts
+++ b/tests/unit/cli-config.test.ts
@@ -237,6 +237,6 @@ describe("cli config set value-length cap (IPC boundary parity)", () => {
       configPath,
     });
     expect(result.code).toBe(0);
-    expect(readConfig(configPath).theme).toBe("x".repeat(10000));
+    expect(readConfig(configPath)).toEqual({ theme: "x".repeat(10000) });
   });
 });

--- a/tests/unit/cli-config.test.ts
+++ b/tests/unit/cli-config.test.ts
@@ -1,6 +1,6 @@
 // [20260912_Feat_CliSkeleton] `murmur config get/set` tests (ticket #264).
 // Covers: whitelist enforcement (out-of-whitelist key -> usage error, exit 2,
-// same key list semantics as settingsHandlers' ALLOWED_SETTING_KEYS),
+// whitelist parity against fileConfig's FILE_CONFIGURABLE_KEYS),
 // murmur.json read/write semantics mirrored from src/helpers/fileConfig.ts,
 // typed value round-trips, and the TS<->mjs whitelist parity lock. All
 // function-level via runCli; no process spawn.
@@ -216,5 +216,27 @@ describe("cli config set", () => {
     expect(result.code).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("config set theme");
+  });
+});
+
+// [20260912_Fix_264_ReviewFollowups] Boundary parity with the IPC settings
+// path: the CLI must reject what the app's own write boundary rejects.
+describe("cli config set value-length cap (IPC boundary parity)", () => {
+  it("rejects string values over the 10000-char cap as a usage error (exit 2)", () => {
+    const result = runCli(["config", "set", "theme", "x".repeat(10001)], {
+      configPath: "/tmp/unused-murmur.json",
+    });
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("10000");
+  });
+
+  it("accepts a value at the cap boundary", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-cli-cap-"));
+    const configPath = path.join(dir, "murmur.json");
+    const result = runCli(["config", "set", "theme", "x".repeat(10000)], {
+      configPath,
+    });
+    expect(result.code).toBe(0);
+    expect(readConfig(configPath).theme).toBe("x".repeat(10000));
   });
 });

--- a/tests/unit/cli-config.test.ts
+++ b/tests/unit/cli-config.test.ts
@@ -11,25 +11,36 @@ import path from "node:path";
 import { runCli } from "../../cli/lib/cliRunner.mjs";
 import { CONFIG_KEYS, isConfigKey } from "../../cli/lib/configKeys.mjs";
 import { readConfig } from "../../cli/lib/configStore.mjs";
-// [20260912_Feat_CliSkeleton] ALLOWED_SETTING_KEYS is exported for the CLI
-// boundary (the single permitted src/ change for this ticket).
-import {
-  validateSetting,
-  ALLOWED_SETTING_KEYS,
-} from "../../src/helpers/ipc/settingsHandlers";
+// [20260912_Fix_264_ConfigWhitelistScope] Parity target is fileConfig's
+// FILE_CONFIGURABLE_KEYS (what murmur.json actually honors), not the IPC
+// settings allowlist — see cli/lib/configKeys.mjs for the rationale.
+import { validateSetting } from "../../src/helpers/ipc/settingsHandlers";
+import { FILE_CONFIGURABLE_KEYS } from "../../src/helpers/fileConfig";
 
 describe("cli config whitelist parity", () => {
-  it("CONFIG_KEYS mirrors ALLOWED_SETTING_KEYS exactly (both directions)", () => {
-    expect(new Set(CONFIG_KEYS)).toEqual(ALLOWED_SETTING_KEYS);
+  // [20260912_Fix_264_ConfigWhitelistScope] The CLI list must equal the
+  // file-config whitelist in BOTH directions: writing a key outside it
+  // would be silently ignored by the app, and missing a key inside it
+  // would strand a configurable in GUI-only land.
+  it("CONFIG_KEYS mirrors FILE_CONFIGURABLE_KEYS exactly (both directions)", () => {
+    expect(new Set(CONFIG_KEYS)).toEqual(new Set(FILE_CONFIGURABLE_KEYS));
     // Duplicate-free mirror: same cardinality as the set.
-    expect(CONFIG_KEYS.length).toBe(ALLOWED_SETTING_KEYS.size);
+    expect(CONFIG_KEYS.length).toBe(FILE_CONFIGURABLE_KEYS.length);
+  });
+
+  // [20260912_Fix_264_ConfigWhitelistScope] Secret hygiene lock: the
+  // decrypted AI key must NEVER be CLI-configurable into the plaintext
+  // murmur.json (fileConfig excludes it by design).
+  it("never exposes the ai_api_key secret through the config subcommand", () => {
+    expect(isConfigKey("ai_api_key")).toBe(false);
   });
 
   it("isConfigKey agrees with validateSetting's key check for every CLI key", () => {
     for (const key of CONFIG_KEYS) {
       expect(isConfigKey(key)).toBe(true);
-      // Same key accepted by the IPC settings boundary (any string value
-      // passes its length check).
+      // Every file-configurable key is also legal at the IPC settings
+      // boundary (superset property; any string value passes its length
+      // check).
       expect(validateSetting(key, "x")).toBe(true);
     }
   });

--- a/tests/unit/cli-config.test.ts
+++ b/tests/unit/cli-config.test.ts
@@ -1,0 +1,209 @@
+// [20260912_Feat_CliSkeleton] `murmur config get/set` tests (ticket #264).
+// Covers: whitelist enforcement (out-of-whitelist key -> usage error, exit 2,
+// same key list semantics as settingsHandlers' ALLOWED_SETTING_KEYS),
+// murmur.json read/write semantics mirrored from src/helpers/fileConfig.ts,
+// typed value round-trips, and the TS<->mjs whitelist parity lock. All
+// function-level via runCli; no process spawn.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runCli } from "../../cli/lib/cliRunner.mjs";
+import { CONFIG_KEYS, isConfigKey } from "../../cli/lib/configKeys.mjs";
+import { readConfig } from "../../cli/lib/configStore.mjs";
+// [20260912_Feat_CliSkeleton] ALLOWED_SETTING_KEYS is exported for the CLI
+// boundary (the single permitted src/ change for this ticket).
+import {
+  validateSetting,
+  ALLOWED_SETTING_KEYS,
+} from "../../src/helpers/ipc/settingsHandlers";
+
+describe("cli config whitelist parity", () => {
+  it("CONFIG_KEYS mirrors ALLOWED_SETTING_KEYS exactly (both directions)", () => {
+    expect(new Set(CONFIG_KEYS)).toEqual(ALLOWED_SETTING_KEYS);
+    // Duplicate-free mirror: same cardinality as the set.
+    expect(CONFIG_KEYS.length).toBe(ALLOWED_SETTING_KEYS.size);
+  });
+
+  it("isConfigKey agrees with validateSetting's key check for every CLI key", () => {
+    for (const key of CONFIG_KEYS) {
+      expect(isConfigKey(key)).toBe(true);
+      // Same key accepted by the IPC settings boundary (any string value
+      // passes its length check).
+      expect(validateSetting(key, "x")).toBe(true);
+    }
+  });
+});
+
+describe("cli config get", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-cli-config-"));
+    configPath = path.join(dir, "murmur.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads an existing string key in text mode (bare value on stdout)", () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ ai_model: "qwen2.5", theme: "dark" }),
+    );
+    const result = runCli(["config", "get", "ai_model"], { configPath });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("qwen2.5\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("formats non-string values as JSON in text mode", () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ ai_temperature: 0.7, auto_paste: true }),
+    );
+    expect(
+      runCli(["config", "get", "ai_temperature"], { configPath }).stdout,
+    ).toBe("0.7\n");
+    expect(runCli(["config", "get", "auto_paste"], { configPath }).stdout).toBe(
+      "true\n",
+    );
+  });
+
+  it("returns null for a whitelisted key that is not set (exit 0)", () => {
+    const result = runCli(["config", "get", "theme"], { configPath });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("null\n");
+  });
+
+  it("--json emits the stable { key, value } schema", () => {
+    fs.writeFileSync(configPath, JSON.stringify({ ai_model: "qwen2.5" }));
+    const result = runCli(["config", "get", "ai_model", "--json"], {
+      configPath,
+    });
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      key: "ai_model",
+      value: "qwen2.5",
+    });
+  });
+
+  it("rejects an out-of-whitelist key with a usage error (exit 2)", () => {
+    const result = runCli(["config", "get", "not_a_real_key"], { configPath });
+    expect(result.code).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("not_a_real_key");
+  });
+
+  it("rejects a missing key argument (exit 2)", () => {
+    const result = runCli(["config", "get"], { configPath });
+    expect(result.code).toBe(2);
+  });
+
+  it("treats a corrupted murmur.json as empty (app parity: reads degrade to {})", () => {
+    fs.writeFileSync(configPath, "{ not valid json");
+    const result = runCli(["config", "get", "theme"], { configPath });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("null\n");
+  });
+});
+
+describe("cli config set", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-cli-config-"));
+    configPath = path.join(dir, "murmur.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes a string value silently in text mode (exit 0, empty stdout)", () => {
+    const result = runCli(["config", "set", "theme", "dark"], { configPath });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(readConfig(configPath)).toEqual({ theme: "dark" });
+  });
+
+  it("parses JSON-looking values into typed settings (number, boolean)", () => {
+    runCli(["config", "set", "ai_temperature", "0.7"], { configPath });
+    runCli(["config", "set", "auto_paste", "true"], { configPath });
+    const written = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(written).toEqual({ ai_temperature: 0.7, auto_paste: true });
+  });
+
+  it("keeps a non-JSON value as a literal string", () => {
+    runCli(["config", "set", "theme", "not-json {"], { configPath });
+    expect(readConfig(configPath)).toEqual({ theme: "not-json {" });
+  });
+
+  it("preserves other whitelisted keys (read-modify-write)", () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ ai_model: "qwen2.5", language: "zh-CN" }),
+    );
+    runCli(["config", "set", "theme", "light"], { configPath });
+    expect(readConfig(configPath)).toEqual({
+      ai_model: "qwen2.5",
+      language: "zh-CN",
+      theme: "light",
+    });
+  });
+
+  it("drops non-whitelisted junk already present in the file (app save parity)", () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ ai_model: "qwen2.5", rogue_key: "junk" }),
+    );
+    runCli(["config", "set", "theme", "dark"], { configPath });
+    const written = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(written).toEqual({ ai_model: "qwen2.5", theme: "dark" });
+  });
+
+  it("--json emits the stable { success, key, value } schema", () => {
+    const result = runCli(["config", "set", "ai_model", "qwen2.5", "--json"], {
+      configPath,
+    });
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: true,
+      key: "ai_model",
+      value: "qwen2.5",
+    });
+  });
+
+  it("rejects an out-of-whitelist key without touching the file (exit 2)", () => {
+    fs.writeFileSync(configPath, JSON.stringify({ theme: "dark" }));
+    const result = runCli(["config", "set", "custom_rogue_key", "x"], {
+      configPath,
+    });
+    expect(result.code).toBe(2);
+    expect(JSON.parse(fs.readFileSync(configPath, "utf-8"))).toEqual({
+      theme: "dark",
+    });
+  });
+
+  it("rejects missing key/value arguments (exit 2)", () => {
+    expect(runCli(["config", "set"], { configPath }).code).toBe(2);
+    expect(runCli(["config", "set", "theme"], { configPath }).code).toBe(2);
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it("maps filesystem write failures to a runtime error (exit 1, stderr only)", () => {
+    // Parent chain contains a regular FILE, so mkdirSync must fail -> the
+    // runner surfaces a runtime error, not a crash.
+    const blockingFile = path.join(dir, "blocker");
+    fs.writeFileSync(blockingFile, "x");
+    const result = runCli(["config", "set", "theme", "dark"], {
+      configPath: path.join(blockingFile, "murmur.json"),
+    });
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("config set theme");
+  });
+});

--- a/tests/unit/cli-history.test.ts
+++ b/tests/unit/cli-history.test.ts
@@ -1,0 +1,363 @@
+// [20260912_Feat_CliSkeleton] `murmur history list` tests (ticket #264).
+// History reads go DIRECT to the app's SQLite file via node:sqlite with a
+// readOnly open, so every test builds a temp transcriptions.db mirroring the
+// real app schema (src/helpers/database.ts createTables + _migrateSchema,
+// post-migration shape). Locked here: newest-first ordering, the exact
+// --json record schema, --query literal substring matching (LIKE wildcards
+// escaped), --limit validation, default limit 50 (app parity), and the
+// readonly-open guarantee (a missing DB is an error, never created).
+// All function-level via runCli — no process spawn, no Electron.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { runCli } from "../../cli/lib/cliRunner.mjs";
+
+/** One seed row; unspecified columns use the app's defaults. */
+interface SeedRow {
+  text: string;
+  processed_text?: string | null;
+  language?: string;
+  duration?: number;
+  source_type?: string;
+  created_at: string;
+}
+
+/**
+ * Create a transcriptions DB with the app's post-migration schema
+ * (database.ts createTables + the source_type/source_file_path/segments/
+ * manually_edited ALTERs) and insert the given rows in order.
+ */
+function createAppDb(
+  dbPath: string,
+  rows: SeedRow[],
+  options?: { wal?: boolean },
+): void {
+  const db = new DatabaseSync(dbPath);
+  try {
+    // The app sets WAL in initialize(); exercised by a dedicated test below.
+    if (options?.wal) db.exec("PRAGMA journal_mode = WAL");
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS transcriptions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        text TEXT NOT NULL,
+        raw_text TEXT,
+        processed_text TEXT,
+        confidence REAL,
+        language TEXT DEFAULT 'zh-CN',
+        duration REAL,
+        file_size INTEGER,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        source_type TEXT DEFAULT 'recording',
+        source_file_path TEXT,
+        segments TEXT,
+        manually_edited INTEGER DEFAULT 0
+      )
+    `);
+    const insert = db.prepare(`
+      INSERT INTO transcriptions
+        (text, processed_text, language, duration, source_type, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    for (const row of rows) {
+      insert.run(
+        row.text,
+        row.processed_text ?? null,
+        row.language ?? "zh-CN",
+        row.duration ?? 0,
+        row.source_type ?? "recording",
+        row.created_at,
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+describe("cli history list", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-cli-history-"));
+    dbPath = path.join(dir, "transcriptions.db");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("lists records newest-first in text mode with #id/created/preview lines", () => {
+    createAppDb(dbPath, [
+      { text: "first note", created_at: "2026-09-12 10:00:01" },
+      { text: "second note", created_at: "2026-09-12 10:00:02" },
+      { text: "third note", created_at: "2026-09-12 10:00:03" },
+    ]);
+    const result = runCli(["history", "list"], { dbPath });
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe(
+      [
+        "#3\t2026-09-12 10:00:03\tthird note",
+        "#2\t2026-09-12 10:00:02\tsecond note",
+        "#1\t2026-09-12 10:00:01\tfirst note",
+      ].join("\n") + "\n",
+    );
+  });
+
+  it("--json emits the exact stable records schema", () => {
+    createAppDb(dbPath, [
+      {
+        text: "raw speech",
+        processed_text: "polished speech",
+        language: "zh-CN",
+        duration: 3.5,
+        source_type: "file",
+        created_at: "2026-09-12 10:00:01",
+      },
+      { text: "second", created_at: "2026-09-12 10:00:02" },
+    ]);
+    const result = runCli(["history", "list", "--json"], { dbPath });
+    expect(result.code).toBe(0);
+    // toEqual locks the schema exactly: no extra/missing fields allowed.
+    expect(JSON.parse(result.stdout)).toEqual({
+      records: [
+        {
+          id: 2,
+          text: "second",
+          processed_text: null,
+          language: "zh-CN",
+          duration: 0,
+          source_type: "recording",
+          created_at: "2026-09-12 10:00:02",
+        },
+        {
+          id: 1,
+          text: "raw speech",
+          processed_text: "polished speech",
+          language: "zh-CN",
+          duration: 3.5,
+          source_type: "file",
+          created_at: "2026-09-12 10:00:01",
+        },
+      ],
+    });
+  });
+
+  it("text mode flattens newlines and truncates long text to a preview", () => {
+    const longText = `${"word ".repeat(40)}\nsecond line`;
+    createAppDb(dbPath, [
+      { text: longText, created_at: "2026-09-12 10:00:01" },
+    ]);
+    const result = runCli(["history", "list"], { dbPath });
+    expect(result.code).toBe(0);
+    const lines = result.stdout.split("\n");
+    expect(lines).toHaveLength(2); // the record line + trailing newline
+    const preview = lines[0];
+    expect(preview).toMatch(/^#1\t2026-09-12 10:00:01\t/);
+    expect(preview).toContain("…");
+    expect(preview).not.toContain("\nsecond line");
+  });
+
+  it("defaults to the app's limit of 50 records", () => {
+    const rows: SeedRow[] = Array.from({ length: 55 }, (_, i) => ({
+      text: `note ${i}`,
+      created_at: `2026-09-12 10:00:${String(i).padStart(2, "0")}`,
+    }));
+    createAppDb(dbPath, rows);
+    const result = runCli(["history", "list", "--json"], { dbPath });
+    const records = JSON.parse(result.stdout).records as Array<{
+      text: string;
+    }>;
+    expect(records).toHaveLength(50);
+    // Newest first: note 54 is the newest, note 5 the oldest kept.
+    expect(records[0]?.text).toBe("note 54");
+    expect(records[49]?.text).toBe("note 5");
+  });
+
+  it("--limit N truncates the result", () => {
+    const rows: SeedRow[] = Array.from({ length: 10 }, (_, i) => ({
+      text: `note ${i}`,
+      created_at: `2026-09-12 10:00:${String(i).padStart(2, "0")}`,
+    }));
+    createAppDb(dbPath, rows);
+    const result = runCli(["history", "list", "--json", "--limit", "3"], {
+      dbPath,
+    });
+    const records = JSON.parse(result.stdout).records as Array<{
+      text: string;
+    }>;
+    expect(records).toHaveLength(3);
+    expect(records.map((record) => record.text)).toEqual([
+      "note 9",
+      "note 8",
+      "note 7",
+    ]);
+  });
+
+  it("--query filters by substring over text AND processed_text", () => {
+    createAppDb(dbPath, [
+      { text: "meeting minutes topic", created_at: "2026-09-12 10:00:01" },
+      {
+        text: "raw chatter",
+        processed_text: "polished budget talk",
+        created_at: "2026-09-12 10:00:02",
+      },
+      { text: "unrelated", created_at: "2026-09-12 10:00:03" },
+    ]);
+    const textHit = runCli(
+      ["history", "list", "--json", "--query", "meeting"],
+      { dbPath },
+    );
+    expect(
+      (JSON.parse(textHit.stdout).records as Array<{ id: number }>).map(
+        (record) => record.id,
+      ),
+    ).toEqual([1]);
+
+    const processedHit = runCli(
+      ["history", "list", "--json", "--query", "budget"],
+      { dbPath },
+    );
+    expect(
+      (JSON.parse(processedHit.stdout).records as Array<{ id: number }>).map(
+        (record) => record.id,
+      ),
+    ).toEqual([2]);
+  });
+
+  it("--query treats LIKE wildcards literally (%, _ escaped)", () => {
+    createAppDb(dbPath, [
+      { text: "price is 50% off", created_at: "2026-09-12 10:00:01" },
+      { text: "column_a_value", created_at: "2026-09-12 10:00:02" },
+      { text: "plain note", created_at: "2026-09-12 10:00:03" },
+    ]);
+    // Unescaped, "%" and "_" are LIKE wildcards and would match everything.
+    const percent = runCli(["history", "list", "--json", "--query", "%"], {
+      dbPath,
+    });
+    expect(
+      (JSON.parse(percent.stdout).records as Array<{ id: number }>).map(
+        (record) => record.id,
+      ),
+    ).toEqual([1]);
+
+    const underscore = runCli(["history", "list", "--json", "--query", "_"], {
+      dbPath,
+    });
+    expect(
+      (JSON.parse(underscore.stdout).records as Array<{ id: number }>).map(
+        (record) => record.id,
+      ),
+    ).toEqual([2]);
+  });
+
+  it("--query with no matches returns empty output (exit 0, never an error)", () => {
+    createAppDb(dbPath, [
+      { text: "something", created_at: "2026-09-12 10:00:01" },
+    ]);
+    const jsonResult = runCli(["history", "list", "--json", "--query", "zzz"], {
+      dbPath,
+    });
+    expect(jsonResult.code).toBe(0);
+    expect(JSON.parse(jsonResult.stdout)).toEqual({ records: [] });
+
+    const textResult = runCli(["history", "list", "--query", "zzz"], {
+      dbPath,
+    });
+    expect(textResult.code).toBe(0);
+    expect(textResult.stdout).toBe("");
+  });
+
+  it("combines --query with --limit", () => {
+    const rows: SeedRow[] = Array.from({ length: 5 }, (_, i) => ({
+      text: `kv heartbeat ${i}`,
+      created_at: `2026-09-12 10:00:${String(i).padStart(2, "0")}`,
+    }));
+    createAppDb(dbPath, rows);
+    const result = runCli(
+      ["history", "list", "--json", "--query", "heartbeat", "--limit", "2"],
+      { dbPath },
+    );
+    const records = JSON.parse(result.stdout).records as Array<{
+      text: string;
+    }>;
+    expect(records).toHaveLength(2);
+    expect(records[0]?.text).toBe("kv heartbeat 4");
+  });
+
+  it("rejects invalid --limit values as usage errors (exit 2)", () => {
+    createAppDb(dbPath, [{ text: "x", created_at: "2026-09-12 10:00:00" }]);
+    for (const bad of ["0", "-1", "abc", "1.5"]) {
+      const result = runCli(["history", "list", "--limit", bad], { dbPath });
+      expect(result.code).toBe(2);
+      expect(result.stderr).toContain("--limit");
+    }
+  });
+
+  it("rejects extra positional arguments (exit 2)", () => {
+    const result = runCli(["history", "list", "extra"], { dbPath });
+    expect(result.code).toBe(2);
+  });
+
+  it("missing database: runtime error (exit 1) and the file is never created", () => {
+    const missingPath = path.join(dir, "does-not-exist.db");
+    const result = runCli(["history", "list"], { dbPath: missingPath });
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(missingPath);
+    // readOnly open must not materialise an empty DB as a side effect.
+    expect(fs.existsSync(missingPath)).toBe(false);
+  });
+
+  it("reads a WAL-mode database (the app runs with journal_mode=WAL)", () => {
+    createAppDb(
+      dbPath,
+      [{ text: "wal row", created_at: "2026-09-12 10:00:01" }],
+      { wal: true },
+    );
+    const result = runCli(["history", "list", "--json"], { dbPath });
+    expect(result.code).toBe(0);
+    expect(
+      (JSON.parse(result.stdout).records as Array<{ text: string }>).map(
+        (record) => record.text,
+      ),
+    ).toEqual(["wal row"]);
+  });
+
+  it("resolves the DB from ELECTRON_USER_DATA when no explicit path is given", () => {
+    createAppDb(path.join(dir, "transcriptions.db"), [
+      { text: "via env", created_at: "2026-09-12 10:00:01" },
+    ]);
+    const result = runCli(["history", "list", "--json"], {
+      env: { ELECTRON_USER_DATA: dir },
+      platform: "darwin",
+      homedir: () => "/home/tester",
+    });
+    expect(result.code).toBe(0);
+    expect(
+      (JSON.parse(result.stdout).records as Array<{ text: string }>).map(
+        (record) => record.text,
+      ),
+    ).toEqual(["via env"]);
+  });
+
+  it("resolves the DB from the MURMUR_DB_PATH override (app env parity)", () => {
+    createAppDb(dbPath, [
+      { text: "override", created_at: "2026-09-12 10:00:01" },
+    ]);
+    const result = runCli(["history", "list", "--json"], {
+      env: { MURMUR_DB_PATH: dbPath },
+      platform: "darwin",
+      homedir: () => "/home/tester",
+    });
+    expect(result.code).toBe(0);
+    expect(
+      (JSON.parse(result.stdout).records as Array<{ text: string }>).map(
+        (record) => record.text,
+      ),
+    ).toEqual(["override"]);
+  });
+});

--- a/tests/unit/cli-history.test.ts
+++ b/tests/unit/cli-history.test.ts
@@ -161,7 +161,9 @@ describe("cli history list", () => {
     expect(preview).not.toContain("\nsecond line");
   });
 
-  it("defaults to the app's limit of 50 records", () => {
+  // [20260912_Fix_264_WindowsHostTests] 55 inserts + first SQLite open on a
+  // cold Windows CI runner can exceed the 5s default (precedent: #341).
+  it("defaults to the app's limit of 50 records", { timeout: 15000 }, () => {
     const rows: SeedRow[] = Array.from({ length: 55 }, (_, i) => ({
       text: `note ${i}`,
       created_at: `2026-09-12 10:00:${String(i).padStart(2, "0")}`,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -168,7 +168,10 @@ describe("cli path resolution (mirrors environment.ts + main.ts + database.ts)",
     });
     expect(dir).toBe("/custom/user/data");
   });
-
+  // [20260912_Fix_264_WindowsHostTests] Production joins with the HOST's
+  // path module, so expectations must be built through path.join too — a
+  // Windows CI host produces backslash joins even for a faked darwin
+  // platform (the separator is a host property, not a platform argument).
   it("derives the platform data directory like environment.ts", () => {
     expect(
       resolveDataDirectory({
@@ -176,7 +179,9 @@ describe("cli path resolution (mirrors environment.ts + main.ts + database.ts)",
         platform: "darwin",
         homedir: fakeHomedir,
       }),
-    ).toBe("/home/tester/Library/Application Support/Murmur");
+    ).toBe(
+      path.join("/home/tester", "Library", "Application Support", "Murmur"),
+    );
     expect(
       resolveDataDirectory({
         env: {},
@@ -190,7 +195,7 @@ describe("cli path resolution (mirrors environment.ts + main.ts + database.ts)",
         platform: "linux",
         homedir: fakeHomedir,
       }),
-    ).toBe("/home/tester/.config/Murmur");
+    ).toBe(path.join("/home/tester", ".config", "Murmur"));
   });
 
   it("resolves murmur.json next to the data directory (main.ts behaviour)", () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,0 +1,220 @@
+// [20260912_Feat_CliSkeleton] Convention tests for the murmur CLI runner
+// (ticket #264, spec #258). The locked global conventions are exercised here
+// at function level (no process spawn, no Electron shell):
+//   - exit codes: 0 success / 1 runtime error / 2 usage error (4 reserved)
+//   - results on stdout, logs/errors on stderr only
+//   - --json anywhere in argv switches stdout to structured output
+//   - no prompts, no spinners: every invocation returns a complete result
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  runCli,
+  EXIT_OK,
+  EXIT_RUNTIME_ERROR,
+  EXIT_USAGE_ERROR,
+} from "../../cli/lib/cliRunner.mjs";
+import {
+  resolveConfigPath,
+  resolveDatabasePath,
+  resolveDataDirectory,
+} from "../../cli/lib/paths.mjs";
+
+describe("cli exit-code conventions", () => {
+  it("defines the locked exit codes 0/1/2", () => {
+    expect(EXIT_OK).toBe(0);
+    expect(EXIT_RUNTIME_ERROR).toBe(1);
+    expect(EXIT_USAGE_ERROR).toBe(2);
+  });
+
+  it("no arguments is a usage error: exit 2, usage on stderr, stdout empty", () => {
+    const result = runCli([], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_USAGE_ERROR);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Usage:");
+  });
+
+  it("unknown command is a usage error (exit 2)", () => {
+    const result = runCli(["wat"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_USAGE_ERROR);
+    expect(result.stderr).toContain("unknown command: wat");
+  });
+
+  it("unknown subcommands are usage errors (exit 2)", () => {
+    const configResult = runCli(["config", "delete", "theme"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(configResult.code).toBe(EXIT_USAGE_ERROR);
+
+    const historyResult = runCli(["history", "export"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(historyResult.code).toBe(EXIT_USAGE_ERROR);
+  });
+
+  it("unknown flags are usage errors (exit 2)", () => {
+    const result = runCli(["history", "list", "--frobnicate"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_USAGE_ERROR);
+    expect(result.stderr).toContain("--frobnicate");
+  });
+
+  it("missing database is a runtime error: exit 1, message on stderr, stdout empty", () => {
+    const result = runCli(["history", "list"], {
+      dbPath: "/nonexistent-dir-murmur-cli/transcriptions.db",
+      configPath: "/tmp/x.json",
+    });
+    expect(result.code).toBe(EXIT_RUNTIME_ERROR);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("history list");
+  });
+});
+
+describe("cli output conventions", () => {
+  it("--help prints usage on stdout with exit 0 and nothing on stderr", () => {
+    const result = runCli(["--help"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toContain("Usage:");
+    expect(result.stderr).toBe("");
+  });
+
+  it("--version prints the injected version with exit 0", () => {
+    const result = runCli(["--version"], { version: "9.9.9-test" });
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toBe("9.9.9-test\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("--version without a resolvable version falls back to 'unknown'", () => {
+    const result = runCli(["--version"]);
+    expect(result.stdout).toBe("unknown\n");
+  });
+
+  it("--json is honoured as a global flag before the subcommand", () => {
+    const result = runCli(["--json", "config", "get", "theme"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_OK);
+    expect(JSON.parse(result.stdout)).toEqual({ key: "theme", value: null });
+  });
+
+  it("--json is honoured after the subcommand too", () => {
+    const before = runCli(["config", "--json", "get", "theme"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    const after = runCli(["config", "get", "theme", "--json"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(before.code).toBe(EXIT_OK);
+    expect(after.code).toBe(EXIT_OK);
+    expect(JSON.parse(before.stdout)).toEqual({ key: "theme", value: null });
+    expect(JSON.parse(after.stdout)).toEqual({ key: "theme", value: null });
+  });
+
+  it("successful invocations never write to stderr (no logs on stdout path)", () => {
+    const result = runCli(["config", "get", "theme"], {
+      configPath: "/tmp/nonexistent-murmur.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("null\n");
+  });
+
+  it("runs synchronously and returns a complete result (no-TTY: no prompts, no spinners)", () => {
+    // Function-level contract: an invocation neither reads stdin nor streams
+    // progress — it resolves to the full { code, stdout, stderr } payload.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-cli-test-"));
+    try {
+      const result = runCli(["config", "set", "theme", "dark"], {
+        configPath: path.join(dir, "murmur.json"),
+        dbPath: "/tmp/x.db",
+      });
+      expect(result).toHaveProperty("code");
+      expect(result).toHaveProperty("stdout");
+      expect(result).toHaveProperty("stderr");
+      expect(result.code).toBe(EXIT_OK);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("cli path resolution (mirrors environment.ts + main.ts + database.ts)", () => {
+  const fakeHomedir = () => "/home/tester";
+
+  it("ELECTRON_USER_DATA overrides the platform data directory", () => {
+    const dir = resolveDataDirectory({
+      env: { ELECTRON_USER_DATA: "/custom/user/data" },
+      platform: "darwin",
+      homedir: fakeHomedir,
+    });
+    expect(dir).toBe("/custom/user/data");
+  });
+
+  it("derives the platform data directory like environment.ts", () => {
+    expect(
+      resolveDataDirectory({
+        env: {},
+        platform: "darwin",
+        homedir: fakeHomedir,
+      }),
+    ).toBe("/home/tester/Library/Application Support/Murmur");
+    expect(
+      resolveDataDirectory({
+        env: {},
+        platform: "win32",
+        homedir: fakeHomedir,
+      }),
+    ).toBe(path.join("/home/tester", "AppData", "Roaming", "Murmur"));
+    expect(
+      resolveDataDirectory({
+        env: {},
+        platform: "linux",
+        homedir: fakeHomedir,
+      }),
+    ).toBe("/home/tester/.config/Murmur");
+  });
+
+  it("resolves murmur.json next to the data directory (main.ts behaviour)", () => {
+    const configPath = resolveConfigPath({
+      env: { ELECTRON_USER_DATA: "/data" },
+      platform: "darwin",
+      homedir: fakeHomedir,
+    });
+    expect(configPath).toBe(path.join("/data", "murmur.json"));
+  });
+
+  it("resolves the database with the MURMUR_DB_PATH override (database.ts behaviour)", () => {
+    const overridden = resolveDatabasePath({
+      env: { MURMUR_DB_PATH: "/tmp/other.db", ELECTRON_USER_DATA: "/data" },
+      platform: "darwin",
+      homedir: fakeHomedir,
+    });
+    expect(overridden).toBe("/tmp/other.db");
+
+    const defaulted = resolveDatabasePath({
+      env: { ELECTRON_USER_DATA: "/data" },
+      platform: "darwin",
+      homedir: fakeHomedir,
+    });
+    expect(defaulted).toBe(path.join("/data", "transcriptions.db"));
+  });
+});


### PR DESCRIPTION
## What

`murmur` CLI 入口（零依赖 ESM，ELECTRON_RUN_AS_NODE 运行，不依赖系统 Node）+ 首批本地子命令（应用无需运行）：

- `config get <key>` / `config set <key> <value>` — 读写 murmur.json，白名单对齐 **FILE_CONFIGURABLE_KEYS**（murmur.json 实际生效的 11 键）
- `history list [--query] [--json] [--limit N]` — node:sqlite **readOnly 打开**（缺库不创建，结构上保证；WAL 模式可读，评审实测含 crash-hot-WAL 场景），参数化查询 + LIKE 通配转义（零注入面）
- 全局约定测试锁定：退出码 0/1/2（4 预留）、`--json` 任意 argv 位置、stderr 日志、无 TTY 无提示、成功路径 stdout 纯净

## 关键设计

- `runCli(argv) → {code, stdout, stderr}` 纯函数形态：全部约定函数级可测，零进程 spawn
- 路径推导逐条对齐 environment.ts/database.ts/main.ts（含 ELECTRON_USER_DATA、MURMUR_DB_PATH 覆盖）；dev 模式 userData 大小写分歧如实记录（打包版零影响，跟踪至 #265）
- 白名单镜像 + 双向奇偶校验测试；**ai_api_key 永不可 CLI 配置**的秘密卫生锁（fileConfig 刻意将密钥排除在明文 dotfile 之外——本票评审前置修正了原 ALLOWED_SETTING_KEYS 对齐的 footgun）
- 边界奇偶：`config set` 值长度上限 10000 对齐 IPC validateSetting

## 打包

package.json `bin` + electron-builder `files` 加 `cli/**/*.mjs`；eslint/prettier/format 覆盖 cli 目录。ELECTRON_RUN_AS_NODE 冒烟实测通过。

## 独立 code-review

APPROVE（0 MAJOR / 4 MINOR / 2 NIT）：路径推导/存储语义机械 diff 零漂移；readonly-WAL 深查（含热 WAL 残留场景）实测稳健。4 MINOR 已全部采纳修复（homedir 默认、值长度上限、过期注释、typo），dev 路径分歧记录在案。

## 验证

CLI 套件 69 用例全绿（51 新增 + 剪贴板套件）；lint/typecheck/format 全过；worktree 内 ci:check 10/11（唯一失败为 worktree 缺未跟踪 .venv 的 Python 环境问题，零 Python 改动，远端 CI 完整安装）

Closes #264