### PR TITLE
feat: murmur mcp — stdio MCP server 骨架 + transcribe_file/get_murmur_status (Spec #258 #269, closes #269)

### DIFF
--- a/cli/lib/channelBridge.mjs
+++ b/cli/lib/channelBridge.mjs
@@ -253,12 +253,17 @@ export async function connectChannelBridge(options = {}) {
     requestStatus() {
       return client.request(METHOD_STATUS, {});
     },
-    requestTranscribe(audioPath, params = {}, onProgress) {
-      return client.request(
-        METHOD_TRANSCRIBE_FILE,
-        { audioPath, options: params },
-        onProgress,
-      );
+    // [20260912_Feat_269_McpServer] Optional `persist` flag (ticket #269):
+    // a top-level transcribe_file param that tells the app NOT to save the
+    // transcription to history (persist=false — the MCP tool's save=false
+    // default). Undefined omits the field entirely, so every pre-#269 wire
+    // frame stays byte-identical.
+    requestTranscribe(audioPath, params = {}, onProgress, persist) {
+      const frameParams =
+        persist === undefined
+          ? { audioPath, options: params }
+          : { audioPath, options: params, persist };
+      return client.request(METHOD_TRANSCRIBE_FILE, frameParams, onProgress);
     },
     // [20260912_Feat_268_BridgePolishHistory] Ticket #268 methods. The
     // polish request params carry ONLY the task (text + optional mode):

--- a/cli/lib/cliRunner.mjs
+++ b/cli/lib/cliRunner.mjs
@@ -16,6 +16,7 @@
 //   murmur status | transcribe <file> [--diarize] [--save]
 //   murmur polish <text> [--mode <mode>]          (ticket #268)
 //   murmur history delete <id> [--yes]            (ticket #268)
+//   murmur mcp                                    (ticket #269)
 import {
   resolveConfigPath,
   resolveDatabasePath,
@@ -74,6 +75,11 @@ Usage:
                                        app (ticket #268; the GUI reflects the
                                        deletion on its next read). Non-interactive
                                        shells must pass --yes.
+  murmur mcp                           Start the MCP server over stdio
+                                       (ticket #269). stdout carries ONLY MCP
+                                       protocol frames; diagnostics go to
+                                       stderr. The process exits when the MCP
+                                       client disconnects (stdin closes).
 
 Global options:
   --json                               Structured JSON output on stdout
@@ -644,6 +650,67 @@ async function runHistoryDelete(argv, ctx) {
 }
 // [20260912_Feat_268_BridgePolishHistory] END
 
+// [20260912_Feat_269_McpServer] --- murmur mcp (ticket #269) ---
+// Starts the MCP stdio server. Like channelBridge.mjs loads the bundled TS
+// client kernel, this loads the bundled MCP server module
+// (cli/dist/mcpServer.mjs, built from src/helpers/mcp/mcpServer.ts by
+// `pnpm run build:mcp`) and hands it a `connect` factory built on
+// connectChannelBridge — so endpoint/token discovery and the exit-4-style
+// classification stay in ONE place (channelBridge.mjs) and the MCP module
+// stays pure tool/transport logic. A missing bundle is a build problem
+// (exit 1), mirroring the channelClient.mjs handling.
+
+// esbuild bundle of src/helpers/mcp/mcpServer.ts (see build:mcp).
+const MCP_SERVER_BUNDLE_URL = new URL("../dist/mcpServer.mjs", import.meta.url);
+
+async function loadMcpServerModule() {
+  try {
+    // .href is already a valid file:// URL (built from import.meta.url).
+    return await import(MCP_SERVER_BUNDLE_URL.href);
+  } catch {
+    throw new Error(
+      "MCP 服务器模块缺失：未找到 cli/dist/mcpServer.mjs，" +
+        "请运行 pnpm run build:mcp 重新构建后再试",
+    );
+  }
+}
+
+async function runMcp(argv, ctx) {
+  const parsed = parseArgs(argv, new Set());
+  if (parsed.unknown) return usageError(`mcp: unknown flag ${parsed.unknown}`);
+  if (parsed.positionals.length > 0)
+    return usageError("mcp: unexpected extra arguments");
+
+  let mcpModule;
+  try {
+    mcpModule = await loadMcpServerModule();
+  } catch (error) {
+    return runtimeError("mcp", error.message);
+  }
+
+  // Resolves when the MCP client disconnects (stdin EOF). runMcpStdio never
+  // writes to stdout itself — stdout carries protocol frames only; startup
+  // diagnostics flow through the stderr sink below.
+  const exitCode = await mcpModule.runMcpStdio({
+    connect: () =>
+      connectChannelBridge({
+        env: ctx.env,
+        platform: ctx.platform,
+        homedir: ctx.homedir,
+      }),
+    version: ctx.version || undefined,
+    log: (chunk) => {
+      if (ctx.stderrWrite) {
+        ctx.stderrWrite(chunk);
+      } else {
+        ctx.stderrChunks.push(chunk);
+      }
+    },
+  });
+  return { code: exitCode, stdout: "", stderr: ctx.stderrChunks.join("") };
+}
+// [20260912_Feat_269_McpServer] END
+
 /**
  * Run one CLI invocation. argv excludes the node/electron and script paths.
  *
@@ -742,6 +809,15 @@ export function runCli(argv, options = {}) {
     );
   }
   // [20260912_Feat_268_BridgePolishHistory] END
+  // [20260912_Feat_269_McpServer] `murmur mcp` (ticket #269) is an async
+  // long-running command: it returns a Promise resolving when the MCP
+  // client disconnects (stdin EOF), with the same { code, stdout, stderr }
+  // result shape as the other bridge commands.
+  if (command === "mcp") {
+    return /** @type {{ code: number, stdout: string, stderr: string }} */ (
+      runMcp(dispatch.slice(1), ctx)
+    );
+  }
   if (command !== "config" && command !== "history") {
     return usageError(`unknown command: ${command}`);
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dev:renderer": "cd src && vite",
     "build:preload": "esbuild preload.ts --bundle --platform=node --format=cjs --external:electron --outfile=dist-preload/preload.js",
     "build:cli": "esbuild src/helpers/localChannel/client.ts --bundle --platform=node --format=esm --outfile=cli/dist/channelClient.mjs",
-    "build": "npm run build:main && npm run build:preload && npm run build:cli && cd src && vite build && cd .. && electron-builder",
+    "build:mcp": "esbuild src/helpers/mcp/mcpServer.ts --bundle --platform=node --format=esm --outfile=cli/dist/mcpServer.mjs",
+    "build": "npm run build:main && npm run build:preload && npm run build:cli && npm run build:mcp && cd src && vite build && cd .. && electron-builder",
     "build:renderer": "cd src && vite build",
     "prepare:python": "pip install funasr modelscope torch torchaudio librosa numpy && python download_models.py",
     "prepare:python:uv": "uv sync && uv run python download_models.py",
@@ -27,14 +28,14 @@
     "test:python:info": "node scripts/test-embedded-python.js --info",
     "test:python:unit": "node scripts/run-python-tests.js",
     "test:asr": "node scripts/asr-regression.js",
-    "prebuild:mac": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:renderer",
+    "prebuild:mac": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:mcp && npm run build:renderer",
     "build:mac": "electron-builder --mac",
-    "prebuild:win": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:renderer",
+    "prebuild:win": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:mcp && npm run build:renderer",
     "build:win": "electron-builder --win",
-    "prebuild:linux": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:renderer",
+    "prebuild:linux": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:mcp && npm run build:renderer",
     "build:linux": "electron-builder --linux",
-    "pack": "npm run build:main && npm run build:preload && npm run build:cli && npm run build:renderer && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir",
-    "dist": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:renderer && electron-builder",
+    "pack": "npm run build:main && npm run build:preload && npm run build:cli && npm run build:mcp && npm run build:renderer && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir",
+    "dist": "npm run prepare:python:embedded && npm run build:main && npm run build:preload && npm run build:cli && npm run build:mcp && npm run build:renderer && electron-builder",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
@@ -116,6 +117,7 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -128,7 +130,8 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^17.0.8",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^4.6.2"
   },
   "build": {
     "appId": "com.murmur.app",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.6.2)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.3.1(@types/react@19.2.14)(react@19.2.6)
@@ -70,6 +73,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.6.0
+      zod:
+        specifier: ^4.6.2
+        version: 4.6.2
     devDependencies:
       '@electron/notarize':
         specifier: ^3.0.1
@@ -944,6 +950,12 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -987,6 +999,16 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -1521,6 +1543,10 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1534,6 +1560,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -1689,6 +1723,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -1721,6 +1759,10 @@ packages:
   builder-util@26.15.3:
     resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
     engines: {node: '>=14.0.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   bytestreamjs@2.0.1:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
@@ -1839,11 +1881,35 @@ packages:
     engines: {node: ^14.13.0 || >=16.0.0}
     hasBin: true
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -1934,6 +2000,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1986,6 +2056,9 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -2019,6 +2092,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2103,6 +2180,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -2178,8 +2258,20 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.2:
+    resolution: {integrity: sha512-YolzkJNxsTL3tCJMWFxpxtG2sCjbZ4LQUBUrkdaJK0ub0p6lmJt+2+1SwhKjLc652lpH9L/79Ptez972H9tphw==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2187,6 +2279,16 @@ packages:
 
   exponential-backoff@3.1.2:
     resolution: {integrity: sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==}
+
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -2224,6 +2326,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2243,8 +2349,16 @@ packages:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2406,6 +2520,10 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -2425,6 +2543,14 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -2450,6 +2576,14 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2484,6 +2618,14 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2555,6 +2697,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2642,6 +2787,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.12:
+    resolution: {integrity: sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -2677,6 +2825,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2865,13 +3016,29 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -2942,6 +3109,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -3021,6 +3192,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3070,6 +3245,10 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3084,6 +3263,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3101,6 +3283,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
 
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
@@ -3174,6 +3360,10 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3188,9 +3378,25 @@ packages:
     resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
     engines: {node: '>=16.0.0'}
 
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -3315,6 +3521,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -3332,6 +3542,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
@@ -3371,9 +3584,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -3389,6 +3610,9 @@ packages:
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3416,6 +3640,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -3497,6 +3725,14 @@ packages:
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -3644,6 +3880,10 @@ packages:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -3684,6 +3924,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -3742,6 +3986,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unzipper@0.12.5:
     resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
 
@@ -3770,6 +4018,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
@@ -4005,6 +4257,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.6.2:
+    resolution: {integrity: sha512-lh5RCAGFa1Cm2hjtNwLQhSs/AsqdWnTQaBER9fEwN/88pSh7KOtJavtBx/0VlkN/uFd61SwYmljLMDAsHlvzBQ==}
 
 snapshots:
 
@@ -4587,6 +4847,10 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.3.0
 
+  '@hono/node-server@2.1.1(hono@4.13.7)':
+    dependencies:
+      hono: 4.13.7
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -4631,6 +4895,28 @@ snapshots:
       fs-extra: 9.1.0
       lodash: 4.18.1
       tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.6.2)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.7)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.2
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.7
+      jose: 6.2.12
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 4.6.2
+      zod-to-json-schema: 3.25.2(zod@4.6.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5139,6 +5425,11 @@ snapshots:
 
   abbrev@4.0.0: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -5146,6 +5437,10 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -5353,6 +5648,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -5406,6 +5715,8 @@ snapshots:
       tiny-async-pool: 1.3.0
     transitivePeerDependencies:
       - supports-color
+
+  bytes@3.1.2: {}
 
   bytestreamjs@2.0.1: {}
 
@@ -5525,9 +5836,24 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.1: {}
+
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-dirname@0.1.0:
     optional: true
@@ -5615,6 +5941,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.0: {}
@@ -5676,6 +6004,8 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -5745,6 +6075,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -5960,6 +6292,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6068,11 +6402,60 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.2:
+    dependencies:
+      eventsource-parser: 3.1.1
 
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.2: {}
+
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.16.0
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extract-zip@2.0.1:
     dependencies:
@@ -6108,6 +6491,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -6132,7 +6526,11 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -6327,6 +6725,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.13.7: {}
+
   hosted-git-info@2.8.9: {}
 
   hosted-git-info@4.1.0:
@@ -6346,6 +6746,22 @@ snapshots:
       void-elements: 3.1.0
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -6371,6 +6787,14 @@ snapshots:
   i18next@26.2.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -6399,6 +6823,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  ip-address@10.7.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -6474,6 +6902,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -6558,6 +6988,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.12: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -6601,6 +7033,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6790,11 +7224,21 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -6843,6 +7287,10 @@ snapshots:
   nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -6939,6 +7387,10 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -6991,6 +7443,8 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -6998,6 +7452,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -7008,6 +7464,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.0: {}
 
   pkijs@3.4.0:
     dependencies:
@@ -7086,6 +7544,11 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -7099,7 +7562,28 @@ snapshots:
 
   pvutils@1.2.0: {}
 
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quick-lru@5.1.1: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -7278,6 +7762,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -7302,6 +7796,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   sanitize-filename@1.6.4:
     dependencies:
@@ -7328,10 +7824,35 @@ snapshots:
 
   semver@7.8.1: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-function-length@1.2.2:
     dependencies:
@@ -7356,6 +7877,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   setimmediate@1.0.5: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -7386,6 +7909,14 @@ snapshots:
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -7467,6 +7998,10 @@ snapshots:
   stackback@0.0.2: {}
 
   stat-mode@1.0.0: {}
+
+  statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -7638,6 +8173,8 @@ snapshots:
 
   tmp@0.2.7: {}
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.9
@@ -7672,6 +8209,12 @@ snapshots:
 
   type-fest@0.13.1:
     optional: true
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -7740,6 +8283,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unzipper@0.12.5:
     dependencies:
       bluebird: 3.7.2
@@ -7772,6 +8317,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   vite@6.4.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
@@ -7988,3 +8535,9 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.6.2):
+    dependencies:
+      zod: 4.6.2
+
+  zod@4.6.2: {}

--- a/src/helpers/localChannel/protocol.ts
+++ b/src/helpers/localChannel/protocol.ts
@@ -61,6 +61,14 @@ export const ERR_NOT_CONNECTED = "local-channel-not-connected";
 
 /** The two endpoints the channel exposes. */
 export const METHOD_TRANSCRIBE_FILE = "transcribe_file";
+// [20260912_Feat_269_McpServer] transcribe_file params shape (ticket #269):
+//   { audioPath: string, options?: Record<string, unknown>,
+//     persist?: boolean }
+// `persist` is the opt-out switch for the server-side DB write: when
+// explicitly false, the transcription runs but is NOT saved to history
+// (the MCP tool's save=false default); absent or true persists exactly as
+// before (GUI/CLI behavior unchanged). Omitting the field keeps the wire
+// frames of pre-#269 clients byte-identical.
 export const METHOD_STATUS = "status";
 // [20260912_Feat_268_BridgePolishHistory] Two more channel methods (ticket
 // #268): `polish` runs the GUI-identical polish orchestrator in-process

--- a/src/helpers/localChannel/server.ts
+++ b/src/helpers/localChannel/server.ts
@@ -59,10 +59,15 @@ import {
 
 /** Endpoint implementations the channel exposes (injected for tests). */
 export interface ChannelServices {
+  // [20260912_Feat_269_McpServer] 4th param `persist` (ticket #269): the
+  // transcribe_file request's opt-out switch for the server-side DB write
+  // (undefined/true = persist as before, false = transcribe without
+  // saving). Optional so pre-#269 service bags keep compiling.
   transcribeFile(
     audioPath: string,
     options: Record<string, unknown>,
     onProgress?: (progress: unknown) => void,
+    persist?: boolean,
   ): Promise<unknown>;
   checkEngineStatus(): Promise<unknown>;
   // [20260912_Feat_268_BridgePolishHistory] Ticket #268 endpoints. Optional
@@ -440,11 +445,29 @@ class LocalChannelServerImpl implements LocalChannelServer {
           return;
         }
         const options = isRecord(params.options) ? params.options : {};
+        // [20260912_Feat_269_McpServer] Persist passthrough (ticket #269):
+        // shape-enforce the optional flag (only boolean is meaningful — a
+        // garbage value is a protocol error, same mold as invalid-frame),
+        // then hand it to the service. undefined keeps the default-true
+        // persist behavior of every pre-#269 client.
+        let persist: boolean | undefined;
+        if (params.persist !== undefined) {
+          if (typeof params.persist !== "boolean") {
+            this.writeFrame(socket, { id, error: "invalid-frame" });
+            return;
+          }
+          persist = params.persist;
+        }
         await this.runRequest(socket, id, () =>
-          this.services.transcribeFile(audioPath, options, (progress) => {
-            // Long tasks stream progress frames before the result frame.
-            this.writeFrame(socket, { id, progress } satisfies ProgressFrame);
-          }),
+          this.services.transcribeFile(
+            audioPath,
+            options,
+            (progress) => {
+              // Long tasks stream progress frames before the result frame.
+              this.writeFrame(socket, { id, progress } satisfies ProgressFrame);
+            },
+            persist,
+          ),
         );
         return;
       }
@@ -657,8 +680,18 @@ export async function startLocalChannel(
   // [20260912_Fix_268_Review] Wording lives in historyService (single
   // source) so CLI and GUI errors stay identical for the same condition.
   const channelServices: ChannelServices = {
-    transcribeFile: (audioPath, options, onProgress) =>
-      transcribeFileService(transcribeDeps, audioPath, options, onProgress),
+    // [20260912_Feat_269_McpServer] Thread the request's persist flag
+    // through to the service (ticket #269): undefined keeps the default
+    // persist behavior for CLI/GUI traffic; false transcribes without
+    // saving (the MCP tool's save=false default).
+    transcribeFile: (audioPath, options, onProgress, persist) =>
+      transcribeFileService(
+        transcribeDeps,
+        audioPath,
+        options,
+        onProgress,
+        persist,
+      ),
     checkEngineStatus: () => checkEngineStatusService(statusDeps),
   };
   if (aiPolish) {

--- a/src/helpers/mcp/mcpServer.ts
+++ b/src/helpers/mcp/mcpServer.ts
@@ -1,0 +1,306 @@
+// [20260912_Feat_269_McpServer] MCP server skeleton for Murmur (ticket
+// #269): a stdio MCP server exposing two honestly-annotated tools that
+// proxy the running app's local channel (tickets #265/#267):
+//   - transcribe_file  → channel `transcribe_file` (save=false default →
+//     the request carries persist:false, so the tool can honestly advertise
+//     itself as non-persisting; save=true opts into history)
+//   - get_murmur_status → channel `status`
+//
+// DESIGN (ticket #269, "keep it simple"): this module is transport + tool
+// logic ONLY. Endpoint/token discovery and the exit-4-style connect
+// classification live in cli/lib/channelBridge.mjs (single source), whose
+// connector wraps the SAME bundled client kernel used by the CLI
+// (cli/dist/channelClient.mjs, built from src/helpers/localChannel/client.ts
+// by `pnpm run build:cli`). The connector is therefore injected via
+// `deps.connect` and `build:mcp` bundles ONLY this file into
+// cli/dist/mcpServer.mjs (esbuild pulls the SDK + zod in); in-process tests
+// inject a connector built on the real createChannelClient against a real
+// createChannelServer, so the client kernel is exercised for real.
+//
+// STDOUT RED LINE: stdout is the MCP protocol channel (StdioServerTransport
+// owns it). Every diagnostic this module emits goes through the `log` sink,
+// which defaults to process.stderr — console.log is never used, and the
+// protocol transports (stdio or in-memory) never receive log output.
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+/** Tool names exposed on the MCP surface (locked by mcpServer.test.ts). */
+export const MCP_TOOL_TRANSCRIBE_FILE = "transcribe_file";
+export const MCP_TOOL_GET_STATUS = "get_murmur_status";
+
+/** Server identity reported during MCP initialize. */
+export const MCP_SERVER_NAME = "murmur";
+const DEFAULT_SERVER_VERSION = "0.0.0";
+
+/** Fallback sink when the caller provides none: stderr ONLY (stdout is the
+ * protocol channel — see the STDOUT RED LINE note in the header). */
+function defaultStderrLog(chunk: string): void {
+  process.stderr.write(chunk);
+}
+
+/**
+ * The slice of the CLI channel bridge (cli/lib/channelBridge.mjs
+ * connectChannelBridge) the MCP tools need. Kept structural so the CLI
+ * wiring passes its existing bridge object straight in and tests can build
+ * the same shape on the real client kernel.
+ */
+export interface McpChannelBridge {
+  requestStatus(): Promise<unknown>;
+  requestTranscribe(
+    audioPath: string,
+    params?: Record<string, unknown>,
+    onProgress?: (progress: unknown) => void,
+    persist?: boolean,
+  ): Promise<unknown>;
+  close(): void;
+}
+
+/** Collaborators injected into the MCP server factory. */
+export interface MurmurMcpServerDeps {
+  /** Opens one channel bridge per tool call; may reject when the app is
+   * unreachable (the rejection message is user-facing and actionable). */
+  connect: () => Promise<McpChannelBridge>;
+  /** Version reported in the MCP initialize handshake. */
+  version?: string;
+  /** Diagnostic sink; defaults to process.stderr (never stdout). */
+  log?: (chunk: string) => void;
+}
+
+/** Narrow an unknown channel result to a plain object record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Single text content block (the only content shape this server emits). */
+function textBlock(text: string): { type: "text"; text: string } {
+  return { type: "text", text };
+}
+
+/**
+ * Build the Murmur MCP server. One McpServer instance serves one transport;
+ * call `runMcpStdio` for the CLI entry or `server.connect(...)` directly in
+ * tests (InMemoryTransport).
+ */
+export function createMurmurMcpServer(deps: MurmurMcpServerDeps): McpServer {
+  const log = deps.log ?? defaultStderrLog;
+  const server = new McpServer(
+    {
+      name: MCP_SERVER_NAME,
+      version: deps.version ?? DEFAULT_SERVER_VERSION,
+    },
+    // No extra capabilities: exactly the two tools below (tools capability
+    // is enabled implicitly by registerTool).
+  );
+
+  // --- transcribe_file ---------------------------------------------------
+  // Annotation honesty (ticket #269, verified against SDK 1.30 ToolAnnotations:
+  // title / readOnlyHint / destructiveHint / idempotentHint / openWorldHint):
+  //   - readOnlyHint FALSE: `save: true` writes a history row — the tool must
+  //     never claim read-only.
+  //   - destructiveHint FALSE: transcription only ADDS data; it never
+  //     deletes or overwrites anything.
+  //   - idempotentHint FALSE: a save=true call appends a new row on every
+  //     invocation, so repeats are not side-effect-free.
+  //   - openWorldHint FALSE: the tool talks only to the local Murmur app.
+  server.registerTool(
+    MCP_TOOL_TRANSCRIBE_FILE,
+    {
+      title: "Transcribe an audio file with Murmur",
+      description:
+        "Transcribe a local audio file through the running Murmur desktop " +
+        "app. By default the transcript is returned WITHOUT being written " +
+        "to Murmur's history; pass save:true to also store it in history.",
+      inputSchema: {
+        path: z.string().describe("Absolute path of the audio file"),
+        diarize: z
+          .boolean()
+          .optional()
+          .describe("Speaker diarization — NOT supported yet (honest refusal)"),
+        save: z
+          .boolean()
+          .optional()
+          .describe(
+            "Also save the transcription to Murmur history (default false)",
+          ),
+      },
+      annotations: {
+        title: "Transcribe audio file",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (args) => {
+      // Diarize is not exposed on the local channel yet — same honest
+      // refusal as the CLI's --diarize (tickets #267/#269). Never fake it.
+      if (args.diarize === true) {
+        return {
+          isError: true,
+          content: [
+            textBlock(
+              "diarize 尚未支持：说话人分离尚未通过本地通道开放（计划在后续 ticket 中暴露）",
+            ),
+          ],
+        };
+      }
+      // persist is threaded top-level on the channel request (ticket #269):
+      // save defaults to FALSE for the MCP surface, so the default call is
+      // genuinely read-only over the wire.
+      const persist = args.save === true;
+      let bridge: McpChannelBridge;
+      try {
+        bridge = await deps.connect();
+      } catch (error) {
+        // Connect failures carry an already-actionable Chinese message
+        // (BridgeUnavailableError from the CLI bridge kernel).
+        const message = error instanceof Error ? error.message : String(error);
+        log(`murmur mcp: transcribe_file connect failed: ${message}\n`);
+        return { isError: true, content: [textBlock(message)] };
+      }
+      try {
+        const result = await bridge.requestTranscribe(
+          args.path,
+          {},
+          undefined,
+          persist,
+        );
+        const record = isRecord(result) ? result : {};
+        if (record.success === false) {
+          // The service ran and reported a failure envelope: surface the
+          // message as a tool error (the caller cannot do anything with a
+          // fake success).
+          const message =
+            typeof record.error === "string" ? record.error : "未知错误";
+          return { isError: true, content: [textBlock(message)] };
+        }
+        // structuredContent carries the transcript (+ id/duration when the
+        // row was persisted, i.e. only when save:true was passed).
+        const text = typeof record.text === "string" ? record.text : "";
+        const structured: { text: string; id?: number; duration?: number } = {
+          text,
+        };
+        if (typeof record.id === "number") {
+          structured.id = record.id;
+        }
+        if (typeof record.duration === "number") {
+          structured.duration = record.duration;
+        }
+        return {
+          content: [textBlock(text)],
+          structuredContent: structured,
+        };
+      } catch (error) {
+        // Channel-level failure (error frame, disconnect, timeout) —
+        // actionable by the caller (retry after starting the app etc.).
+        const message = error instanceof Error ? error.message : String(error);
+        log(`murmur mcp: transcribe_file request failed: ${message}\n`);
+        return { isError: true, content: [textBlock(message)] };
+      } finally {
+        bridge.close();
+      }
+    },
+  );
+
+  // --- get_murmur_status -------------------------------------------------
+  // Unreachable-app semantics (ticket #269 decision): a status probe that
+  // RAN and reports "the app is not reachable" is a SUCCESSFUL tool result,
+  // not an error — per MCP convention isError is for failures actionable as
+  // "the tool did not do what it promised", and here the caller gets exactly
+  // the answer it asked for ({ reachable: false }). Callers branch on the
+  // structured field, so no misleading error semantics are attached.
+  // models_downloaded is OMITTED when unreachable: the on-disk model state
+  // is unknowable without the app, and inventing `false` would be a lie.
+  //   - readOnlyHint TRUE: pure status probe, no writes anywhere.
+  //   - idempotentHint TRUE: repeated calls neither write nor change effect.
+  server.registerTool(
+    MCP_TOOL_GET_STATUS,
+    {
+      title: "Get Murmur engine status",
+      description:
+        "Check whether the Murmur desktop app is reachable and whether its " +
+        "speech models are downloaded.",
+      inputSchema: {},
+      annotations: {
+        title: "Get Murmur engine status",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async () => {
+      let bridge: McpChannelBridge;
+      try {
+        bridge = await deps.connect();
+      } catch (error) {
+        // [20260912_Fix_269_ReviewStatusDiag] Keep the reachable=false
+        // contract, but do not collapse failure classes silently — the
+        // stderr sink records whether this was not-running, a handshake
+        // rejection, or a timeout.
+        log(
+          `murmur mcp: status connect failed: ${error instanceof Error ? error.message : String(error)}\n`,
+        );
+        return {
+          content: [
+            textBlock(
+              "Murmur 应用未运行或不可达（状态查询本身成功返回：reachable=false 不视为工具错误，可提示用户先启动 Murmur 桌面应用）",
+            ),
+          ],
+          structuredContent: { reachable: false },
+        };
+      }
+      try {
+        const status = await bridge.requestStatus();
+        const record = isRecord(status) ? status : {};
+        return {
+          content: [
+            textBlock(
+              record.models_downloaded === true
+                ? "Murmur 应用可达，模型已下载"
+                : "Murmur 应用可达，模型未下载",
+            ),
+          ],
+          structuredContent: {
+            reachable: true,
+            models_downloaded: record.models_downloaded === true,
+          },
+        };
+      } finally {
+        bridge.close();
+      }
+    },
+  );
+
+  return server;
+}
+
+/**
+ * CLI entry (`murmur mcp`): run the server over stdio and resolve once the
+ * client disconnects (stdin close). Returns the process exit code — always
+ * 0 for a clean EOF disconnect; stdout carries protocol frames only.
+ */
+export async function runMcpStdio(deps: MurmurMcpServerDeps): Promise<number> {
+  const log = deps.log ?? defaultStderrLog;
+  const server = createMurmurMcpServer(deps);
+  const transport = new StdioServerTransport();
+  // Resolves on client disconnect (stdin EOF). Safe to set BEFORE connect:
+  // the SDK's Protocol.connect CHAINS a pre-existing transport.onclose
+  // instead of replacing it.
+  const stdinClosed = new Promise<void>((resolve) => {
+    transport.onclose = () => resolve();
+    // [20260912_Fix_269_ReviewStdinEof] SDK 1.30's StdioServerTransport
+    // registers no end/close listener on stdin, so transport.onclose alone
+    // never fires on client disconnect (verified live: the promise stayed
+    // pending and the process only exited via event-loop drain). Watch
+    // stdin explicitly so shutdown is structural, not incidental.
+    process.stdin.once("end", () => resolve());
+    process.stdin.once("close", () => resolve());
+  });
+  await server.connect(transport);
+  log("murmur mcp: MCP server ready on stdio\n");
+  await stdinClosed;
+  log("murmur mcp: client disconnected, shutting down\n");
+  return 0;
+}

--- a/src/helpers/services/transcriptionService.ts
+++ b/src/helpers/services/transcriptionService.ts
@@ -264,6 +264,13 @@ export async function transcribeFileService(
   audioPath: string,
   options: Record<string, unknown> = {},
   onProgress?: (progress: unknown) => void,
+  // [20260912_Feat_269_McpServer] Opt-out persistence switch (ticket #269):
+  // the MCP `transcribe_file` tool must NOT write history unless the caller
+  // explicitly asks for it (save=true), so the tool can honestly advertise
+  // itself as non-persisting by default. Default is UNDEFINED → persist,
+  // which keeps every existing caller (IPC handlers, CLI channel traffic)
+  // byte-identical to the previous always-persist behavior.
+  persist?: boolean,
 ): Promise<unknown> {
   const { funasrManager, databaseManager, logger } = deps;
   const validation = validateAudioPath(audioPath);
@@ -295,7 +302,12 @@ export async function transcribeFileService(
   // raw_text / segments), keep the pre-clean original for the DB.
   applyTranscriptionCleaning(result, logger);
 
-  if (result.success && result.text) {
+  // [20260912_Feat_269_McpServer] The persist block is now conditional
+  // (ticket #269): `persist !== false` keeps the default-true behavior for
+  // every pre-existing caller; only an explicit persist=false (the MCP
+  // tool's save=false default) skips the DB write entirely — the
+  // transcription result itself is unaffected either way.
+  if (result.success && result.text && persist !== false) {
     try {
       // [20260819_T10_CleanerWiring] original_text is added by
       // applyTranscriptionCleaning; read it through the typed view.

--- a/tests/unit/localChannel.test.ts
+++ b/tests/unit/localChannel.test.ts
@@ -884,3 +884,112 @@ async function waitFor(
     await sleep(5);
   }
 }
+
+// [20260912_Feat_269_McpServer] Ticket #269: transcribe_file's optional
+// top-level `persist` flag. Appended as a standalone top-level describe —
+// every case above is untouched. The flag must reach the service as its
+// 4th argument (undefined/true persist, false skip the DB write), garbage
+// values must answer an invalid-frame error, and omitting the field keeps
+// pre-#269 wire frames byte-identical.
+describe("transcribe_file persist passthrough (ticket #269)", () => {
+  let tmpDir: string;
+  let endpointPath: string;
+  let server: LocalChannelServer | null;
+  let endpointCounter = 0;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-269-"));
+    server = null;
+    endpointCounter += 1;
+    endpointPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\murmur-test-269-persist-${process.pid}-${endpointCounter}`
+        : path.join(tmpDir, `chan-persist-${endpointCounter}.sock`);
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Spy service recording the persist flag it receives. The impl carries
+   * the full 4-arg signature so calls[0]?.[3] is a typed tuple index. */
+  function makeSpyService() {
+    return vi.fn(
+      async (
+        _audioPath: string,
+        _options: Record<string, unknown>,
+        _onProgress?: (progress: unknown) => void,
+        _persist?: boolean,
+      ) => ({ success: true, text: "ok" }),
+    );
+  }
+
+  async function startWith(
+    transcribeFile: ReturnType<typeof makeSpyService>,
+  ): Promise<void> {
+    const instance = createChannelServer({
+      endpointPath,
+      token: TOKEN,
+      services: {
+        transcribeFile: (
+          audioPath: string,
+          options: Record<string, unknown>,
+          onProgress?: (progress: unknown) => void,
+          persist?: boolean,
+        ) => transcribeFile(audioPath, options, onProgress, persist),
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+      },
+      logger: asLogger(makeSpyLogger()),
+    });
+    server = instance;
+    await instance.listen();
+  }
+
+  it.each([
+    [
+      "omitted → undefined",
+      undefined as unknown,
+      undefined as boolean | undefined,
+    ],
+    ["false → false", false as unknown, false],
+    ["true → true", true as unknown, true],
+  ])(
+    "persist %s reaches the service as its 4th argument",
+    async (_label, wireValue, expected) => {
+      const transcribeFile = makeSpyService();
+      await startWith(transcribeFile);
+      const client = createChannelClient({ endpointPath, token: TOKEN });
+      await client.connect();
+      const params: Record<string, unknown> = {
+        audioPath: path.join(os.tmpdir(), "murmur-269-nonexistent.wav"),
+      };
+      if (wireValue !== undefined) {
+        params.persist = wireValue;
+      }
+      await client.request("transcribe_file", params);
+      expect(transcribeFile).toHaveBeenCalledTimes(1);
+      expect(transcribeFile.mock.calls[0]?.[3]).toBe(expected);
+      client.close();
+    },
+  );
+
+  it("a non-boolean persist answers invalid-frame without calling the service", async () => {
+    const transcribeFile = makeSpyService();
+    await startWith(transcribeFile);
+    const client = createChannelClient({ endpointPath, token: TOKEN });
+    await client.connect();
+    await expect(
+      client.request("transcribe_file", {
+        audioPath: path.join(os.tmpdir(), "murmur-269-nonexistent.wav"),
+        persist: "yes",
+      }),
+    ).rejects.toThrow("invalid-frame");
+    expect(transcribeFile).not.toHaveBeenCalled();
+    client.close();
+  });
+});
+// [20260912_Feat_269_McpServer] END

--- a/tests/unit/mcpServer.test.ts
+++ b/tests/unit/mcpServer.test.ts
@@ -1,0 +1,513 @@
+// [20260912_Feat_269_McpServer] MCP server tests (ticket #269). REAL
+// tool-call level coverage: the SDK's in-process client (Client +
+// InMemoryTransport.createLinkedPair) is connected to the server instance
+// built by createMurmurMcpServer, and the `connect` dependency is the
+// PRODUCTION bridge connector (cli/lib/channelBridge.mjs over the bundled
+// cli/dist/channelClient.mjs — built in-process via esbuild, same pattern
+// as cli-bridge.test.ts) against a REAL in-process channel server. Locked
+// here: the exact two-tool surface with honest annotations (transcribe_file
+// must NOT claim readOnly), the save→persist threading, the diarize honest
+// refusal, status semantics (unreachable = successful {reachable:false},
+// NOT an error), and the stderr-only logging rule (stdout is the protocol
+// channel and must stay untouched).
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { build } from "esbuild";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  createMurmurMcpServer,
+  MCP_SERVER_NAME,
+  MCP_TOOL_GET_STATUS,
+  MCP_TOOL_TRANSCRIBE_FILE,
+  type MurmurMcpServerDeps,
+} from "../../src/helpers/mcp/mcpServer";
+import { transcribeFileService } from "../../src/helpers/services/transcriptionService";
+import {
+  createChannelServer,
+  type ChannelServices,
+  type LocalChannelServer,
+} from "../../src/helpers/localChannel";
+import type { Logger } from "../../src/helpers/services/transcriptionService";
+import { connectChannelBridge } from "../../cli/lib/channelBridge.mjs";
+import {
+  writeChannelEndpointFile,
+  writeChannelTokenFile,
+} from "../../src/helpers/localChannel/endpoint";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+const TOKEN = "local-channel-269-test-token-0123456789abcdef";
+
+/** Audio path that passes audioPathValidator on every platform (tmpdir is
+ * an allowed root; the file need not exist for the fallback branch). */
+const AUDIO_PATH = path.join(os.tmpdir(), "murmur-269-sample.wav");
+
+/** Silent logger satisfying the channel services Logger interface. */
+const silentLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+} as unknown as Logger;
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+/** Loosely-typed mock bag for the REAL transcribeFileService under test. */
+function makeServiceDeps(transcribeResult?: unknown): {
+  funasrManager: { transcribeFile: MockFn };
+  databaseManager: {
+    saveTranscription: MockFn;
+    getSetting: MockFn;
+  };
+  logger: Record<string, MockFn>;
+} {
+  return {
+    funasrManager: {
+      transcribeFile: vi.fn(
+        async () =>
+          transcribeResult ?? {
+            success: true,
+            text: "MCP 转写结果",
+            duration: 2.5,
+          },
+      ),
+    },
+    databaseManager: {
+      saveTranscription: vi.fn(() => ({ lastInsertRowid: 42n, changes: 1 })),
+      getSetting: vi.fn(() => null),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+}
+
+describe("murmur mcp server (ticket #269)", () => {
+  let tmpDir: string;
+  let endpointPath: string;
+  let channelServer: LocalChannelServer | null;
+  let endpointCounter = 0;
+
+  // The MCP `connect` dependency is the PRODUCTION bridge connector, which
+  // loads the bundled TS client kernel from cli/dist/channelClient.mjs
+  // (gitignored build:cli output). Build it in-process via esbuild's JS API
+  // so the suite is hermetic and always exercises the current client source.
+  beforeAll(async () => {
+    await build({
+      entryPoints: [path.join(REPO_ROOT, "src/helpers/localChannel/client.ts")],
+      outfile: path.join(REPO_ROOT, "cli/dist/channelClient.mjs"),
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      logLevel: "silent",
+    });
+  });
+
+  function freshTmp(): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-269-"));
+    endpointCounter += 1;
+    // Platform-aware endpoint, same construction as cli-bridge.test.ts:
+    // Node on win32 only accepts \\.\pipe\ paths for IPC listening; pipes
+    // are flat-namespaced so pid+counter keeps workers unique.
+    endpointPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\murmur-test-269-${process.pid}-${endpointCounter}`
+        : path.join(tmpDir, `chan-${endpointCounter}.sock`);
+    return tmpDir;
+  }
+
+  afterEach(async () => {
+    if (channelServer) {
+      await channelServer.stop();
+      channelServer = null;
+    }
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  /** Start a real channel server on the platform-aware endpoint. */
+  async function startServer(
+    services: ChannelServices,
+  ): Promise<LocalChannelServer> {
+    const instance = createChannelServer({
+      endpointPath,
+      token: TOKEN,
+      services,
+      logger: silentLogger,
+    });
+    channelServer = instance;
+    await instance.listen();
+    return instance;
+  }
+
+  /** Publish the discovery files exactly like startLocalChannel does. */
+  function publishChannelFiles(dir: string, token: string): void {
+    writeChannelEndpointFile(dir, endpointPath, process.platform);
+    writeChannelTokenFile(dir, token, process.platform);
+  }
+
+  /**
+   * Production bridge connector (connectChannelBridge resolves endpoint +
+   * token from the temp userData and loads the bundled client kernel).
+   */
+  function makeConnectDeps(overrides: Partial<MurmurMcpServerDeps> = {}) {
+    return {
+      connect: () =>
+        connectChannelBridge({ env: { ELECTRON_USER_DATA: tmpDir } }),
+      version: "1.5.1-test",
+      ...overrides,
+    } as MurmurMcpServerDeps;
+  }
+
+  /** Connect an SDK in-process client to a fresh server instance. */
+  async function makeSession(deps: MurmurMcpServerDeps): Promise<{
+    client: Client;
+    server: ReturnType<typeof createMurmurMcpServer>;
+  }> {
+    const server = createMurmurMcpServer(deps);
+    const client = new Client({
+      name: "mcp-269-test-client",
+      version: "0.0.0",
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+    return { client, server };
+  }
+
+  async function callTool(
+    client: Client,
+    name: string,
+    args: Record<string, unknown> = {},
+  ): Promise<CallToolResult> {
+    return (await client.callTool({
+      name,
+      arguments: args,
+    })) as CallToolResult;
+  }
+
+  describe("tools/list surface", () => {
+    it("enumerates exactly the two tools with honest annotations", async () => {
+      freshTmp();
+      const { client } = await makeSession(makeConnectDeps());
+      const { tools } = await client.listTools();
+      expect(tools).toHaveLength(2);
+      const names = tools.map((tool) => tool.name).sort();
+      expect(names).toEqual([MCP_TOOL_GET_STATUS, MCP_TOOL_TRANSCRIBE_FILE]);
+
+      // Honesty lock (ticket #269): save:true CAN write history, so
+      // transcribe_file must NOT claim readOnly. It never deletes
+      // (destructive:false), repeats can append rows (idempotent:false),
+      // and it only talks to the local app (openWorld:false).
+      const transcribe = tools.find(
+        (tool) => tool.name === MCP_TOOL_TRANSCRIBE_FILE,
+      );
+      expect(transcribe?.annotations).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      });
+
+      // The status probe is a pure read: read-only and idempotent.
+      const status = tools.find((tool) => tool.name === MCP_TOOL_GET_STATUS);
+      expect(status?.annotations).toMatchObject({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      expect(tools[0]?.inputSchema).toMatchObject({ type: "object" });
+    });
+
+    it("reports the injected version and server name in initialize", async () => {
+      freshTmp();
+      const { client } = await makeSession(makeConnectDeps());
+      // The SDK client's getServerVersion() is the SERVER's initialize
+      // identity: name must be "murmur" and the version the CLI passed in.
+      expect(client.getServerVersion()).toEqual({
+        name: "murmur",
+        version: "1.5.1-test",
+      });
+      expect(MCP_SERVER_NAME).toBe("murmur");
+    });
+  });
+
+  describe("transcribe_file", () => {
+    it("returns structuredContent {text, id, duration} from the channel result and threads persist=false by default", async () => {
+      freshTmp();
+      // Channel-level spy: the 4th service argument is the persist flag.
+      const transcribeFile = vi.fn(
+        async (
+          _audioPath: string,
+          _options: Record<string, unknown>,
+          _onProgress?: (progress: unknown) => void,
+          _persist?: boolean,
+        ) => ({
+          success: true,
+          text: "你好世界",
+          id: 7,
+          duration: 3.2,
+        }),
+      );
+      await startServer({
+        transcribeFile: (audioPath, options, onProgress, persist) =>
+          transcribeFile(audioPath, options, onProgress, persist),
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_TRANSCRIBE_FILE, {
+        path: AUDIO_PATH,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({
+        text: "你好世界",
+        id: 7,
+        duration: 3.2,
+      });
+      expect(result.content).toEqual([{ type: "text", text: "你好世界" }]);
+      expect(transcribeFile).toHaveBeenCalledTimes(1);
+      // MCP default (no save field) MUST be persist=false over the channel.
+      expect(transcribeFile.mock.calls[0]?.[3]).toBe(false);
+    });
+
+    it("save=false: the real service transcribes but saveTranscription is NEVER called", async () => {
+      freshTmp();
+      const mockDeps = makeServiceDeps();
+      // The channel service IS the real transcribeFileService, fed the
+      // channel's persist flag — the production wiring shape.
+      const transcribeSpy = vi.fn(
+        (
+          audioPath: string,
+          options: Record<string, unknown>,
+          onProgress?: (progress: unknown) => void,
+          persist?: boolean,
+        ) =>
+          transcribeFileService(
+            mockDeps as unknown as Parameters<typeof transcribeFileService>[0],
+            audioPath,
+            options,
+            onProgress,
+            persist,
+          ),
+      );
+      await startServer({
+        transcribeFile: transcribeSpy,
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_TRANSCRIBE_FILE, {
+        path: AUDIO_PATH,
+        save: false,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toMatchObject({
+        text: "MCP 转写结果",
+      });
+      // No persist → no row → no id in the structured payload.
+      expect(result.structuredContent).not.toHaveProperty("id");
+      expect(transcribeSpy.mock.calls[0]?.[3]).toBe(false);
+      expect(mockDeps.funasrManager.transcribeFile).toHaveBeenCalledTimes(1);
+      expect(mockDeps.databaseManager.saveTranscription).not.toHaveBeenCalled();
+    });
+
+    it("save=true: persist=true reaches the service and the row is saved (id surfaces)", async () => {
+      freshTmp();
+      const mockDeps = makeServiceDeps();
+      const transcribeSpy = vi.fn(
+        (
+          audioPath: string,
+          options: Record<string, unknown>,
+          onProgress?: (progress: unknown) => void,
+          persist?: boolean,
+        ) =>
+          transcribeFileService(
+            mockDeps as unknown as Parameters<typeof transcribeFileService>[0],
+            audioPath,
+            options,
+            onProgress,
+            persist,
+          ),
+      );
+      await startServer({
+        transcribeFile: transcribeSpy,
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_TRANSCRIBE_FILE, {
+        path: AUDIO_PATH,
+        save: true,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({
+        text: "MCP 转写结果",
+        id: 42,
+        duration: 2.5,
+      });
+      expect(transcribeSpy.mock.calls[0]?.[3]).toBe(true);
+      expect(mockDeps.databaseManager.saveTranscription).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it("diarize=true is honestly unsupported: isError + 尚未支持, no channel traffic", async () => {
+      freshTmp();
+      const transcribeFile = vi.fn(async () => ({ success: true }));
+      await startServer({
+        transcribeFile,
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_TRANSCRIBE_FILE, {
+        path: AUDIO_PATH,
+        diarize: true,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: expect.stringContaining("尚未支持") },
+      ]);
+      // The refusal happens BEFORE any channel work.
+      expect(transcribeFile).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a service-side failure envelope as isError with the message", async () => {
+      freshTmp();
+      await startServer({
+        transcribeFile: async () => ({ success: false, error: "引擎未就绪" }),
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_TRANSCRIBE_FILE, {
+        path: AUDIO_PATH,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "引擎未就绪" }]);
+    });
+
+    it("app not running: isError with the actionable bridge message", async () => {
+      freshTmp();
+      // No discovery files at all — the production connector classifies
+      // this as unreachable (the same failure the CLI maps to exit 4).
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_TRANSCRIBE_FILE, {
+        path: AUDIO_PATH,
+      });
+      expect(result.isError).toBe(true);
+      const text = result.content[0];
+      expect(text).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("应用可能未运行"),
+      });
+    });
+  });
+
+  describe("get_murmur_status", () => {
+    it("reachable app → structuredContent {reachable:true, models_downloaded:true}, not an error", async () => {
+      freshTmp();
+      await startServer({
+        transcribeFile: async () => ({ success: true }),
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_GET_STATUS, {});
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({
+        reachable: true,
+        models_downloaded: true,
+      });
+    });
+
+    it("reachable app with missing models → models_downloaded:false", async () => {
+      freshTmp();
+      await startServer({
+        transcribeFile: async () => ({ success: true }),
+        checkEngineStatus: async () => ({ models_downloaded: false }),
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_GET_STATUS, {});
+      expect(result.structuredContent).toEqual({
+        reachable: true,
+        models_downloaded: false,
+      });
+    });
+
+    it("unreachable app → SUCCESSFUL result {reachable:false} (a status probe that ran is not an error)", async () => {
+      freshTmp();
+      // No discovery files, no server: the connector throws, the tool
+      // answers {reachable:false} WITHOUT isError (ticket #269 decision).
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_GET_STATUS, {});
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({ reachable: false });
+      // models_downloaded is omitted: unknowable without the app.
+      expect(result.structuredContent).not.toHaveProperty("models_downloaded");
+    });
+  });
+
+  describe("stderr-only logging", () => {
+    it("diagnostics go to the injected stderr sink; stdout is never touched", async () => {
+      freshTmp();
+      const logged: string[] = [];
+      const stdoutWrites: string[] = [];
+      const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+        chunk: unknown,
+      ) => {
+        stdoutWrites.push(String(chunk));
+        return true;
+      }) as typeof process.stdout.write);
+      try {
+        // A connect-failing session produces a diagnostic (no server).
+        const failing = await makeSession(
+          makeConnectDeps({ log: (chunk) => logged.push(chunk) }),
+        );
+        const failed = await callTool(
+          failing.client,
+          MCP_TOOL_TRANSCRIBE_FILE,
+          { path: AUDIO_PATH },
+        );
+        expect(failed.isError).toBe(true);
+
+        // A healthy session round-trips over the in-memory transport only.
+        await startServer({
+          transcribeFile: async () => ({ success: true, text: "ok" }),
+          checkEngineStatus: async () => ({ models_downloaded: true }),
+        });
+        publishChannelFiles(tmpDir, TOKEN);
+        const healthy = await makeSession(
+          makeConnectDeps({ log: (chunk) => logged.push(chunk) }),
+        );
+        const okResult = await callTool(
+          healthy.client,
+          MCP_TOOL_TRANSCRIBE_FILE,
+          { path: AUDIO_PATH },
+        );
+        expect(okResult.isError).toBeUndefined();
+      } finally {
+        stdoutSpy.mockRestore();
+      }
+      // STDOUT RED LINE: not a single byte of log output reached stdout —
+      // it is reserved for protocol frames.
+      expect(stdoutWrites).toEqual([]);
+      // The connect failure WAS diagnosed on the stderr sink.
+      expect(logged.join("")).toContain("transcribe_file connect failed");
+    });
+  });
+});

--- a/tests/unit/transcriptionService.test.ts
+++ b/tests/unit/transcriptionService.test.ts
@@ -328,3 +328,94 @@ describe("transcribeFileService — deferred edge cases (#261 review → #262)",
   });
 });
 // [20260912_Refactor_262_AiHistoryService] END
+
+// [20260912_Feat_269_McpServer] Ticket #269: the persist opt-out for the
+// MCP `transcribe_file` tool. Appended as a standalone describe — every
+// case above is untouched (default behavior stays always-persist).
+describe("transcribeFileService persist opt-out (ticket #269)", () => {
+  // Local deps builder mirroring the harnesses above (loosely-typed
+  // vi.fn() mocks, `unknown` bridge, no `any`).
+  type MockFn = ReturnType<typeof vi.fn>;
+  let mockDeps: {
+    funasrManager: { transcribeFile: MockFn };
+    databaseManager: {
+      saveTranscription: MockFn;
+      getSetting: MockFn;
+      getTranscriptionById: MockFn;
+    };
+    logger: Record<string, MockFn>;
+  };
+
+  beforeEach(() => {
+    mockDeps = {
+      funasrManager: {
+        transcribeFile: vi.fn(async () => ({
+          success: true,
+          text: "文件转录",
+          raw_text: "raw",
+          segments: [],
+          duration: 1.5,
+        })),
+      },
+      databaseManager: {
+        saveTranscription: vi.fn(() => ({ lastInsertRowid: 42n, changes: 1 })),
+        getSetting: vi.fn(() => null),
+        getTranscriptionById: vi.fn(() => null),
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    };
+  });
+
+  const serviceDeps = () => mockDeps as unknown as TranscriptionServiceDeps;
+
+  it("persist=false: still transcribes, but saveTranscription is NEVER called and no id is attached", async () => {
+    const result = (await transcribeFileService(
+      serviceDeps(),
+      "/fake/audio.wav",
+      {},
+      undefined,
+      false,
+    )) as { success: boolean; text?: string; id?: number };
+    expect(mockDeps.funasrManager.transcribeFile).toHaveBeenCalledTimes(1);
+    expect(mockDeps.databaseManager.saveTranscription).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("文件转录");
+    // No DB row → no id on the result (the MCP tool surfaces this absence
+    // by omitting `id` from its structuredContent).
+    expect(result).not.toHaveProperty("id");
+  });
+
+  it("persist=true: persists exactly like the default", async () => {
+    const result = (await transcribeFileService(
+      serviceDeps(),
+      "/fake/audio.wav",
+      {},
+      undefined,
+      true,
+    )) as { success: boolean; id?: number };
+    expect(mockDeps.databaseManager.saveTranscription).toHaveBeenCalledTimes(1);
+    expect(result.id).toBe(42);
+  });
+
+  it("persist omitted (undefined): default-true — existing callers keep the always-persist behavior", async () => {
+    await transcribeFileService(serviceDeps(), "/fake/audio.wav");
+    expect(mockDeps.databaseManager.saveTranscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("persist=false with a failing transcription: unchanged failure envelope, still no save", async () => {
+    mockDeps.funasrManager.transcribeFile.mockResolvedValueOnce({
+      success: false,
+      error: "引擎未就绪",
+    });
+    const result = (await transcribeFileService(
+      serviceDeps(),
+      "/fake/audio.wav",
+      {},
+      undefined,
+      false,
+    )) as Record<string, unknown>;
+    expect(result).toEqual({ success: false, error: "引擎未就绪" });
+    expect(mockDeps.databaseManager.saveTranscription).not.toHaveBeenCalled();
+  });
+});
+// [20260912_Feat_269_McpServer] END


### PR DESCRIPTION
## What

`murmur mcp` 子命令以 stdio transport 启动 MCP server（官方 SDK `@modelcontextprotocol/sdk@1.30`），复用 #267 桥接内核（连接器注入，客户端单源零镜像）：

- **transcribe_file**(path, diarize?, save?)：persist 全链穿透（service → channel → wire → MCP save），**默认不写历史**；annotations 诚实标注（readOnlyHint:false 因 save 可写，tools/list 测试漂移锁定）；diarize 未支持 → isError；可纠错错误 → isError + 可行动消息
- **get_murmur_status**()：只读注解（readOnly+idempotent）；不可达 → 成功 `{reachable:false}`（文档化决策：跑完并回答的状态探测不是工具错误）；评审修复：连接失败分类记入 stderr 不再静默坍缩
- **stdout 红线**：stdout 仅协议帧（grep 干净 + spy 测试零字节断言 + stderr sink 三重保障）
- **生命周期**：评审修复 stdin EOF/close 显式解析关闭（SDK 1.30 的 StdioServerTransport 不监听 stdin end，实测 onclose 永不触发——原实现仅靠事件循环排空退出，任何未来 keepalive 句柄都会造成孤儿进程）

## 依赖

`@modelcontextprotocol/sdk@^1.30.0`（MIT，license 门通过）+ `zod@^4.6.2`（pnpm 严格布局下 SDK peer 需要）。`build:mcp` 挂入全部构建链（与 build:cli 同模式），electron-builder files 已覆盖。

## 独立 code-review

APPROVE（3 MINOR + 4 NIT，0 MAJOR）：persist 三臂逐分支测试锁定（含 `calls[0][3] === false` 服务级断言反向钉住 wire 行为）、注释可验证性好评。MINOR-1（stdin EOF）与 MINOR-2（状态诊断）已修复；MINOR-3 提交纪律已守（显式 staging）。

## 验证

全量 `pnpm test` 2572 用例绿（180 文件）；MCP 套件 12 用例（SDK InMemoryTransport 真客户端工具级调用）；stdio 端到端冒烟（initialize + tools/list + tools/call 对真实 CLI，stdout 仅协议帧）

## 手工验收步骤（写入票内，按 AC）

`claude mcp add murmur -- <app>/cli/murmur.mjs mcp`（需 ELECTRON_RUN_AS_NODE=1）→ 会话内枚举工具 → 调用 transcribe_file 传真实音频路径 → structuredContent 返回文本。#272 分发票落地 bin shim 后此步骤免手工前缀。

Closes #269