### PR TITLE
feat: 本地 IPC 通道 — 认证握手/JSON 帧协议/转写+状态端点 (Spec #258 #265, closes #265)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -64,6 +64,14 @@ import FunASRManager from "./src/helpers/funasrManager";
 import TrayManager from "./src/helpers/tray";
 import HotkeyManager from "./src/helpers/hotkeyManager";
 import { registerAll as registerIPCHandlers } from "./src/helpers/ipc";
+// [20260912_Feat_265_LocalChannel] Local IPC channel (ticket #265, spec
+// #258): an authenticated unix-socket/named-pipe bridge for CLI/MCP
+// clients. main.ts only starts/stops it — all logic lives in the module.
+import {
+  startLocalChannel,
+  type LocalChannelHandle,
+} from "./src/helpers/localChannel";
+// [20260912_Feat_265_LocalChannel] END
 
 // Set production environment PATH
 function setupProductionPath(): void {
@@ -160,6 +168,12 @@ const clipboardManager = new ClipboardManager(logger); // Pass logger instance
 const funasrManager = new FunASRManager(logger); // Pass logger instance
 const trayManager = new TrayManager(logger);
 const hotkeyManager = new HotkeyManager();
+
+// [20260912_Feat_265_LocalChannel] Handle for the local channel started in
+// startApp; nulled in will-quit after stop(). Null when the channel failed
+// to start (guarded — a channel failure must not block app boot).
+let localChannelHandle: LocalChannelHandle | null = null;
+// [20260912_Feat_265_LocalChannel] END
 
 // Initialize database
 const dataDirectory = environmentManager.ensureDataDirectory();
@@ -279,6 +293,22 @@ async function startApp(): Promise<void> {
   trayManager.setWindows(windowManager.mainWindow);
   await trayManager.createTray();
   logger.info("系统托盘设置完成");
+
+  // [20260912_Feat_265_LocalChannel] Start the local IPC channel after all
+  // managers are initialized (ticket #265, spec #258). Guarded: a channel
+  // failure (e.g. endpoint owned by a live instance) must never block app
+  // boot. The module writes the 0600 token file, heals stale unix sockets
+  // and binds the transport — main.ts stays a thin call.
+  try {
+    localChannelHandle = await startLocalChannel({
+      userDataPath: app.getPath("userData"),
+      serviceDeps: { funasrManager, databaseManager, logger },
+      logger,
+    });
+  } catch (err) {
+    logger.warn("本地通道启动失败（非致命，不影响应用启动）:", err);
+  }
+  // [20260912_Feat_265_LocalChannel] END
 
   logger.info("应用启动完成");
 }
@@ -423,6 +453,19 @@ app.on("will-quit", async (e) => {
   // [20260911_Fix_339_DockActivate] END
   e.preventDefault();
   globalShortcut.unregisterAll();
+
+  // [20260912_Feat_265_LocalChannel] Release the local channel first:
+  // destroy client sessions and remove the unix socket file so no client
+  // connects to a dying app (ticket #265 will-quit cleanup).
+  try {
+    if (localChannelHandle) {
+      await localChannelHandle.stop();
+      localChannelHandle = null;
+    }
+  } catch (err) {
+    logger.error("Error stopping local channel:", err);
+  }
+  // [20260912_Feat_265_LocalChannel] END
 
   try {
     const shutdownPromise = funasrManager.gracefulShutdown();

--- a/src/helpers/localChannel/client.ts
+++ b/src/helpers/localChannel/client.ts
@@ -1,0 +1,245 @@
+// [20260912_Feat_265_LocalChannel] Channel client helper (ticket #265,
+// spec #258). Speaks the same newline-delimited JSON protocol as the
+// channel server; designed for reuse by the CLI/MCP bridge (ticket #267):
+// connect() performs the mandatory first-frame token handshake, request()
+// correlates responses by id and forwards progress frames to an optional
+// callback. Pure node:net — runs headless in tests and under
+// ELECTRON_RUN_AS_NODE (zero Electron imports).
+
+import net from "node:net";
+import { StringDecoder } from "node:string_decoder";
+import {
+  CHANNEL_CONNECT_TIMEOUT_MS,
+  ERR_NOT_CONNECTED,
+  createFrameSplitter,
+  encodeFrame,
+  FrameOverflowError,
+} from "./protocol";
+import type {
+  AcceptedFrame,
+  ErrorFrame,
+  ProgressFrame,
+  RequestErrorFrame,
+  RequestFrame,
+  ResultFrame,
+} from "./protocol";
+import type { TokenFrame } from "./protocol";
+
+export interface ChannelClientOptions {
+  /** Unix socket path or Windows pipe name (see resolveChannelEndpoint). */
+  endpointPath: string;
+  /** Hex token read from <userData>/murmur-channel-token. */
+  token: string;
+  connectTimeoutMs?: number;
+}
+
+export interface ChannelClient {
+  /** Connect + token handshake. Rejects on refusal, timeout or rejection. */
+  connect(): Promise<void>;
+  /**
+   * Send a request and await its result frame. Progress frames en route
+   * are forwarded to `onProgress`. Rejects on an error frame or disconnect.
+   */
+  request(
+    method: string,
+    params?: Record<string, unknown>,
+    onProgress?: (progress: unknown) => void,
+  ): Promise<unknown>;
+  /** Destroy the socket; pending requests reject with a closed error. */
+  close(): void;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  onProgress?: (progress: unknown) => void;
+}
+
+/** Server frames the client can receive after the handshake settled. */
+type InboundServerFrame = Partial<
+  AcceptedFrame & ErrorFrame & ResultFrame & ProgressFrame & RequestErrorFrame
+>;
+
+export function createChannelClient(
+  options: ChannelClientOptions,
+): ChannelClient {
+  const connectTimeoutMs =
+    options.connectTimeoutMs ?? CHANNEL_CONNECT_TIMEOUT_MS;
+  let socket: net.Socket | null = null;
+  let split: ((chunk: string) => string[]) | null = null;
+  let decoder: StringDecoder | null = null;
+  let nextRequestId = 0;
+  const pending = new Map<string, PendingRequest>();
+  let handshakeWaiter: {
+    resolve: () => void;
+    reject: (error: Error) => void;
+  } | null = null;
+
+  /** Reject everything outstanding (used on protocol errors/disconnects). */
+  function failAll(message: string): void {
+    const waiter = handshakeWaiter;
+    handshakeWaiter = null;
+    waiter?.reject(new Error(message));
+    for (const [id, entry] of pending) {
+      pending.delete(id);
+      entry.reject(new Error(message));
+    }
+  }
+
+  function deliver(frame: unknown): void {
+    const f = isRecord(frame) ? (frame as InboundServerFrame) : null;
+    if (!f) {
+      failAll("local-channel-malformed-frame");
+      return;
+    }
+    // Id-less error frames are handshake-level rejections (token-rejected,
+    // connection-limit-rejected) — fail the connect/handshake waiters.
+    if (f.error !== undefined && f.id === undefined) {
+      failAll(String(f.error));
+      return;
+    }
+    if (handshakeWaiter) {
+      if (f.accepted === true) {
+        const waiter = handshakeWaiter;
+        handshakeWaiter = null;
+        waiter.resolve();
+        return;
+      }
+      failAll("local-channel-unexpected-handshake-frame");
+      return;
+    }
+    if (typeof f.id !== "string") return; // uncorrelated frame — ignore
+    const entry = pending.get(f.id);
+    if (!entry) return;
+    if (f.progress !== undefined) {
+      entry.onProgress?.(f.progress);
+      return;
+    }
+    pending.delete(f.id);
+    if (f.error !== undefined) {
+      entry.reject(new Error(String(f.error)));
+      return;
+    }
+    if ("result" in f) {
+      entry.resolve(f.result);
+      return;
+    }
+    entry.reject(new Error("local-channel-malformed-frame"));
+  }
+
+  function onChunk(chunk: Buffer): void {
+    if (!split || !decoder) return;
+    // StringDecoder reassembles UTF-8 sequences split across TCP segments
+    // (results carry Chinese text).
+    // [20260912_Fix_265_ReviewHardening] Frame-length bound (mirrors the
+    // server): an overflowing peer destroys the connection and fails all
+    // pending requests instead of growing the buffer.
+    let frames: string[];
+    try {
+      frames = split(decoder.write(chunk));
+    } catch (error) {
+      if (error instanceof FrameOverflowError) {
+        socket?.destroy();
+        failAll("local-channel-frame-overflow");
+        return;
+      }
+      throw error;
+    }
+    for (const raw of frames) {
+      if (!raw.trim()) continue;
+      let frame: unknown;
+      try {
+        frame = JSON.parse(raw);
+      } catch {
+        failAll("local-channel-malformed-frame");
+        return;
+      }
+      deliver(frame);
+    }
+  }
+
+  function onClose(): void {
+    socket = null;
+    split = null;
+    decoder = null;
+    failAll("local-channel-connection-closed");
+  }
+
+  function connect(): Promise<void> {
+    if (socket) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const sock = net.connect(options.endpointPath);
+      let connectTimer: NodeJS.Timeout | null = null;
+      const settleConnect = (error?: Error): void => {
+        if (connectTimer) {
+          clearTimeout(connectTimer);
+          connectTimer = null;
+        }
+        if (error) {
+          sock.destroy();
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+      connectTimer = setTimeout(
+        () => settleConnect(new Error("local-channel-connect-timeout")),
+        connectTimeoutMs,
+      );
+      connectTimer.unref();
+
+      sock.on("connect", () => {
+        // Mandatory first frame: the token handshake (ticket #265).
+        const tokenFrame: TokenFrame = { token: options.token };
+        sock.write(encodeFrame(tokenFrame));
+      });
+      sock.on("data", onChunk);
+      sock.on("error", (err: Error) => settleConnect(err));
+      sock.on("close", () => {
+        if (connectTimer) {
+          clearTimeout(connectTimer);
+          connectTimer = null;
+        }
+        onClose();
+      });
+
+      socket = sock;
+      split = createFrameSplitter();
+      decoder = new StringDecoder("utf8");
+      handshakeWaiter = {
+        resolve: () => settleConnect(),
+        reject: (error: Error) => settleConnect(error),
+      };
+    });
+  }
+
+  function request(
+    method: string,
+    params: Record<string, unknown> = {},
+    onProgress?: (progress: unknown) => void,
+  ): Promise<unknown> {
+    const sock = socket;
+    if (!sock) {
+      return Promise.reject(new Error(ERR_NOT_CONNECTED));
+    }
+    nextRequestId += 1;
+    const id = `req-${nextRequestId}`;
+    return new Promise<unknown>((resolve, reject) => {
+      pending.set(id, { resolve, reject, onProgress });
+      const requestFrame: RequestFrame = { id, method, params };
+      sock.write(encodeFrame(requestFrame));
+    });
+  }
+
+  function close(): void {
+    socket?.destroy();
+    onClose();
+  }
+
+  return { connect, request, close };
+}
+
+/** Narrow an unknown parsed value to a plain object record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/helpers/localChannel/endpoint.ts
+++ b/src/helpers/localChannel/endpoint.ts
@@ -86,9 +86,10 @@ export function writeChannelEndpointFile(
 
 export function removeChannelEndpointFile(
   userDataPath: string,
-  platform: string = process.platform,
+  _platform: string = process.platform,
 ): void {
-  if (platform === "win32") return;
+  // A plain data file (unlike the socket itself) — removable on every
+  // platform; no win32 gate.
   try {
     fs.rmSync(path.join(userDataPath, ENDPOINT_FILE_NAME), { force: true });
   } catch {

--- a/src/helpers/localChannel/endpoint.ts
+++ b/src/helpers/localChannel/endpoint.ts
@@ -1,0 +1,98 @@
+// [20260912_Feat_265_LocalChannel] Endpoint + token derivation for the
+// local IPC channel (ticket #265, spec #258). Consistency contract with
+// cli/lib/paths.mjs (ticket #264): the socket path and the token file live
+// in the SAME userData the app uses — main.ts derives them from
+// app.getPath("userData"), which is authoritative (see the dev-mode
+// userData caveat recorded in cli/lib/paths.mjs). Windows uses a named
+// pipe whose name carries a 128-bit random segment, per the PoC (P5): the
+// random name prevents accidental connects but is NOT an access control —
+// the first-frame token handshake is.
+
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  FILE_MODE_OWNER_ONLY,
+  PIPE_NAME_PREFIX,
+  PIPE_NAME_RANDOM_BYTES,
+  SOCKET_FILE_NAME,
+  TOKEN_BYTES,
+  TOKEN_FILE_NAME,
+} from "./protocol";
+
+/**
+ * Resolve the channel endpoint for this launch.
+ * - win32: `\\.\pipe\murmur-<128-bit random hex>` (per-launch random name)
+ * - else:  `<userDataPath>/murmur-channel.sock`
+ *
+ * `platform` is injectable so tests on any OS can cover both shapes.
+ */
+export function resolveChannelEndpoint(
+  userDataPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return `\\\\.\\pipe\\${PIPE_NAME_PREFIX}${randomBytes(PIPE_NAME_RANDOM_BYTES).toString("hex")}`;
+  }
+  return path.join(userDataPath, SOCKET_FILE_NAME);
+}
+
+/** Generate the channel auth token: 32 random bytes, hex-encoded. */
+export function generateChannelToken(): string {
+  return randomBytes(TOKEN_BYTES).toString("hex");
+}
+
+/**
+ * Persist the token for local CLI/MCP clients, regenerated at every app
+ * launch (ticket #265). Written with owner-only permissions; chmod after
+ * the write so a file left by an earlier launch can never keep looser
+ * perms (writeFileSync's mode only applies at creation). Returns the
+ * token file path.
+ */
+export function writeChannelTokenFile(
+  userDataPath: string,
+  token: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const tokenPath = path.join(userDataPath, TOKEN_FILE_NAME);
+  fs.writeFileSync(tokenPath, token, { mode: FILE_MODE_OWNER_ONLY });
+  if (platform !== "win32") {
+    fs.chmodSync(tokenPath, FILE_MODE_OWNER_ONLY);
+  }
+  return tokenPath;
+}
+
+// [20260912_Fix_265_ReviewHardening] Endpoint discovery contract (PoC):
+// Windows pipe names are per-launch random and the namespace must not be
+// enumerated (P1), so startLocalChannel persists the live endpoint here —
+// same 0600-owner-only treatment as the token file; clients (#267) read it.
+export const ENDPOINT_FILE_NAME = "murmur-channel-endpoint";
+
+export function writeChannelEndpointFile(
+  userDataPath: string,
+  endpointPath: string,
+  platform: string = process.platform,
+): string {
+  const endpointFilePath = path.join(userDataPath, ENDPOINT_FILE_NAME);
+  fs.writeFileSync(endpointFilePath, `${endpointPath}\n`, {
+    mode: FILE_MODE_OWNER_ONLY,
+  });
+  if (platform !== "win32") {
+    // Umasks vary: chmod after write makes owner-only unconditional.
+    fs.chmodSync(endpointFilePath, FILE_MODE_OWNER_ONLY);
+  }
+  return endpointFilePath;
+}
+
+export function removeChannelEndpointFile(
+  userDataPath: string,
+  platform: string = process.platform,
+): void {
+  if (platform === "win32") return;
+  try {
+    fs.rmSync(path.join(userDataPath, ENDPOINT_FILE_NAME), { force: true });
+  } catch {
+    // Best-effort cleanup; a leftover endpoint file fails the client's
+    // connect probe, which is the same path as "app not running".
+  }
+}

--- a/src/helpers/localChannel/index.ts
+++ b/src/helpers/localChannel/index.ts
@@ -1,0 +1,31 @@
+// [20260912_Feat_265_LocalChannel] Public surface of the local channel
+// module (ticket #265, spec #258). main.ts needs only startLocalChannel;
+// the CLI/MCP bridge (ticket #267) adds createChannelClient +
+// resolveChannelEndpoint + generateChannelToken. Everything here is
+// Electron-free (node builtins only) so tests and CLI run headless.
+
+export { createChannelServer, startLocalChannel } from "./server";
+export type {
+  ChannelServerOptions,
+  ChannelServices,
+  LocalChannelHandle,
+  LocalChannelServer,
+  LocalChannelServiceDeps,
+  StartLocalChannelInput,
+} from "./server";
+export { createChannelClient } from "./client";
+export type { ChannelClient, ChannelClientOptions } from "./client";
+export {
+  generateChannelToken,
+  resolveChannelEndpoint,
+  writeChannelTokenFile,
+} from "./endpoint";
+export {
+  HANDSHAKE_TIMEOUT_MS,
+  MAX_CONNECTIONS,
+  SESSION_IDLE_TTL_MS,
+  SOCKET_FILE_NAME,
+  TOKEN_FILE_NAME,
+  createFrameSplitter,
+  encodeFrame,
+} from "./protocol";

--- a/src/helpers/localChannel/protocol.ts
+++ b/src/helpers/localChannel/protocol.ts
@@ -1,0 +1,142 @@
+// [20260912_Feat_265_LocalChannel] Protocol types, wire constants and
+// newline-delimited JSON framing for the local IPC channel (ticket #265,
+// spec #258). Transport-agnostic: the same framing runs over a Unix domain
+// socket (macOS/Linux) and a Windows named pipe, per the named-pipe PoC
+// (docs/research/2026-09-12-windows-named-pipe-poc.md). RED LINE carried
+// over from the PoC: the server emits ZERO business frames before the
+// client's first token frame is validated — the only pre-handshake output
+// allowed is a rejection frame ({error: ...}).
+
+/** Time a client has to deliver a valid token frame before its connection is destroyed. */
+export const HANDSHAKE_TIMEOUT_MS = 5000;
+
+/** Idle time (no frames received) before an authenticated session is destroyed. */
+export const SESSION_IDLE_TTL_MS = 10 * 60 * 1000;
+
+// [20260912_Fix_265_ReviewHardening] Frame length bound. The PoC proved any
+// local process can connect pre-auth on win32 (P2), so an unbounded
+// no-newline stream would be a pre-auth memory bomb; PoC phase 1 accepted
+// connection-count DoS as the bound — this closes the buffer-growth half.
+// 1 MiB is far above any legitimate frame (transcription results are plain
+// text; chunked long-text polish never ships a single >1 MiB frame).
+export const MAX_FRAME_BYTES = 1024 * 1024;
+
+/** Raised by the frame splitter when a peer exceeds MAX_FRAME_BYTES. */
+export class FrameOverflowError extends Error {
+  constructor() {
+    super("frame exceeds the protocol size limit");
+    this.name = "FrameOverflowError";
+  }
+}
+
+/** Maximum concurrent channel connections; excess connections are rejected. */
+export const MAX_CONNECTIONS = 8;
+
+/** Channel token entropy: 32 random bytes, hex-encoded (PoC P4 shape). */
+export const TOKEN_BYTES = 32;
+
+/** Token file name under userData; contents are the hex token itself. */
+export const TOKEN_FILE_NAME = "murmur-channel-token";
+
+/** Unix domain socket file name under userData. */
+export const SOCKET_FILE_NAME = "murmur-channel.sock";
+
+/** Named-pipe name prefix; the full name is \\.\pipe\murmur-<128-bit hex>. */
+export const PIPE_NAME_PREFIX = "murmur-";
+
+/** Random bytes in the Windows pipe name (128-bit, PoC P5 anti-collision). */
+export const PIPE_NAME_RANDOM_BYTES = 16;
+
+/** Owner-only file permission bits for the token file and the unix socket. */
+export const FILE_MODE_OWNER_ONLY = 0o600;
+
+/** Timeout for the stale-socket probe-connect during the unix self-heal. */
+export const STALE_SOCKET_PROBE_TIMEOUT_MS = 1000;
+
+/** Default client-side connect+handshake timeout. */
+export const CHANNEL_CONNECT_TIMEOUT_MS = 5000;
+
+/** Client-side rejection for requests issued on a non-connected client. */
+export const ERR_NOT_CONNECTED = "local-channel-not-connected";
+
+/** The two endpoints the channel exposes. */
+export const METHOD_TRANSCRIBE_FILE = "transcribe_file";
+export const METHOD_STATUS = "status";
+
+/** Mandatory first frame from the client. */
+export interface TokenFrame {
+  token: string;
+}
+
+/** Server handshake success reply. */
+export interface AcceptedFrame {
+  accepted: true;
+}
+
+/** Server rejection frame (handshake failure or connection-cap rejection). */
+export interface ErrorFrame {
+  error: string;
+}
+
+/** Post-handshake request from the client. */
+export interface RequestFrame {
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** Post-handshake server frames, correlated by the request id. */
+export interface ResultFrame {
+  id: string;
+  result: unknown;
+}
+export interface ProgressFrame {
+  id: string;
+  progress: unknown;
+}
+export interface RequestErrorFrame {
+  id: string;
+  error: string;
+}
+
+/** Every frame the server may write. */
+export type ServerFrame =
+  | AcceptedFrame
+  | ErrorFrame
+  | ResultFrame
+  | ProgressFrame
+  | RequestErrorFrame;
+
+/** Serialize a frame onto the wire (newline-delimited JSON). */
+export function encodeFrame(
+  frame: ServerFrame | TokenFrame | RequestFrame,
+): string {
+  return `${JSON.stringify(frame)}\n`;
+}
+
+/**
+ * Incremental newline-frame splitter shared by server and client. Feeding
+ * each received chunk returns the complete frames accumulated so far;
+ * partial frames stay buffered until their newline arrives.
+ */
+export function createFrameSplitter(
+  maxBytes: number = MAX_FRAME_BYTES,
+): (chunk: string) => string[] {
+  let buffer = "";
+  return (chunk: string): string[] => {
+    buffer += chunk;
+    if (buffer.length > maxBytes) {
+      // Checked on the ACCUMULATED buffer: a dribbled no-newline stream is
+      // bounded just like a single oversized segment.
+      throw new FrameOverflowError();
+    }
+    const frames: string[] = [];
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      frames.push(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+    }
+    return frames;
+  };
+}

--- a/src/helpers/localChannel/server.ts
+++ b/src/helpers/localChannel/server.ts
@@ -1,0 +1,575 @@
+// [20260912_Feat_265_LocalChannel] Transport-agnostic local channel server
+// (ticket #265, spec #258). One module serves both transports: a Unix
+// domain socket (macOS/Linux, 0600) and a Windows named pipe with a
+// 128-bit random per-launch name — the compensating-control combination
+// proven by the named-pipe PoC (docs/research/2026-09-12-windows-named-
+// pipe-poc.md): first-frame token handshake, random pipe name, short
+// session TTL, destroy on any handshake failure, connection cap.
+// RED LINE (PoC P2/P4): the server emits ZERO business frames before the
+// token is validated — the only pre-handshake output allowed is a
+// rejection frame. The module is constructible WITHOUT Electron: every
+// collaborator (services, token, endpoint path, logger, tunables) is
+// injected; main.ts wires it through the thin startLocalChannel() below.
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import { StringDecoder } from "node:string_decoder";
+import { validateAudioPath } from "../audioPathValidator";
+import {
+  checkEngineStatusService,
+  transcribeFileService,
+  type Logger,
+} from "../services/transcriptionService";
+import {
+  FILE_MODE_OWNER_ONLY,
+  HANDSHAKE_TIMEOUT_MS,
+  MAX_CONNECTIONS,
+  METHOD_STATUS,
+  METHOD_TRANSCRIBE_FILE,
+  SESSION_IDLE_TTL_MS,
+  STALE_SOCKET_PROBE_TIMEOUT_MS,
+  createFrameSplitter,
+  encodeFrame,
+  FrameOverflowError,
+} from "./protocol";
+import type {
+  AcceptedFrame,
+  ProgressFrame,
+  RequestErrorFrame,
+  RequestFrame,
+  ResultFrame,
+  ServerFrame,
+} from "./protocol";
+import {
+  generateChannelToken,
+  resolveChannelEndpoint,
+  writeChannelTokenFile,
+  writeChannelEndpointFile,
+  removeChannelEndpointFile,
+} from "./endpoint";
+
+/** Endpoint implementations the channel exposes (injected for tests). */
+export interface ChannelServices {
+  transcribeFile(
+    audioPath: string,
+    options: Record<string, unknown>,
+    onProgress?: (progress: unknown) => void,
+  ): Promise<unknown>;
+  checkEngineStatus(): Promise<unknown>;
+}
+
+export interface ChannelServerOptions {
+  /** Unix socket path or Windows pipe name (see resolveChannelEndpoint). */
+  endpointPath: string;
+  /** Per-launch hex token; compared timing-safe against the client's first frame. */
+  token: string;
+  services: ChannelServices;
+  logger: Logger;
+  /** Injectable for tests; defaults to the real platform. */
+  platform?: NodeJS.Platform;
+  handshakeTimeoutMs?: number;
+  sessionIdleTtlMs?: number;
+  maxConnections?: number;
+}
+
+export interface LocalChannelServer {
+  readonly endpointPath: string;
+  /** Bind + listen. Rejects when a live instance already owns the endpoint. */
+  listen(): Promise<void>;
+  /** Destroy all sessions, close the listener, remove the unix socket file. */
+  stop(): Promise<void>;
+}
+
+/** One connected client and its per-connection protocol state. */
+interface ChannelSession {
+  socket: net.Socket;
+  authenticated: boolean;
+  split: (chunk: string) => string[];
+  decoder: StringDecoder;
+  handshakeTimer: NodeJS.Timeout | null;
+  idleTimer: NodeJS.Timeout | null;
+  inFlight: number;
+}
+
+/**
+ * Probe-connect the endpoint as a plain client: a successful connect means
+ * a live instance owns it; a failure/timeout means the file is stale.
+ */
+function probeEndpointLive(endpointPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = net.connect(endpointPath);
+    let settled = false;
+    const settle = (live: boolean): void => {
+      if (settled) return;
+      settled = true;
+      probe.destroy();
+      resolve(live);
+    };
+    const timer = setTimeout(
+      () => settle(false),
+      STALE_SOCKET_PROBE_TIMEOUT_MS,
+    );
+    timer.unref();
+    probe.once("connect", () => {
+      clearTimeout(timer);
+      settle(true);
+    });
+    probe.once("error", () => {
+      clearTimeout(timer);
+      settle(false);
+    });
+  });
+}
+
+/** Narrow an unknown value to a plain object record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+class LocalChannelServerImpl implements LocalChannelServer {
+  readonly endpointPath: string;
+
+  private readonly token: string;
+  private readonly services: ChannelServices;
+  private readonly logger: Logger;
+  private readonly platform: NodeJS.Platform;
+  private readonly handshakeTimeoutMs: number;
+  private readonly sessionIdleTtlMs: number;
+  private readonly maxConnections: number;
+  private readonly sessions = new Set<ChannelSession>();
+  private server: net.Server | null = null;
+
+  constructor(options: ChannelServerOptions) {
+    this.endpointPath = options.endpointPath;
+    this.token = options.token;
+    this.services = options.services;
+    this.logger = options.logger;
+    this.platform = options.platform ?? process.platform;
+    this.handshakeTimeoutMs =
+      options.handshakeTimeoutMs ?? HANDSHAKE_TIMEOUT_MS;
+    this.sessionIdleTtlMs = options.sessionIdleTtlMs ?? SESSION_IDLE_TTL_MS;
+    this.maxConnections = options.maxConnections ?? MAX_CONNECTIONS;
+  }
+
+  async listen(): Promise<void> {
+    // [20260912_Feat_265_LocalChannel] Unix-only stale-socket self-heal
+    // (ticket #265 point 4): a leftover socket file from a crashed previous
+    // instance is probe-connected as a client; only a DEAD endpoint is
+    // unlinked. A live instance answering the probe means another Murmur
+    // owns the channel — log and refuse to bind (a second app instance
+    // would already have exited via #260, so this is crash leftovers).
+    if (this.platform !== "win32" && fs.existsSync(this.endpointPath)) {
+      const live = await probeEndpointLive(this.endpointPath);
+      if (live) {
+        this.logger.warn?.(
+          "本地通道端点已被其他运行中的实例占用，本实例不绑定通道",
+          { endpointPath: this.endpointPath },
+        );
+        throw new Error("local-channel-endpoint-in-use");
+      }
+      this.logger.info?.("清理残留的本地通道套接字文件后重新绑定", {
+        endpointPath: this.endpointPath,
+      });
+      fs.rmSync(this.endpointPath, { force: true });
+    }
+
+    await this.listenServer();
+
+    // Owner-only socket file perms (unix). On Windows the endpoint is a
+    // named pipe; its security is the token handshake per the PoC, not DACL.
+    if (this.platform !== "win32") {
+      fs.chmodSync(this.endpointPath, FILE_MODE_OWNER_ONLY);
+    }
+    this.logger.info?.("本地通道已监听", { endpointPath: this.endpointPath });
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    this.server = null;
+    for (const session of this.sessions) {
+      session.socket.destroy();
+    }
+    if (!server) return;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    // Explicit unlink covers corner cases where close() did not remove the
+    // socket file (Node removes it on unix, but never relies on it here).
+    if (this.platform !== "win32") {
+      fs.rmSync(this.endpointPath, { force: true });
+    }
+    this.logger.info?.("本地通道已停止");
+  }
+
+  /** Unref'd timer helper: channel timers must never hold the app open. */
+  private startTimer(fn: () => void, ms: number): NodeJS.Timeout {
+    const timer = setTimeout(fn, ms);
+    timer.unref();
+    return timer;
+  }
+
+  private listenServer(): Promise<void> {
+    const server = net.createServer((socket) => this.onConnection(socket));
+    this.server = server;
+    // Persistent error listener: runtime errors (accept storms, ECONNRESET
+    // on the listener) must not surface as uncaught exceptions.
+    server.on("error", (err: Error) => {
+      this.logger.error?.("本地通道服务器错误:", err);
+    });
+    return new Promise<void>((resolve, reject) => {
+      const onceBindError = (err: Error): void => reject(err);
+      server.once("error", onceBindError);
+      server.listen(this.endpointPath, () => {
+        server.removeListener("error", onceBindError);
+        resolve();
+      });
+    });
+  }
+
+  private onConnection(socket: net.Socket): void {
+    if (this.sessions.size >= this.maxConnections) {
+      // PoC compensating control: deny-and-drop keeps local processes from
+      // holding channel capacity. The rejection frame (like token-rejected)
+      // leaks only "a Murmur channel exists" — no business data.
+      this.writeFrame(socket, { error: "connection-limit-rejected" });
+      socket.destroy();
+      return;
+    }
+    const session: ChannelSession = {
+      socket,
+      authenticated: false,
+      split: createFrameSplitter(),
+      decoder: new StringDecoder("utf8"),
+      handshakeTimer: null,
+      idleTimer: null,
+      // [20260912_Fix_265_ReviewHardening] Idle TTL must not fire mid-task:
+      // a transcription longer than SESSION_IDLE_TTL_MS generates no inbound
+      // frames, so in-flight requests suppress the timer until they settle.
+      inFlight: 0,
+    };
+    this.sessions.add(session);
+    session.handshakeTimer = this.startTimer(() => {
+      this.logger.warn?.("本地通道握手超时，断开连接");
+      socket.destroy();
+    }, this.handshakeTimeoutMs);
+    socket.on("data", (chunk: Buffer) => this.onData(session, chunk));
+    socket.on("error", (err: Error) => {
+      // Client disconnects mid-task surface here (ECONNRESET/EPIPE) —
+      // handled, not swallowed; debug level because resets are routine.
+      this.logger.debug?.("本地通道连接错误", err.message);
+    });
+    socket.on("close", () => this.removeSession(session));
+  }
+
+  private onData(session: ChannelSession, chunk: Buffer): void {
+    // StringDecoder reassembles UTF-8 sequences split across TCP segments
+    // (transcription results carry Chinese text).
+    // [20260912_Fix_265_ReviewHardening] A peer exceeding MAX_FRAME_BYTES
+    // (pre-auth reachable on win32 per PoC P2) is destroyed, not buffered.
+    let frames: string[];
+    try {
+      frames = session.split(session.decoder.write(chunk));
+    } catch (error) {
+      if (error instanceof FrameOverflowError) {
+        this.logger.warn?.("本地通道帧超限，断开连接");
+        session.socket.destroy();
+        return;
+      }
+      throw error;
+    }
+    for (const raw of frames) {
+      if (!raw.trim()) continue;
+      this.handleFrame(session, raw);
+      if (session.socket.destroyed) return;
+    }
+  }
+
+  private handleFrame(session: ChannelSession, raw: string): void {
+    let frame: unknown;
+    try {
+      frame = JSON.parse(raw);
+    } catch {
+      this.handleUnparsableFrame(session);
+      return;
+    }
+    if (!session.authenticated) {
+      this.handleHandshake(session, frame);
+      return;
+    }
+    // [20260912_Fix_265_ReviewHardening] No arming here: handleRequest's
+    // finally re-arms when in-flight work settles, so the idle timer can
+    // never be armed with a request already counted as in flight.
+    void this.handleRequest(session, frame);
+  }
+
+  /** Any unparsable or non-conforming first frame is an auth failure. */
+  private handleUnparsableFrame(session: ChannelSession): void {
+    if (!session.authenticated) {
+      this.logger.warn?.("本地通道握手失败：首帧不是合法的 token 帧");
+      this.writeFrame(session.socket, { error: "token-rejected" });
+      session.socket.destroy();
+      return;
+    }
+    this.logger.warn?.("本地通道收到无法解析的帧，断开连接");
+    session.socket.destroy();
+  }
+
+  private handleHandshake(session: ChannelSession, frame: unknown): void {
+    const token = isRecord(frame) ? frame.token : undefined;
+    if (typeof token !== "string" || !this.tokenMatches(token)) {
+      // PoC P4: wrong OR missing token → rejection frame + immediate destroy.
+      this.logger.warn?.("本地通道握手失败：token 缺失或不匹配，断开连接");
+      this.writeFrame(session.socket, { error: "token-rejected" });
+      session.socket.destroy();
+      return;
+    }
+    session.authenticated = true;
+    if (session.handshakeTimer) {
+      clearTimeout(session.handshakeTimer);
+      session.handshakeTimer = null;
+    }
+    this.armIdleTimer(session);
+    this.writeFrame(session.socket, { accepted: true } satisfies AcceptedFrame);
+    this.logger.info?.("本地通道客户端握手成功");
+  }
+
+  /** Timing-safe comparison over fixed-length SHA-256 digests (no length leak). */
+  private tokenMatches(candidate: string): boolean {
+    const digest = (value: string): Buffer =>
+      createHash("sha256").update(value).digest();
+    return timingSafeEqual(digest(candidate), digest(this.token));
+  }
+
+  private armIdleTimer(session: ChannelSession): void {
+    if (session.idleTimer) clearTimeout(session.idleTimer);
+    // [20260912_Fix_265_ReviewHardening] A request in flight suppresses the
+    // idle timer entirely: progress frames go OUTBOUND and long transcriptions
+    // go quiet on the wire, so "no inbound frames" no longer implies "idle".
+    if (session.inFlight > 0) {
+      session.idleTimer = null;
+      return;
+    }
+    session.idleTimer = this.startTimer(() => {
+      this.logger.info?.("本地通道会话空闲超时，断开连接");
+      session.socket.destroy();
+    }, this.sessionIdleTtlMs);
+  }
+
+  private removeSession(session: ChannelSession): void {
+    if (session.handshakeTimer) clearTimeout(session.handshakeTimer);
+    if (session.idleTimer) clearTimeout(session.idleTimer);
+    this.sessions.delete(session);
+  }
+
+  private async handleRequest(
+    session: ChannelSession,
+    frame: unknown,
+  ): Promise<void> {
+    // [20260912_Fix_265_ReviewHardening] In-flight accounting brackets the
+    // whole request so the idle TTL cannot fire mid-task; the timer re-arms
+    // when the last request settles.
+    session.inFlight += 1;
+    // Clear the timer armed at handshake (or by the previous request's
+    // settle) — in-flight work suppresses the idle TTL entirely.
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = null;
+    }
+    try {
+      await this.dispatchRequest(session, frame);
+    } finally {
+      session.inFlight -= 1;
+      if (session.inFlight === 0 && !session.socket.destroyed) {
+        this.armIdleTimer(session);
+      }
+    }
+  }
+
+  private async dispatchRequest(
+    session: ChannelSession,
+    frame: unknown,
+  ): Promise<void> {
+    const request = isRecord(frame) ? (frame as Partial<RequestFrame>) : null;
+    const socket = session.socket;
+    if (!request || typeof request.id !== "string") {
+      // No correlation id — the frame can never be answered; drop the client.
+      socket.destroy();
+      return;
+    }
+    const id = request.id;
+    if (typeof request.method !== "string") {
+      this.writeFrame(socket, { id, error: "invalid-frame" });
+      return;
+    }
+    switch (request.method) {
+      case METHOD_STATUS:
+        await this.runRequest(socket, id, () =>
+          this.services.checkEngineStatus(),
+        );
+        return;
+      case METHOD_TRANSCRIBE_FILE: {
+        const params = isRecord(request.params) ? request.params : {};
+        const audioPath = params.audioPath;
+        if (typeof audioPath !== "string") {
+          this.writeFrame(socket, { id, error: "audioPath-required" });
+          return;
+        }
+        // [20260912_Feat_265_LocalChannel] Channel-entry validation
+        // (ticket #265 point 5): validateAudioPath FIRST — an invalid path
+        // is answered with an error frame and the engine is never touched.
+        const validation = validateAudioPath(audioPath);
+        if (!validation.valid) {
+          this.writeFrame(socket, { id, error: validation.error });
+          return;
+        }
+        const options = isRecord(params.options) ? params.options : {};
+        await this.runRequest(socket, id, () =>
+          this.services.transcribeFile(audioPath, options, (progress) => {
+            // Long tasks stream progress frames before the result frame.
+            this.writeFrame(socket, { id, progress } satisfies ProgressFrame);
+          }),
+        );
+        return;
+      }
+      default:
+        this.writeFrame(socket, { id, error: "unknown-method" });
+    }
+  }
+
+  private async runRequest(
+    socket: net.Socket,
+    id: string,
+    run: () => Promise<unknown>,
+  ): Promise<void> {
+    try {
+      const result = await run();
+      this.writeFrame(socket, { id, result } satisfies ResultFrame);
+    } catch (error) {
+      this.logger.error?.("本地通道请求处理失败:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      this.writeFrame(socket, {
+        id,
+        error: message,
+      } satisfies RequestErrorFrame);
+    }
+  }
+
+  /** Write a frame unless the peer already went away (mid-task disconnect). */
+  private writeFrame(socket: net.Socket, frame: ServerFrame): void {
+    if (socket.destroyed) return;
+    socket.write(encodeFrame(frame));
+  }
+}
+
+/** Build a channel server. Electron-free: everything is injected. */
+export function createChannelServer(
+  options: ChannelServerOptions,
+): LocalChannelServer {
+  return new LocalChannelServerImpl(options);
+}
+
+// [20260912_Feat_265_LocalChannel] --- main.ts wiring (thin) ---
+// startLocalChannel is the ONLY function main.ts needs: generate the
+// per-launch token, persist it 0600 for CLI/MCP clients, resolve the
+// endpoint, bind (with unix stale-socket self-heal) and bind the real
+// transcription services. Channel failure must never block app boot —
+// the caller guards with try/catch.
+
+/** Service collaborator bag: the manager slices the channel endpoints touch. */
+export interface LocalChannelServiceDeps {
+  funasrManager: {
+    // Real FunASRManager.transcribeFile returns Promise<unknown> — the
+    // transcription service reads the result through a structural view.
+    transcribeFile(
+      audioPath: string,
+      options: Record<string, unknown>,
+    ): Promise<unknown>;
+    checkModelFiles(): Promise<unknown>;
+  };
+  databaseManager: {
+    saveTranscription(data: Record<string, unknown>): {
+      lastInsertRowid?: number | bigint | null;
+      changes?: number | bigint;
+    };
+    // Synchronous settings read (hotword injection).
+    getSetting(key: string, defaultValue?: unknown): unknown;
+  };
+  logger: Logger;
+}
+
+export interface StartLocalChannelInput {
+  /**
+   * Root for the socket + token files. The app passes
+   * app.getPath("userData") — authoritative per cli/lib/paths.mjs.
+   */
+  userDataPath: string;
+  serviceDeps: LocalChannelServiceDeps;
+  logger: Logger;
+  platform?: NodeJS.Platform;
+}
+
+export interface LocalChannelHandle {
+  readonly endpointPath: string;
+  readonly tokenPath: string;
+  /** File persisting the endpoint name (Windows discovery contract, PoC). */
+  readonly endpointFilePath: string;
+  /** Release the endpoint and all connections (will-quit cleanup). */
+  stop(): Promise<void>;
+}
+
+export async function startLocalChannel(
+  input: StartLocalChannelInput,
+): Promise<LocalChannelHandle> {
+  const { userDataPath, serviceDeps, logger } = input;
+  const platform = input.platform ?? process.platform;
+  // Fresh token every launch (ticket #265): regenerate and overwrite the
+  // 0600 token file local clients read.
+  const token = generateChannelToken();
+  const endpointPath = resolveChannelEndpoint(userDataPath, platform);
+  // [20260912_Feat_265_LocalChannel] Boundary cast (established
+  // ipc/index.ts TypeRelax pattern, no `any`): the transcription services
+  // document richer result shapes than the real managers return, but only
+  // read them through structural views. The bag above already mirrors the
+  // real manager surface; this single cast adapts it to the services'
+  // documented deps without touching the services themselves.
+  const transcribeDeps = serviceDeps as unknown as Parameters<
+    typeof transcribeFileService
+  >[0];
+  const statusDeps = serviceDeps as unknown as Parameters<
+    typeof checkEngineStatusService
+  >[0];
+  const server = createChannelServer({
+    endpointPath,
+    token,
+    logger,
+    platform,
+    services: {
+      transcribeFile: (audioPath, options, onProgress) =>
+        transcribeFileService(transcribeDeps, audioPath, options, onProgress),
+      checkEngineStatus: () => checkEngineStatusService(statusDeps),
+    },
+  });
+  // [20260912_Fix_265_ReviewHardening] Bind FIRST, then publish secrets:
+  // if listen() fails (endpoint in use), no token file is written, so a
+  // failed boot can never leave credentials that authenticate against a
+  // channel that does not exist (fail-closed).
+  await server.listen();
+  const tokenPath = writeChannelTokenFile(userDataPath, token, platform);
+  // Windows pipes are per-launch random names (PoC): persist the endpoint
+  // so #267's CLI/MCP clients can discover it without enumeration (P1).
+  const endpointFilePath = writeChannelEndpointFile(
+    userDataPath,
+    endpointPath,
+    platform,
+  );
+  logger.info?.("本地 IPC 通道已启动", { endpointPath, tokenPath });
+  return {
+    endpointPath,
+    tokenPath,
+    endpointFilePath,
+    stop: async () => {
+      await server.stop();
+      removeChannelEndpointFile(userDataPath, platform);
+    },
+  };
+}
+// [20260912_Feat_265_LocalChannel] END

--- a/tests/unit/localChannel.test.ts
+++ b/tests/unit/localChannel.test.ts
@@ -1,0 +1,674 @@
+// [20260912_Feat_265_LocalChannel] Black-box tests for the local IPC
+// channel server + client helper (ticket #265, spec #258). The server is
+// constructed WITHOUT Electron (deps-injected services/token/logger) and
+// exercised over REAL loopback sockets: handshake red line (zero business
+// frames before the token is validated), endpoint dispatch, progress
+// streaming, handshake timeout, session idle TTL, connection cap, and the
+// startLocalChannel wiring (token file + real service binding). Stale
+// unix-socket self-heal lives in localChannelHeal.test.ts.
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createChannelClient,
+  createChannelServer,
+  createFrameSplitter,
+  startLocalChannel,
+  type ChannelServices,
+  type LocalChannelServer,
+} from "../../src/helpers/localChannel";
+import type { Logger } from "../../src/helpers/services/transcriptionService";
+
+// [20260912_Feat_265_LocalChannel] Opaque test token — the server treats
+// it as an opaque string; logs must never echo it (asserted below).
+const TOKEN = "local-channel-test-token-0123456789abcdef";
+const WRONG_TOKEN = "definitely-not-the-token";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+interface SpyLogger {
+  info: MockFn;
+  warn: MockFn;
+  error: MockFn;
+  debug: MockFn;
+}
+
+function makeSpyLogger(): SpyLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+/** Spy logger satisfying the services Logger interface. */
+function asLogger(spy: SpyLogger): Logger {
+  return spy as unknown as Logger;
+}
+
+function buildServices(
+  overrides: Partial<ChannelServices> = {},
+): ChannelServices {
+  return {
+    transcribeFile: vi.fn(async () => ({
+      success: true,
+      text: "转录结果",
+      raw_text: "raw",
+      segments: [],
+    })),
+    checkEngineStatus: vi.fn(async () => ({ models_downloaded: true })),
+    ...overrides,
+  };
+}
+
+describe("localChannel (ticket #265)", () => {
+  let tmpDir: string;
+  let endpointPath: string;
+  let server: LocalChannelServer | null;
+  let spyLogger: SpyLogger;
+  let endpointCounter = 0;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-265-"));
+    server = null;
+    spyLogger = makeSpyLogger();
+    endpointCounter += 1;
+    // [20260912_Fix_265_ReviewHardening] Platform-aware endpoint: Node on
+    // Windows only accepts \\.\pipe\ paths for IPC listening — a DOS tmp
+    // path fails uv_pipe_bind with EACCES. Pipes are flat-namespaced, so
+    // pid+counter keeps vitest parallel workers unique.
+    endpointPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\murmur-test-${process.pid}-${endpointCounter}`
+        : path.join(tmpDir, `chan-${endpointCounter}.sock`);
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function startTestServer(
+    services: ChannelServices,
+    options: Partial<Parameters<typeof createChannelServer>[0]> = {},
+  ): Promise<LocalChannelServer> {
+    const instance = createChannelServer({
+      endpointPath,
+      token: TOKEN,
+      services,
+      logger: asLogger(spyLogger),
+      ...options,
+    });
+    server = instance;
+    await instance.listen();
+    return instance;
+  }
+
+  function expectNoTokenInLogs(): void {
+    for (const spy of [
+      spyLogger.info,
+      spyLogger.warn,
+      spyLogger.error,
+      spyLogger.debug,
+    ]) {
+      for (const call of spy.mock.calls) {
+        for (const arg of call) {
+          expect(String(arg)).not.toContain(TOKEN);
+          expect(String(arg)).not.toContain(WRONG_TOKEN);
+        }
+      }
+    }
+  }
+
+  describe("handshake", () => {
+    it("accepts a correct token and answers a status request with a result frame", async () => {
+      const services = buildServices();
+      await startTestServer(services);
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      const result = await client.request("status", {});
+      expect(result).toEqual({ models_downloaded: true });
+      expect(services.checkEngineStatus).toHaveBeenCalledTimes(1);
+      client.close();
+      expectNoTokenInLogs();
+    });
+
+    it("rejects a wrong token with token-rejected and destroys the connection", async () => {
+      await startTestServer(buildServices());
+      const client = createChannelClient({ endpointPath, token: WRONG_TOKEN });
+      await expect(client.connect()).rejects.toThrow("token-rejected");
+      // The server must have torn the socket down (client observes close).
+      await expect(client.request("status", {})).rejects.toThrow(
+        /not-connected|closed/,
+      );
+      expectNoTokenInLogs();
+    });
+
+    it("rejects a connection whose first frame is a request instead of a token", async () => {
+      await startTestServer(buildServices());
+      const raw = await rawConnect(endpointPath);
+      const { frames, closed } = readFrames(raw);
+      raw.write(`${JSON.stringify({ id: "1", method: "status" })}\n`);
+      await closed;
+      expect(frames).toEqual([{ error: "token-rejected" }]);
+      raw.destroy();
+    });
+
+    it("RED LINE: emits zero frames before the token frame is validated", async () => {
+      await startTestServer(buildServices());
+      // Connect and stay silent: a server that "speaks first" would leak
+      // business data to any local process (named-pipe PoC P2).
+      const silent = await rawConnect(endpointPath);
+      const silentFrames = readFrames(silent);
+      await sleep(150);
+      expect(silentFrames.frames).toEqual([]);
+      // A wrong token yields EXACTLY one frame — the rejection — then close.
+      const wrong = await rawConnect(endpointPath);
+      const wrongFrames = readFrames(wrong);
+      wrong.write(`${JSON.stringify({ token: WRONG_TOKEN })}\n`);
+      await wrongFrames.closed;
+      expect(wrongFrames.frames).toEqual([{ error: "token-rejected" }]);
+      silent.destroy();
+      wrong.destroy();
+      expectNoTokenInLogs();
+    });
+
+    it("destroys the connection when no token frame arrives before the handshake timeout", async () => {
+      await startTestServer(buildServices(), { handshakeTimeoutMs: 80 });
+      const raw = await rawConnect(endpointPath);
+      const { frames, closed } = readFrames(raw);
+      const timedOut = await withTimeout(closed, 2000);
+      expect(timedOut).toBe(true);
+      expect(frames).toEqual([]);
+      raw.destroy();
+    });
+  });
+
+  describe("endpoints", () => {
+    it("transcribe_file: happy path forwards params to the service and returns its result", async () => {
+      // Explicit params so mock.calls exposes a typed tuple for the
+      // forwarding assertions below.
+      const transcribeFile = vi.fn(
+        async (
+          _audioPath: string,
+          _options: Record<string, unknown>,
+          _onProgress?: (progress: unknown) => void,
+        ) => ({ success: true, text: "ok", id: 7 }),
+      );
+      await startTestServer(buildServices({ transcribeFile }));
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      const audioPath = path.join(os.tmpdir(), "murmur-265-nonexistent.wav");
+      const options = { hotword: "" };
+      const result = (await client.request("transcribe_file", {
+        audioPath,
+        options,
+      })) as Record<string, unknown>;
+      expect(result).toEqual({ success: true, text: "ok", id: 7 });
+      expect(transcribeFile).toHaveBeenCalledTimes(1);
+      const call = transcribeFile.mock.calls[0]!;
+      expect(call[0]).toBe(audioPath);
+      expect(call[1]).toEqual(options);
+      client.close();
+    });
+
+    it("transcribe_file: answers an error frame for an invalid path and never calls the service", async () => {
+      const transcribeFile = vi.fn(async () => ({ success: true }));
+      await startTestServer(buildServices({ transcribeFile }));
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      await expect(
+        client.request("transcribe_file", { audioPath: "/definitely/not.txt" }),
+      ).rejects.toThrow("不支持的音频格式");
+      expect(transcribeFile).not.toHaveBeenCalled();
+      client.close();
+    });
+
+    it("transcribe_file: missing audioPath answers audioPath-required without calling the service", async () => {
+      const transcribeFile = vi.fn(async () => ({ success: true }));
+      await startTestServer(buildServices({ transcribeFile }));
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      await expect(client.request("transcribe_file", {})).rejects.toThrow(
+        "audioPath-required",
+      );
+      expect(transcribeFile).not.toHaveBeenCalled();
+      client.close();
+    });
+
+    it("transcribe_file: streams progress frames before the result frame", async () => {
+      const transcribeFile = vi.fn(
+        async (
+          _audioPath: string,
+          _options: Record<string, unknown>,
+          onProgress?: (progress: unknown) => void,
+        ) => {
+          onProgress?.({ percent: 40 });
+          onProgress?.({ percent: 90 });
+          return { success: true, text: "done" };
+        },
+      );
+      await startTestServer(buildServices({ transcribeFile }));
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      const sequence: string[] = [];
+      const payloads: unknown[] = [];
+      const requestPromise = client.request(
+        "transcribe_file",
+        { audioPath: path.join(os.tmpdir(), "murmur-265-nonexistent.wav") },
+        (progress) => {
+          sequence.push("progress");
+          payloads.push(progress);
+        },
+      );
+      void requestPromise.then(
+        () => sequence.push("result"),
+        () => sequence.push("error"),
+      );
+      const result = await requestPromise;
+      expect(result).toEqual({ success: true, text: "done" });
+      expect(sequence).toEqual(["progress", "progress", "result"]);
+      expect(payloads).toEqual([{ percent: 40 }, { percent: 90 }]);
+      client.close();
+    });
+
+    it("answers unknown-method for an unregistered method", async () => {
+      await startTestServer(buildServices());
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      await expect(client.request("frobnicate", {})).rejects.toThrow(
+        "unknown-method",
+      );
+      client.close();
+    });
+
+    it("keeps serving new clients after one disconnects mid-transcription", async () => {
+      let releaseTranscription: (() => void) | null = null;
+      const gate = new Promise<void>((resolve) => {
+        releaseTranscription = resolve;
+      });
+      const transcribeFile = vi.fn(async () => {
+        await gate;
+        return { success: true, text: "late" };
+      });
+      await startTestServer(buildServices({ transcribeFile }));
+      // Client 1 issues a long task, then vanishes before the result.
+      const gone = createChannelClient({ endpointPath, token: TOKEN });
+      await gone.connect();
+      const resultPromise = gone.request("transcribe_file", {
+        audioPath: path.join(os.tmpdir(), "murmur-265-nonexistent.wav"),
+      });
+      resultPromise.catch(() => {
+        // expected: the client leaves before the result frame
+      });
+      gone.close();
+      releaseTranscription!();
+      await expect(resultPromise).rejects.toThrow();
+      // The server writes the orphaned result into the void, then serves
+      // client 2 normally (writeFrame guards on the destroyed socket).
+      const stay = createChannelClient({ endpointPath, token: TOKEN });
+      await stay.connect();
+      await expect(stay.request("status", {})).resolves.toEqual({
+        models_downloaded: true,
+      });
+      stay.close();
+    });
+  });
+
+  describe("session lifecycle", () => {
+    it("closes an idle session after the injectable TTL", async () => {
+      await startTestServer(buildServices(), { sessionIdleTtlMs: 120 });
+      const raw = await rawConnect(endpointPath);
+      const { frames, closed } = readFrames(raw);
+      raw.write(`${JSON.stringify({ token: TOKEN })}\n`);
+      await waitFor(() => frames.length > 0);
+      expect(frames).toEqual([{ accepted: true }]);
+      const timedOut = await withTimeout(closed, 2000);
+      expect(timedOut).toBe(true);
+      raw.destroy();
+    });
+
+    it("rejects the connection beyond the injectable cap (9th of 8)", async () => {
+      await startTestServer(buildServices(), { maxConnections: 8 });
+      const holders: net.Socket[] = [];
+      try {
+        for (let i = 0; i < 8; i += 1) {
+          const holder = await rawConnect(endpointPath);
+          holders.push(holder);
+          // Let the server process the connection event before the next.
+          await sleep(15);
+        }
+        const ninth = await rawConnect(endpointPath);
+        const { frames, closed } = readFrames(ninth);
+        const rejected = await withTimeout(closed, 2000);
+        expect(rejected).toBe(true);
+        expect(frames).toEqual([{ error: "connection-limit-rejected" }]);
+        ninth.destroy();
+      } finally {
+        for (const holder of holders) holder.destroy();
+      }
+    });
+
+    it("stop() tears down sessions and releases the endpoint for a fresh bind", async () => {
+      const first = createChannelServer({
+        endpointPath,
+        token: TOKEN,
+        services: buildServices(),
+        logger: asLogger(spyLogger),
+      });
+      server = first;
+      await first.listen();
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      await first.stop();
+      // The client observes the server going away.
+      await expect(client.request("status", {})).rejects.toThrow();
+      if (process.platform !== "win32") {
+        expect(fs.existsSync(endpointPath)).toBe(false);
+      }
+      // A fresh bind on the same endpoint succeeds after stop().
+      const second = createChannelServer({
+        endpointPath,
+        token: TOKEN,
+        services: buildServices(),
+        logger: asLogger(spyLogger),
+      });
+      await second.listen();
+      const client2 = createChannelClient({ endpointPath, token: TOKEN });
+      await client2.connect();
+      await expect(client2.request("status", {})).resolves.toEqual({
+        models_downloaded: true,
+      });
+      client2.close();
+      await second.stop();
+      server = null;
+    });
+  });
+
+  // [20260912_Fix_265_ReviewHardening] Review-driven hardening locks.
+  describe("hardening (review #265)", () => {
+    it("destroys the connection when a frame exceeds MAX_FRAME_BYTES", async () => {
+      await startTestServer(buildServices());
+      const raw = await rawConnect(endpointPath);
+      const { closed } = readFrames(raw);
+      // Handshake first (small frame), then dribble an oversized no-newline
+      // payload — the server must destroy instead of buffering forever.
+      raw.write(`${JSON.stringify({ token: TOKEN })}\n`);
+      let payload = "";
+      while (payload.length <= 1024 * 1024 + 1) {
+        payload += "x".repeat(100000);
+      }
+      raw.write(
+        `${JSON.stringify({ id: "1", method: "status", pad: payload })}\n`,
+      );
+      await closed;
+      raw.destroy();
+    });
+
+    it("keeps a long in-flight request alive past the idle TTL", async () => {
+      // TTL 200ms; the transcription service settles after ~600ms. The
+      // pre-fix behavior destroyed the session mid-task (idle fires on
+      // inbound-frame silence), failing the request.
+      let resolveTranscribe: (value: unknown) => void = () => {};
+      const services = buildServices({
+        transcribeFile: vi.fn(
+          () =>
+            new Promise((resolve) => {
+              resolveTranscribe = resolve;
+            }),
+        ),
+      });
+      await startTestServer(services, { sessionIdleTtlMs: 200 });
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      const audioPath = path.join(os.tmpdir(), "murmur-265-nonexistent.wav");
+      const requestPromise = client.request("transcribe_file", {
+        audioPath,
+      });
+      // Let the idle TTL elapse while the request is still in flight.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      resolveTranscribe({ success: true, text: "迟到但完整" });
+      const result = (await requestPromise) as Record<string, unknown>;
+      expect(result.success).toBe(true);
+      client.close();
+    });
+
+    it("does not idle-destroy an authenticated idle session before the TTL", async () => {
+      const services = buildServices();
+      await startTestServer(buildServices(), { sessionIdleTtlMs: 200 });
+      void services;
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Well before the 200ms TTL the session must still serve requests.
+      const result = (await client.request("status", {})) as Record<
+        string,
+        unknown
+      >;
+      expect(result.models_downloaded).toBe(true);
+      client.close();
+    });
+  });
+
+  describe("wiring (startLocalChannel)", () => {
+    it("writes the token file, serves the status endpoint with the real service binding", async () => {
+      const serviceDeps = {
+        funasrManager: {
+          transcribeFile: vi.fn(async () => ({ success: true })),
+          checkModelFiles: vi.fn(async () => ({
+            models_downloaded: true,
+            extra: "field",
+          })),
+        },
+        databaseManager: {
+          saveTranscription: vi.fn(),
+          getSetting: vi.fn(() => null),
+        },
+        logger: asLogger(spyLogger),
+      };
+      const handle = await startLocalChannel({
+        userDataPath: tmpDir,
+        serviceDeps,
+        logger: asLogger(spyLogger),
+      });
+      server = {
+        endpointPath: handle.endpointPath,
+        listen: async () => undefined,
+        stop: () => handle.stop(),
+      };
+      expect(serviceDeps.funasrManager.checkModelFiles).not.toHaveBeenCalled();
+      const token = fs.readFileSync(handle.tokenPath, "utf8");
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+      const client = createChannelClient({
+        endpointPath: handle.endpointPath,
+        token,
+      });
+      await client.connect();
+      const result = (await client.request("status", {})) as Record<
+        string,
+        unknown
+      >;
+      expect(result.models_downloaded).toBe(true);
+      expect(serviceDeps.funasrManager.checkModelFiles).toHaveBeenCalledTimes(
+        1,
+      );
+      client.close();
+      expectNoTokenInLogs();
+    });
+
+    // [20260912_Fix_265_ReviewHardening] Windows discovery contract (PoC):
+    // the per-launch random pipe name must be persisted for #267 clients.
+    it("persists the endpoint file on start and removes it on stop", async () => {
+      const serviceDeps = {
+        funasrManager: {
+          transcribeFile: vi.fn(async () => ({ success: true })),
+          checkModelFiles: vi.fn(async () => ({ models_downloaded: true })),
+        },
+        databaseManager: {
+          saveTranscription: vi.fn(),
+          getSetting: vi.fn(() => null),
+        },
+        logger: asLogger(spyLogger),
+      };
+      const handle = await startLocalChannel({
+        userDataPath: tmpDir,
+        serviceDeps,
+        logger: asLogger(spyLogger),
+      });
+      server = {
+        endpointPath: handle.endpointPath,
+        listen: async () => undefined,
+        stop: () => handle.stop(),
+      };
+      const endpointFilePath = path.join(tmpDir, "murmur-channel-endpoint");
+      expect(fs.readFileSync(endpointFilePath, "utf8")).toBe(
+        `${handle.endpointPath}\n`,
+      );
+      await handle.stop();
+      expect(fs.existsSync(endpointFilePath)).toBe(false);
+    });
+
+    it("regenerates the token file on every launch", async () => {
+      const serviceDeps = {
+        funasrManager: {
+          transcribeFile: vi.fn(async () => ({ success: true })),
+          checkModelFiles: vi.fn(async () => ({ models_downloaded: true })),
+        },
+        databaseManager: {
+          saveTranscription: vi.fn(),
+          getSetting: vi.fn(() => null),
+        },
+        logger: asLogger(spyLogger),
+      };
+      const first = await startLocalChannel({
+        userDataPath: tmpDir,
+        serviceDeps,
+        logger: asLogger(spyLogger),
+      });
+      const firstToken = fs.readFileSync(first.tokenPath, "utf8");
+      await first.stop();
+      const second = await startLocalChannel({
+        userDataPath: tmpDir,
+        serviceDeps,
+        logger: asLogger(spyLogger),
+      });
+      server = {
+        endpointPath: second.endpointPath,
+        listen: async () => undefined,
+        stop: () => second.stop(),
+      };
+      const secondToken = fs.readFileSync(second.tokenPath, "utf8");
+      expect(secondToken).toMatch(/^[0-9a-f]{64}$/);
+      expect(secondToken).not.toBe(firstToken);
+      await second.stop();
+      server = null;
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "writes the token file with owner-only permissions (0600)",
+      async () => {
+        const serviceDeps = {
+          funasrManager: {
+            transcribeFile: vi.fn(async () => ({ success: true })),
+            checkModelFiles: vi.fn(async () => ({ models_downloaded: true })),
+          },
+          databaseManager: {
+            saveTranscription: vi.fn(),
+            getSetting: vi.fn(() => null),
+          },
+          logger: asLogger(spyLogger),
+        };
+        const handle = await startLocalChannel({
+          userDataPath: tmpDir,
+          serviceDeps,
+          logger: asLogger(spyLogger),
+        });
+        server = {
+          endpointPath: handle.endpointPath,
+          listen: async () => undefined,
+          stop: () => handle.stop(),
+        };
+        const mode = fs.statSync(handle.tokenPath).mode & 0o777;
+        expect(mode).toBe(0o600);
+        await handle.stop();
+        server = null;
+      },
+    );
+  });
+
+  describe("framing helpers", () => {
+    it("createFrameSplitter buffers partial frames and emits complete ones", () => {
+      const split = createFrameSplitter();
+      expect(split('{"a":')).toEqual([]);
+      expect(split('1}\n{"b":2}\n')).toEqual(['{"a":1}', '{"b":2}']);
+      expect(split("tail-without-newline")).toEqual([]);
+    });
+  });
+});
+
+// --- raw-socket test helpers (the client helper covers the happy paths;
+// these expose exact wire frames for the red-line/auth assertions). ---
+
+function rawConnect(target: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect(target);
+    sock.once("connect", () => resolve(sock));
+    sock.once("error", reject);
+  });
+}
+
+function readFrames(sock: net.Socket): {
+  frames: unknown[];
+  closed: Promise<void>;
+} {
+  const frames: unknown[] = [];
+  const split = createFrameSplitter();
+  sock.on("data", (chunk: Buffer) => {
+    for (const raw of split(chunk.toString("utf8"))) {
+      if (!raw.trim()) continue;
+      frames.push(JSON.parse(raw) as unknown);
+    }
+  });
+  const closed = new Promise<void>((resolve) => {
+    sock.once("close", () => resolve());
+  });
+  return { frames, closed };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Resolve true when the promise settles before timeoutMs, false otherwise. */
+async function withTimeout(
+  promise: Promise<void>,
+  timeoutMs: number,
+): Promise<boolean> {
+  const winner = await Promise.race([
+    promise.then(
+      () => "settled" as const,
+      () => "settled" as const,
+    ),
+    sleep(timeoutMs).then(() => "timeout" as const),
+  ]);
+  return winner === "settled";
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error("waitFor: condition not met before timeout");
+    }
+    await sleep(5);
+  }
+}

--- a/tests/unit/localChannelHeal.test.ts
+++ b/tests/unit/localChannelHeal.test.ts
@@ -1,0 +1,136 @@
+// [20260912_Feat_265_LocalChannel] Stale-socket self-heal tests for the
+// local IPC channel (ticket #265 point 4, spec #258). Unix-only behavior —
+// every case is gated with it.skipIf(process.platform === "win32") per the
+// repo convention. Covered: a dead endpoint (leftover socket/regular file
+// from a crashed instance) is probe-connected, found dead, unlinked and
+// rebound; a LIVE instance answering the probe makes the second bind
+// attempt log and refuse (the first instance keeps serving).
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createChannelClient,
+  createChannelServer,
+  type ChannelServices,
+  type LocalChannelServer,
+} from "../../src/helpers/localChannel";
+import type { Logger } from "../../src/helpers/services/transcriptionService";
+
+const TOKEN = "heal-test-token-0123456789abcdefghijklmnop";
+
+function buildServices(): ChannelServices {
+  return {
+    transcribeFile: vi.fn(async () => ({ success: true, text: "x" })),
+    checkEngineStatus: vi.fn(async () => ({ models_downloaded: true })),
+  };
+}
+
+function asLogger(spy: {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+}): Logger {
+  return spy as unknown as Logger;
+}
+
+describe("local channel stale-socket self-heal (unix only)", () => {
+  let tmpDir: string;
+  let endpointPath: string;
+  const servers: LocalChannelServer[] = [];
+  let spyLogger: ReturnType<typeof makeSpy>;
+
+  function makeSpy() {
+    return {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-265-heal-"));
+    endpointPath = path.join(tmpDir, "heal.sock");
+    spyLogger = makeSpy();
+  });
+
+  afterEach(async () => {
+    for (const instance of servers) {
+      await instance.stop();
+    }
+    servers.length = 0;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeServer(logger = asLogger(spyLogger)): LocalChannelServer {
+    const instance = createChannelServer({
+      endpointPath,
+      token: TOKEN,
+      services: buildServices(),
+      logger,
+    });
+    servers.push(instance);
+    return instance;
+  }
+
+  it.skipIf(process.platform === "win32")(
+    "unlinks a dead endpoint file and binds fresh",
+    async () => {
+      // A leftover file at the socket path (crash leftovers): the probe
+      // connect must fail, the file gets unlinked, and the bind succeeds.
+      fs.writeFileSync(endpointPath, "stale leftover");
+      expect(fs.existsSync(endpointPath)).toBe(true);
+      const instance = makeServer();
+      await instance.listen();
+      expect(spyLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("残留"),
+        expect.objectContaining({ endpointPath }),
+      );
+      // The healed endpoint actually serves a client roundtrip.
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      await expect(client.request("status", {})).resolves.toEqual({
+        models_downloaded: true,
+      });
+      client.close();
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "refuses to bind and logs when a live instance owns the endpoint",
+    async () => {
+      const first = makeServer();
+      await first.listen();
+      const secondSpy = makeSpy();
+      const second = makeServer(asLogger(secondSpy));
+      await expect(second.listen()).rejects.toThrow(
+        "local-channel-endpoint-in-use",
+      );
+      expect(secondSpy.warn).toHaveBeenCalledWith(
+        expect.stringContaining("占用"),
+        expect.objectContaining({ endpointPath }),
+      );
+      // The original instance is untouched and keeps serving.
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      await expect(client.request("status", {})).resolves.toEqual({
+        models_downloaded: true,
+      });
+      client.close();
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "removes the socket file on stop()",
+    async () => {
+      const instance = makeServer();
+      await instance.listen();
+      expect(fs.existsSync(endpointPath)).toBe(true);
+      await instance.stop();
+      expect(fs.existsSync(endpointPath)).toBe(false);
+      servers.pop();
+    },
+  );
+});


### PR DESCRIPTION
## What

Electron 主进程本地认证通道（CLI/MCP 统一桥接面，Phase 1 核心）：

- **传输**：unix domain socket（`<userData>/murmur-channel.sock`，0600）/ Windows named pipe（`\\\\.\\pipe\\murmur-<128bit>`），按 PoC 决策实现补偿控制
- **红线（PoC）**：token 校验前服务端**零业务帧**——单一 `writeFrame` 播点 + auth 门结构性强保证，测试以线上字节帧断言（静默连接零帧/错 token 恰一帧拒绝）
- **协议**：换行 JSON 帧、请求 id 关联、进度帧先于结果帧、StringDecoder 处理中文跨段
- **端点**：`transcribe_file`（入口 validateAudioPath 先行，服务内二次校验纵深）/`status`（只读），全部骑行 #261 服务函数
- **自愈（unix）**：死 socket 探测后 unlink 重绑；活实例拒绑；win32 门控

## 安全评审（REQUEST_CHANGES → 全项修复）

1 MAJOR + 4 MINOR：
- **MAJOR（已修）**：测试端点在 Windows 上是非法 DOS 路径（uv_pipe_bind EACCES）——按平台构造管道路径
- 帧上限 `MAX_FRAME_BYTES` 1MiB 双侧断连（win32 预认证内存膨胀面闭合，PoC 残余从沉默改为代码强制）
- 空闲 TTL 在途抑制 + 重臂时序修正：长转写（>10min 无入站帧）不再被中途断连
- 端点文件持久化（win32 发现契约，P1 禁枚举的正面替代）
- token 改为 listen 成功后写入：启动失败零凭据残留（fail-closed）
NIT 留档：chmod 窗口、二连 connect 契约疣。

## main 接线

startApp 尾部守护启动（失败不阻塞引导）；will-quit **最先**停止通道（同步销毁会话，无死锁面）；双启动由 #260 单实例锁兜底。

## 验证

`pnpm ci:check` 11/11；通道套件 25 用例（含红线/超时/上限/进度序/TTL 在途存活/帧超限/端点文件/自愈）；旁证套件无损伤

Closes #265