### PR TITLE
feat: murmur mcp install — 三客户端一键接入 幂等深合并 (Spec #258 #271, closes #271)

### DIFF
--- a/cli/lib/cliRunner.mjs
+++ b/cli/lib/cliRunner.mjs
@@ -17,6 +17,7 @@
 //   murmur polish <text> [--mode <mode>]          (ticket #268)
 //   murmur history delete <id> [--yes]            (ticket #268)
 //   murmur mcp                                    (ticket #269)
+//   murmur mcp install [--client ...] [--command ...]  (ticket #271; local)
 import {
   resolveConfigPath,
   resolveDatabasePath,
@@ -31,7 +32,17 @@ import {
   connectChannelBridge,
   validateAudioExtension,
 } from "./channelBridge.mjs";
+// [20260912_Feat_271_McpInstall] Project-scope MCP client registration
+// (ticket #271): client target table, merge logic and the typed error live
+// in mcpInstall.mjs; this module owns flags/output/exit-code wiring.
+import {
+  DEFAULT_MCP_COMMAND,
+  MCP_CLIENT_TARGETS,
+  McpInstallError,
+  installMcpEntry,
+} from "./mcpInstall.mjs";
 import os from "node:os";
+import path from "node:path";
 import readline from "node:readline/promises";
 
 // [20260912_Fix_264_ReviewFollowups] Mirrors validateSetting's
@@ -80,6 +91,27 @@ Usage:
                                        protocol frames; diagnostics go to
                                        stderr. The process exits when the MCP
                                        client disconnects (stdin closes).
+  murmur mcp install [--client <name>] [--command <path>] [--json]
+                                       Register the Murmur MCP server with
+                                       local MCP clients (ticket #271).
+                                       Clients: claude, cursor, vscode, all
+                                       (default: all). Writes PROJECT-scope
+                                       config in the CURRENT directory:
+                                       .mcp.json (Claude Code),
+                                       .cursor/mcp.json (Cursor) under
+                                       "mcpServers", and .vscode/mcp.json
+                                       (VS Code) under "servers". Existing
+                                       files are merged — only the "murmur"
+                                       entry is added/replaced; every other
+                                       entry is preserved. A second identical
+                                       run makes no change. --user is not
+                                       supported yet. --command overrides the
+                                       executable written into the configs
+                                       (default "murmur"; the packaged CLI
+                                       runs via ELECTRON_RUN_AS_NODE=1
+                                       <electron-binary> cli/murmur.mjs, so
+                                       point --command at that entry when
+                                       "murmur" is not on PATH).
 
 Global options:
   --json                               Structured JSON output on stdout
@@ -711,6 +743,131 @@ async function runMcp(argv, ctx) {
 }
 // [20260912_Feat_269_McpServer] END
 
+// [20260912_Feat_271_McpInstall] --- murmur mcp install (ticket #271) ---
+// Local (no app, no channel): writes/merges the per-client MCP config files
+// in the CURRENT directory via mcpInstall.mjs. Exit 0 on full or partial
+// success, 1 when EVERY requested client failed (e.g. the only requested
+// client's config file is not valid JSON), 2 on usage errors. `--user` is
+// rejected honestly: user-scope paths/semantics differ per client and are
+// deliberately deferred to their own ticket.
+
+// Accepted `--client` values ("all" = every target in MCP_CLIENT_TARGETS).
+const MCP_INSTALL_CLIENT_CHOICES = new Set([
+  "claude",
+  "cursor",
+  "vscode",
+  "all",
+]);
+
+/** Per-client stdout line in text mode (status verb + absolute path). */
+function mcpInstallStatusLine(result) {
+  if (result.status === "created") {
+    return `${result.label}: 已写入 ${result.path}\n`;
+  }
+  if (result.status === "updated") {
+    return `${result.label}: 已更新（合并） ${result.path}\n`;
+  }
+  return `${result.label}: 无变化 ${result.path}\n`;
+}
+
+function runMcpInstall(argv, ctx) {
+  // knownFlags must list every accepted flag; the booleanFlags subset marks
+  // the valueless ones (--project/--user are the scope pair).
+  const parsed = parseArgs(
+    argv,
+    new Set(["--client", "--command", "--project", "--user"]),
+    new Set(["--project", "--user"]),
+  );
+  if (parsed.unknown)
+    return usageError(`mcp install: unknown flag ${parsed.unknown}`);
+  if (parsed.missing)
+    return usageError(`mcp install: ${parsed.missing} requires a value`);
+  if (parsed.positionals.length > 0)
+    return usageError("mcp install: unexpected extra arguments");
+
+  // Scope: --project is the default and the only implemented scope. --user
+  // is a usage error (尚未支持) — honest refusal instead of guessing at
+  // per-client user-level semantics.
+  if (parsed.flags["--user"]) {
+    return usageError(
+      "mcp install: --user 尚未支持（用户级配置各客户端语义不同，将在后续 ticket 支持；当前仅支持项目级 --project，即默认行为）",
+    );
+  }
+
+  let clientChoice = "all";
+  if (parsed.flags["--client"] !== undefined) {
+    clientChoice = parsed.flags["--client"];
+    if (!MCP_INSTALL_CLIENT_CHOICES.has(clientChoice)) {
+      return usageError(
+        `mcp install: 未知的客户端: ${clientChoice}（可用: claude, cursor, vscode, all）`,
+      );
+    }
+  }
+
+  let command = DEFAULT_MCP_COMMAND;
+  if (parsed.flags["--command"] !== undefined) {
+    command = parsed.flags["--command"];
+    // parseArgs never yields "" for --command (a bare empty token becomes a
+    // positional, rejected above); whitespace still can, so guard it.
+    if (command.trim().length === 0) {
+      return usageError("mcp install: --command 不能为空");
+    }
+  }
+
+  const targets =
+    clientChoice === "all"
+      ? MCP_CLIENT_TARGETS
+      : MCP_CLIENT_TARGETS.filter((target) => target.id === clientChoice);
+
+  // Per-client isolation: one client's failure (invalid JSON, unwritable
+  // path) never aborts the others. Every failure is recorded; exit 1 only
+  // when all requested clients failed.
+  const results = targets.map((target) => {
+    try {
+      return installMcpEntry(target, { cwd: ctx.cwd, command });
+    } catch (error) {
+      const message =
+        error instanceof McpInstallError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      return {
+        client: target.id,
+        label: target.label,
+        path: path.join(ctx.cwd, target.relativePath),
+        status: "failed",
+        success: false,
+        error: message,
+      };
+    }
+  });
+  const allFailed = results.every((result) => !result.success);
+
+  // Locked --json schema: { clients: [McpInstallClientResult, ...] } — the
+  // same per-client records in both output modes, failures included.
+  if (ctx.json) {
+    return {
+      code: allFailed ? EXIT_RUNTIME_ERROR : EXIT_OK,
+      stdout: `${JSON.stringify({ clients: results })}\n`,
+      stderr: "",
+    };
+  }
+  // Results on stdout, error text on stderr (locked CLI convention).
+  const okLines = results
+    .filter((result) => result.success)
+    .map(mcpInstallStatusLine);
+  const errorLines = results
+    .filter((result) => !result.success)
+    .map((result) => `murmur mcp install: ${result.error}\n`);
+  return {
+    code: allFailed ? EXIT_RUNTIME_ERROR : EXIT_OK,
+    stdout: okLines.join(""),
+    stderr: errorLines.join(""),
+  };
+}
+// [20260912_Feat_271_McpInstall] END
+
 /**
  * Run one CLI invocation. argv excludes the node/electron and script paths.
  *
@@ -732,6 +889,10 @@ async function runMcp(argv, ctx) {
  * @param {() => string} [options.homedir] Home dir resolver (defaults to os.homedir).
  * @param {string} [options.configPath] Explicit murmur.json path (skips env derivation).
  * @param {string} [options.dbPath] Explicit SQLite path (skips env derivation).
+ * @param {string} [options.cwd] Working directory for project-scope file
+ *   writes (`mcp install`, ticket #271; defaults to process.cwd()). Injected
+ *   by tests so project config files land in a temp directory instead of the
+ *   real working tree.
  * @param {(chunk: string) => void} [options.stderrWrite] Streaming sink for
  *   progress lines (wired to process.stderr by the entry point; tests omit it
  *   and read the accumulated stderr instead).
@@ -759,6 +920,9 @@ export function runCli(argv, options = {}) {
     // [20260912_Feat_267_BridgeTranscribe] Bridge subcommands resolve the
     // channel endpoint/token from the same userData derivation.
     userDataPath: resolveDataDirectory(pathContext),
+    // [20260912_Feat_271_McpInstall] Project-scope root for `mcp install`
+    // (mirrors the userDataPath/platform injection pattern above).
+    cwd: options.cwd ?? process.cwd(),
     env: pathContext.env,
     platform: pathContext.platform,
     homedir: pathContext.homedir,
@@ -809,6 +973,16 @@ export function runCli(argv, options = {}) {
     );
   }
   // [20260912_Feat_268_BridgePolishHistory] END
+  // [20260912_Feat_271_McpInstall] `mcp install` (ticket #271) is a LOCAL
+  // sync command, but it MUST be routed BEFORE the bare `mcp` terminal match
+  // below: bare `mcp` (ticket #269) dispatches the stdio server and rejects
+  // every positional, so without this earlier check `murmur mcp install`
+  // would die as "mcp: unexpected extra arguments". Only the exact
+  // "mcp install" prefix is stolen — `murmur mcp <anything-else>` still
+  // reaches runMcp unchanged.
+  if (command === "mcp" && subcommand === "install") {
+    return runMcpInstall(rest, ctx);
+  }
   // [20260912_Feat_269_McpServer] `murmur mcp` (ticket #269) is an async
   // long-running command: it returns a Promise resolving when the MCP
   // client disconnects (stdin EOF), with the same { code, stdout, stderr }

--- a/cli/lib/mcpInstall.mjs
+++ b/cli/lib/mcpInstall.mjs
@@ -1,0 +1,214 @@
+// [20260912_Feat_271_McpInstall] Project-scope MCP client registration for
+// `murmur mcp install` (ticket #271). Writes/merges the MCP client config
+// files that register the Murmur MCP server (ticket #269's `murmur mcp`
+// stdio server) for the three supported local clients:
+//   - Claude Code: .mcp.json            under top-level key "mcpServers"
+//   - Cursor:      .cursor/mcp.json     under top-level key "mcpServers"
+//   - VS Code:     .vscode/mcp.json     under top-level key "servers"
+//     (VS Code's documented difference — its project file uses "servers".)
+// Contract: idempotent merge, never clobber. The existing file is parsed and
+// only the "murmur" entry inside the client's server map is deep-merged;
+// every other key/entry is preserved by value (plain JSON round-trip,
+// 2-space indent like cli/lib/configStore.mjs). A config file that is not
+// valid JSON (or whose server map is not a JSON object) raises
+// McpInstallError and the file is left byte-for-byte untouched.
+// All paths derive from the injected cwd — no real home-dir writes.
+import fs from "node:fs";
+import path from "node:path";
+
+// Mirrors cli/lib/configStore.mjs (the repo's config writer).
+const JSON_INDENT_SPACES = 2;
+
+/** Server key this CLI owns inside every client's server map. */
+export const MCP_SERVER_KEY = "murmur";
+
+/** Args for the canonical server entry: `<command> mcp` (ticket #269). */
+export const MCP_SERVER_ARGS = ["mcp"];
+
+/** Default executable written into client configs (resolved on PATH post-#272). */
+export const DEFAULT_MCP_COMMAND = "murmur";
+
+/**
+ * @typedef {object} McpClientTarget
+ * @property {string} id `--client` value.
+ * @property {string} label Human-readable client name (stdout lines).
+ * @property {string} relativePath Config file path relative to the project
+ *   root (forward slashes; joined with path.join so Windows gets "\").
+ * @property {string} topLevelKey Server map key in this client's config.
+ */
+
+/** @type {McpClientTarget[]} */
+export const MCP_CLIENT_TARGETS = [
+  {
+    id: "claude",
+    label: "Claude Code",
+    relativePath: ".mcp.json",
+    topLevelKey: "mcpServers",
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    relativePath: ".cursor/mcp.json",
+    topLevelKey: "mcpServers",
+  },
+  {
+    id: "vscode",
+    label: "VS Code",
+    relativePath: ".vscode/mcp.json",
+    topLevelKey: "servers",
+  },
+];
+
+/**
+ * @typedef {object} McpInstallClientResult
+ * @property {string} client Target id.
+ * @property {string} label Target label.
+ * @property {string} path Absolute config file path.
+ * @property {"created"|"updated"|"unchanged"|"failed"} status
+ * @property {boolean} success
+ * @property {string | null} error
+ */
+
+/**
+ * Raised for config files this command must never overwrite: invalid JSON,
+ * a non-object top level, or a non-object server map. The CLI maps this to
+ * a per-client failure (runtime error) while leaving the file untouched.
+ */
+export class McpInstallError extends Error {}
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Structural equality over JSON values (key order irrelevant). */
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every((key) => key in b && deepEqual(a[key], b[key]))
+    );
+  }
+  return false;
+}
+
+/**
+ * Deep-merge `incoming` over `existing` (both JSON values). Objects merge
+ * recursively (existing keys survive, incoming keys win); every other type
+ * (arrays included) is replaced wholesale by the incoming value. Used ONLY
+ * inside the "murmur" entry — foreign entries are never passed through here.
+ */
+function deepMergeEntry(existing, incoming) {
+  if (!isPlainObject(existing) || !isPlainObject(incoming)) return incoming;
+  const merged = { ...existing };
+  for (const key of Object.keys(incoming)) {
+    merged[key] = deepMergeEntry(existing[key], incoming[key]);
+  }
+  return merged;
+}
+
+/**
+ * Install (create or merge) the Murmur server entry into one client's
+ * project-scope config file. Never overwrites unparseable files — those
+ * throw McpInstallError. When the resulting "murmur" entry already equals
+ * the merged entry the file is not written at all, so an idempotent second
+ * run preserves the original bytes exactly.
+ *
+ * @param {McpClientTarget} target Client to install into.
+ * @param {object} options
+ * @param {string} options.cwd Project root (the process's working directory
+ *   in production; injected by tests so no real directories are touched).
+ * @param {string} [options.command] Executable for the server entry
+ *   (default DEFAULT_MCP_COMMAND; accepted verbatim).
+ * @returns {McpInstallClientResult}
+ */
+export function installMcpEntry(target, options) {
+  const command = options.command ?? DEFAULT_MCP_COMMAND;
+  const configPath = path.join(options.cwd, target.relativePath);
+  const canonicalEntry = { command, args: [...MCP_SERVER_ARGS] };
+  const failurePath = configPath;
+
+  const readExistingDocument = () => {
+    if (!fs.existsSync(configPath)) return null;
+    let raw;
+    try {
+      raw = fs.readFileSync(configPath, "utf-8");
+    } catch (error) {
+      throw new McpInstallError(
+        `无法读取 ${failurePath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new McpInstallError(
+        `${failurePath} 不是有效的 JSON，已保留原文件未做修改`,
+      );
+    }
+    if (!isPlainObject(parsed)) {
+      throw new McpInstallError(
+        `${failurePath} 的顶层必须是 JSON 对象，已保留原文件未做修改`,
+      );
+    }
+    return parsed;
+  };
+
+  const existingDocument = readExistingDocument();
+  const created = existingDocument === null;
+  // Mutations happen only after every validation below has passed, so a
+  // validation failure never reaches the write path.
+  const document = existingDocument ?? {};
+  const existingMap = document[target.topLevelKey];
+  if (existingMap !== undefined && !isPlainObject(existingMap)) {
+    throw new McpInstallError(
+      `${failurePath} 中的 "${target.topLevelKey}" 不是 JSON 对象，已保留原文件未做修改`,
+    );
+  }
+  const serverMap = existingMap ?? {};
+  const existingEntry = serverMap[MCP_SERVER_KEY];
+  const mergedEntry = deepMergeEntry(existingEntry, canonicalEntry);
+
+  if (!created && deepEqual(existingEntry, mergedEntry)) {
+    // Idempotent no-change: skip the write entirely so the file's original
+    // bytes (formatting included) are preserved.
+    return {
+      client: target.id,
+      label: target.label,
+      path: configPath,
+      status: "unchanged",
+      success: true,
+      error: null,
+    };
+  }
+
+  serverMap[MCP_SERVER_KEY] = mergedEntry;
+  document[target.topLevelKey] = serverMap;
+
+  try {
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(document, null, JSON_INDENT_SPACES),
+      "utf-8",
+    );
+  } catch (error) {
+    throw new McpInstallError(
+      `无法写入 ${failurePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return {
+    client: target.id,
+    label: target.label,
+    path: configPath,
+    status: created ? "created" : "updated",
+    success: true,
+    error: null,
+  };
+}

--- a/tests/unit/cli-mcp-install.test.ts
+++ b/tests/unit/cli-mcp-install.test.ts
@@ -1,0 +1,495 @@
+// [20260912_Feat_271_McpInstall] Function-level convention tests for
+// `murmur mcp install` (ticket #271). All paths derive from an injected
+// `cwd` pointing at a per-test temp directory — NO real home-dir or repo
+// writes. Locked here:
+//   - fresh install content per client, including VS Code's "servers"
+//     top-level key difference (Claude Code/Cursor use "mcpServers")
+//   - idempotency: a second identical run reports 无变化 and leaves the
+//     original file bytes untouched
+//   - merge semantics: only the "murmur" entry is added/replaced; foreign
+//     server entries and unrelated top-level keys survive
+//   - invalid existing JSON → exit 1, file left byte-for-byte untouched
+//   - scope/client/flag validation (--user honestly unsupported → usage 2)
+//   - the locked --json schema { clients: [...] }
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  runCli,
+  EXIT_OK,
+  EXIT_RUNTIME_ERROR,
+  EXIT_USAGE_ERROR,
+} from "../../cli/lib/cliRunner.mjs";
+
+// The canonical server entry every client config receives (ticket #269:
+// `<cli> mcp` under ELECTRON_RUN_AS_NODE is the client-facing command).
+const CANONICAL_MURMUR_ENTRY = { command: "murmur", args: ["mcp"] };
+
+const CLAUDE_RELATIVE_PATH = ".mcp.json";
+const CURSOR_RELATIVE_PATH = path.join(".cursor", "mcp.json");
+const VSCODE_RELATIVE_PATH = path.join(".vscode", "mcp.json");
+
+let tempDir: string | null = null;
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "murmur-mcp-install-"));
+}
+
+function currentTempDir(): string {
+  if (tempDir === null) throw new Error("temp dir not initialised");
+  return tempDir;
+}
+
+afterEach(() => {
+  if (tempDir !== null) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+/** runCli(`murmur mcp install ...`) against the per-test temp cwd. */
+function runInstall(argv: string[] = [], options: { json?: boolean } = {}) {
+  const args = options.json ? [...argv, "--json"] : argv;
+  return runCli(["mcp", "install", ...args], {
+    cwd: currentTempDir(),
+    // Never let path resolution fall through to the real user directories.
+    configPath: path.join(currentTempDir(), "unused-murmur.json"),
+    dbPath: path.join(currentTempDir(), "unused-transcriptions.db"),
+  });
+}
+
+function writeConfigFile(relativePath: string, content: string): void {
+  const absolutePath = path.join(currentTempDir(), relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content, "utf-8");
+}
+
+function readRawConfigFile(relativePath: string): string {
+  return fs.readFileSync(path.join(currentTempDir(), relativePath), "utf-8");
+}
+
+describe("mcp install: fresh install content (three clients)", () => {
+  it("default (all) writes all three config files with the canonical murmur entry", () => {
+    tempDir = makeTempDir();
+    const result = runInstall();
+
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(
+      `Claude Code: 已写入 ${path.join(currentTempDir(), CLAUDE_RELATIVE_PATH)}`,
+    );
+    expect(result.stdout).toContain(
+      `Cursor: 已写入 ${path.join(currentTempDir(), CURSOR_RELATIVE_PATH)}`,
+    );
+    expect(result.stdout).toContain(
+      `VS Code: 已写入 ${path.join(currentTempDir(), VSCODE_RELATIVE_PATH)}`,
+    );
+
+    expect(JSON.parse(readRawConfigFile(CLAUDE_RELATIVE_PATH))).toEqual({
+      mcpServers: { murmur: CANONICAL_MURMUR_ENTRY },
+    });
+    expect(JSON.parse(readRawConfigFile(CURSOR_RELATIVE_PATH))).toEqual({
+      mcpServers: { murmur: CANONICAL_MURMUR_ENTRY },
+    });
+    expect(JSON.parse(readRawConfigFile(VSCODE_RELATIVE_PATH))).toEqual({
+      servers: { murmur: CANONICAL_MURMUR_ENTRY },
+    });
+  });
+
+  it("writes 2-space-indented JSON exactly like the repo config writer (no trailing newline)", () => {
+    tempDir = makeTempDir();
+    runInstall(["--client", "claude"]);
+
+    expect(readRawConfigFile(CLAUDE_RELATIVE_PATH)).toBe(
+      JSON.stringify(
+        { mcpServers: { murmur: CANONICAL_MURMUR_ENTRY } },
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("VS Code uses the top-level key `servers`, never `mcpServers`", () => {
+    tempDir = makeTempDir();
+    runInstall(["--client", "vscode"]);
+
+    const parsed = JSON.parse(readRawConfigFile(VSCODE_RELATIVE_PATH));
+    expect(parsed).toEqual({ servers: { murmur: CANONICAL_MURMUR_ENTRY } });
+    expect(parsed).not.toHaveProperty("mcpServers");
+  });
+
+  it("--client filters the write scope: only the requested client's file appears", () => {
+    tempDir = makeTempDir();
+    const result = runInstall(["--client", "cursor"]);
+
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toContain(
+      `Cursor: 已写入 ${path.join(currentTempDir(), CURSOR_RELATIVE_PATH)}`,
+    );
+    expect(
+      fs.existsSync(path.join(currentTempDir(), CURSOR_RELATIVE_PATH)),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(currentTempDir(), CLAUDE_RELATIVE_PATH)),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(currentTempDir(), VSCODE_RELATIVE_PATH)),
+    ).toBe(false);
+  });
+
+  it('--command overrides the executable verbatim; args stay ["mcp"]', () => {
+    tempDir = makeTempDir();
+    const electronEntry = "/Applications/Murmur.app/Contents/MacOS/Electron";
+    const result = runInstall([
+      "--client",
+      "claude",
+      "--command",
+      electronEntry,
+    ]);
+
+    expect(result.code).toBe(EXIT_OK);
+    expect(JSON.parse(readRawConfigFile(CLAUDE_RELATIVE_PATH))).toEqual({
+      mcpServers: { murmur: { command: electronEntry, args: ["mcp"] } },
+    });
+  });
+});
+
+describe("mcp install: idempotent merge, never clobber", () => {
+  it("a second identical run reports 无变化 for every client and leaves bytes untouched", () => {
+    tempDir = makeTempDir();
+    const first = runInstall();
+    expect(first.code).toBe(EXIT_OK);
+
+    const rawBefore = {
+      claude: readRawConfigFile(CLAUDE_RELATIVE_PATH),
+      cursor: readRawConfigFile(CURSOR_RELATIVE_PATH),
+      vscode: readRawConfigFile(VSCODE_RELATIVE_PATH),
+    };
+
+    const second = runInstall();
+    expect(second.code).toBe(EXIT_OK);
+    expect(second.stderr).toBe("");
+    expect(second.stdout).toContain(
+      `Claude Code: 无变化 ${path.join(currentTempDir(), CLAUDE_RELATIVE_PATH)}`,
+    );
+    expect(second.stdout).toContain(
+      `Cursor: 无变化 ${path.join(currentTempDir(), CURSOR_RELATIVE_PATH)}`,
+    );
+    expect(second.stdout).toContain(
+      `VS Code: 无变化 ${path.join(currentTempDir(), VSCODE_RELATIVE_PATH)}`,
+    );
+    expect(readRawConfigFile(CLAUDE_RELATIVE_PATH)).toBe(rawBefore.claude);
+    expect(readRawConfigFile(CURSOR_RELATIVE_PATH)).toBe(rawBefore.cursor);
+    expect(readRawConfigFile(VSCODE_RELATIVE_PATH)).toBe(rawBefore.vscode);
+  });
+
+  it("merges into existing files preserving foreign server entries and unrelated top-level keys", () => {
+    tempDir = makeTempDir();
+    writeConfigFile(
+      CLAUDE_RELATIVE_PATH,
+      JSON.stringify({
+        mcpServers: {
+          "other-server": { command: "npx", args: ["-y", "other-mcp"] },
+        },
+        customTopLevel: { keep: true },
+      }),
+    );
+
+    const result = runInstall(["--client", "claude"]);
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toContain(
+      `Claude Code: 已更新（合并） ${path.join(currentTempDir(), CLAUDE_RELATIVE_PATH)}`,
+    );
+
+    expect(JSON.parse(readRawConfigFile(CLAUDE_RELATIVE_PATH))).toEqual({
+      mcpServers: {
+        "other-server": { command: "npx", args: ["-y", "other-mcp"] },
+        murmur: CANONICAL_MURMUR_ENTRY,
+      },
+      customTopLevel: { keep: true },
+    });
+  });
+
+  it("creates the client's server map when the file exists without it (top-level keys preserved)", () => {
+    tempDir = makeTempDir();
+    writeConfigFile(VSCODE_RELATIVE_PATH, JSON.stringify({ otherTop: 42 }));
+
+    const result = runInstall(["--client", "vscode"]);
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toContain("已更新（合并）");
+
+    expect(JSON.parse(readRawConfigFile(VSCODE_RELATIVE_PATH))).toEqual({
+      otherTop: 42,
+      servers: { murmur: CANONICAL_MURMUR_ENTRY },
+    });
+  });
+
+  it("replaces an existing murmur entry with different args (foreign entries preserved)", () => {
+    tempDir = makeTempDir();
+    writeConfigFile(
+      CURSOR_RELATIVE_PATH,
+      JSON.stringify({
+        mcpServers: {
+          murmur: { command: "old-cli", args: ["mcp", "--legacy"] },
+          other: { command: "keep-me" },
+        },
+      }),
+    );
+
+    const result = runInstall(["--client", "cursor"]);
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toContain("已更新（合并）");
+
+    expect(JSON.parse(readRawConfigFile(CURSOR_RELATIVE_PATH))).toEqual({
+      mcpServers: {
+        murmur: CANONICAL_MURMUR_ENTRY,
+        other: { command: "keep-me" },
+      },
+    });
+  });
+
+  it("deep-merges inside the murmur entry only: unknown nested keys survive, command/args are canonical", () => {
+    tempDir = makeTempDir();
+    writeConfigFile(
+      CLAUDE_RELATIVE_PATH,
+      JSON.stringify({
+        mcpServers: {
+          murmur: { command: "old", args: ["mcp"], env: { MURMUR_TOKEN: "t" } },
+        },
+      }),
+    );
+
+    const result = runInstall(["--client", "claude"]);
+    expect(result.code).toBe(EXIT_OK);
+
+    expect(JSON.parse(readRawConfigFile(CLAUDE_RELATIVE_PATH))).toEqual({
+      mcpServers: {
+        murmur: {
+          command: "murmur",
+          args: ["mcp"],
+          env: { MURMUR_TOKEN: "t" },
+        },
+      },
+    });
+  });
+
+  it("an identical pre-existing murmur entry counts as 无变化 (no rewrite)", () => {
+    tempDir = makeTempDir();
+    const existing = JSON.stringify({
+      mcpServers: { murmur: CANONICAL_MURMUR_ENTRY, other: { command: "x" } },
+      note: "hand-written",
+    });
+    writeConfigFile(CLAUDE_RELATIVE_PATH, existing);
+
+    const result = runInstall(["--client", "claude"]);
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toContain("无变化");
+    expect(result.stderr).toBe("");
+    expect(readRawConfigFile(CLAUDE_RELATIVE_PATH)).toBe(existing);
+  });
+});
+
+describe("mcp install: invalid existing config never gets overwritten", () => {
+  it("single requested client with invalid JSON → exit 1, file content untouched", () => {
+    tempDir = makeTempDir();
+    const broken = "{ not valid json !!!";
+    writeConfigFile(CURSOR_RELATIVE_PATH, broken);
+
+    const result = runInstall(["--client", "cursor"]);
+    expect(result.code).toBe(EXIT_RUNTIME_ERROR);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("不是有效的 JSON");
+    expect(result.stderr).toContain("已保留原文件未做修改");
+    expect(readRawConfigFile(CURSOR_RELATIVE_PATH)).toBe(broken);
+  });
+
+  it("non-object top level → exit 1, untouched; non-object server map → exit 1, untouched", () => {
+    tempDir = makeTempDir();
+    writeConfigFile(CLAUDE_RELATIVE_PATH, JSON.stringify([1, 2, 3]));
+    const arrayResult = runInstall(["--client", "claude"]);
+    expect(arrayResult.code).toBe(EXIT_RUNTIME_ERROR);
+    expect(readRawConfigFile(CLAUDE_RELATIVE_PATH)).toBe(
+      JSON.stringify([1, 2, 3]),
+    );
+
+    writeConfigFile(CLAUDE_RELATIVE_PATH, JSON.stringify({ mcpServers: "no" }));
+    const mapResult = runInstall(["--client", "claude"]);
+    expect(mapResult.code).toBe(EXIT_RUNTIME_ERROR);
+    expect(mapResult.stderr).toContain("mcpServers");
+    expect(readRawConfigFile(CLAUDE_RELATIVE_PATH)).toBe(
+      JSON.stringify({ mcpServers: "no" }),
+    );
+  });
+
+  it("one invalid client among all → partial success exit 0; the healthy clients still install", () => {
+    tempDir = makeTempDir();
+    const broken = "~~not json~~";
+    writeConfigFile(CLAUDE_RELATIVE_PATH, broken);
+
+    const result = runInstall();
+    expect(result.code).toBe(EXIT_OK);
+    // Failure text on stderr only; successful per-client lines stay on stdout.
+    expect(result.stderr).toContain("不是有效的 JSON");
+    expect(result.stdout).toContain(
+      `Cursor: 已写入 ${path.join(currentTempDir(), CURSOR_RELATIVE_PATH)}`,
+    );
+    expect(result.stdout).toContain(
+      `VS Code: 已写入 ${path.join(currentTempDir(), VSCODE_RELATIVE_PATH)}`,
+    );
+    expect(result.stdout).not.toContain("Claude Code");
+    expect(readRawConfigFile(CLAUDE_RELATIVE_PATH)).toBe(broken);
+  });
+});
+
+describe("mcp install: usage errors (exit 2)", () => {
+  it("unknown --client value is a usage error", () => {
+    tempDir = makeTempDir();
+    const result = runInstall(["--client", "fenster"]);
+    expect(result.code).toBe(EXIT_USAGE_ERROR);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("未知的客户端: fenster");
+    expect(result.stderr).toContain("Usage:");
+  });
+
+  it("--user is rejected as 尚未支持 (usage 2) and writes nothing", () => {
+    tempDir = makeTempDir();
+    const result = runInstall(["--user"]);
+    expect(result.code).toBe(EXIT_USAGE_ERROR);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("尚未支持");
+    expect(fs.readdirSync(currentTempDir())).toEqual([]);
+  });
+
+  it("extra positionals and unknown flags are usage errors", () => {
+    tempDir = makeTempDir();
+    const positional = runInstall(["now"]);
+    expect(positional.code).toBe(EXIT_USAGE_ERROR);
+    expect(positional.stderr).toContain("unexpected extra arguments");
+
+    const unknownFlag = runInstall(["--force"]);
+    expect(unknownFlag.code).toBe(EXIT_USAGE_ERROR);
+    expect(unknownFlag.stderr).toContain("--force");
+  });
+
+  it("an empty --command value is a usage error", () => {
+    tempDir = makeTempDir();
+    const result = runInstall(["--client", "claude", "--command", "   "]);
+    expect(result.code).toBe(EXIT_USAGE_ERROR);
+    expect(result.stderr).toContain("--command 不能为空");
+  });
+
+  it("--project (the documented default) is accepted explicitly", () => {
+    tempDir = makeTempDir();
+    const result = runInstall(["--client", "claude", "--project"]);
+    expect(result.code).toBe(EXIT_OK);
+    expect(
+      fs.existsSync(path.join(currentTempDir(), CLAUDE_RELATIVE_PATH)),
+    ).toBe(true);
+  });
+});
+
+describe("mcp install: --json schema", () => {
+  it("fresh install locks the per-client record schema and order", () => {
+    tempDir = makeTempDir();
+    const result = runInstall([], { json: true });
+
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({
+      clients: [
+        {
+          client: "claude",
+          label: "Claude Code",
+          path: path.join(currentTempDir(), CLAUDE_RELATIVE_PATH),
+          status: "created",
+          success: true,
+          error: null,
+        },
+        {
+          client: "cursor",
+          label: "Cursor",
+          path: path.join(currentTempDir(), CURSOR_RELATIVE_PATH),
+          status: "created",
+          success: true,
+          error: null,
+        },
+        {
+          client: "vscode",
+          label: "VS Code",
+          path: path.join(currentTempDir(), VSCODE_RELATIVE_PATH),
+          status: "created",
+          success: true,
+          error: null,
+        },
+      ],
+    });
+  });
+
+  it('a second run reports status "unchanged" per client', () => {
+    tempDir = makeTempDir();
+    runInstall();
+    const second = runInstall([], { json: true });
+
+    const parsed = JSON.parse(second.stdout) as {
+      clients: { client: string; status: string }[];
+    };
+    expect(
+      parsed.clients.map((record) => [record.client, record.status]),
+    ).toEqual([
+      ["claude", "unchanged"],
+      ["cursor", "unchanged"],
+      ["vscode", "unchanged"],
+    ]);
+  });
+
+  it('a failed client carries status "failed", success false and the error text', () => {
+    tempDir = makeTempDir();
+    writeConfigFile(CLAUDE_RELATIVE_PATH, "~~broken~~");
+
+    const result = runInstall(["--client", "claude"], { json: true });
+    expect(result.code).toBe(EXIT_RUNTIME_ERROR);
+    const parsed = JSON.parse(result.stdout) as {
+      clients: {
+        client: string;
+        status: string;
+        success: boolean;
+        error: string | null;
+      }[];
+    };
+    expect(parsed.clients).toHaveLength(1);
+    expect(parsed.clients[0]?.client).toBe("claude");
+    expect(parsed.clients[0]?.status).toBe("failed");
+    expect(parsed.clients[0]?.success).toBe(false);
+    expect(parsed.clients[0]?.error).toContain("不是有效的 JSON");
+  });
+});
+
+describe("mcp install: routing and help", () => {
+  it("bare `murmur mcp` still rejects positionals — only the exact `mcp install` prefix is routed", async () => {
+    tempDir = makeTempDir();
+    // bare `mcp` (#269) is an async bridge-family command → await the result.
+    const result = await runCli(["mcp", "bogus"], {
+      cwd: currentTempDir(),
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_USAGE_ERROR);
+    expect(result.stderr).toContain("mcp: unexpected extra arguments");
+    expect(
+      fs.existsSync(path.join(currentTempDir(), CLAUDE_RELATIVE_PATH)),
+    ).toBe(false);
+  });
+
+  it("--help documents `mcp install` with clients, scope and --command", () => {
+    const result = runCli(["--help"], {
+      configPath: "/tmp/x.json",
+      dbPath: "/tmp/x.db",
+    });
+    expect(result.code).toBe(EXIT_OK);
+    expect(result.stdout).toContain("mcp install");
+    expect(result.stdout).toContain("--client");
+    expect(result.stdout).toContain("--command");
+    expect(result.stdout).toContain("servers");
+  });
+});


### PR DESCRIPTION
## What

`murmur mcp install [--client claude|cursor|vscode|all] [--command <path>]` 一条命令把 Murmur MCP server 写入三大客户端项目级配置：

| 客户端 | 路径 | 顶层键 |
|---|---|---|
| Claude Code | `.mcp.json` | `mcpServers` |
| Cursor | `.cursor/mcp.json` | `mcpServers` |
| VS Code | `.vscode/mcp.json` | **`servers`**（文档化差异，负向断言锁定不存在 mcpServers） |

## 行为契约

- **幂等深合并**：只动 `murmur` 键——外来 server 条目与无关顶层键按值保留；用户在 murmur 条目内的自定义键（如 env）存活，command/args 以规范值刷新；深相等 → `无变化` 且**字节级零写入**（手排格式文件实测不变）
- 校验先于变更（结构性保证文件不被污染）：非法 JSON/非对象顶层/非对象 server map → McpInstallError 且文件零触碰
- `--command` 覆写可执行路径（逐字写入，仅进 JSON 不执行）；`--user` 诚实拒绝（usage 2，用户级语义因客户端而异留独立票）
- 退出码：0 全部/部分成功；1 仅当全部失败；2 usage；`--json` schema 恰形锁定
- 路由：`mcp install` 在 #269 bare-`mcp` 之前精确拦截（`mcp <其他>` 仍进 stdio server，回归测试锁定）

## 独立 code-review

APPROVE（0 MAJOR / 2 MINOR / 4 NIT）：合并正确性经评审独立探针验证（手排格式/逆序键/单行 JSON 均字节保留；`__proto__` 自有键无污染）；2 MINOR（非原子写、并发竞态）与 `configStore.mjs` 既有仓库惯例一致，留作加固 follow-up。

## 验证

CLI 套件 80/80（24 新增）；lint/typecheck:tests 全过；worktree ci:check 10/11（唯一失败为 worktree 缺 .venv 的 Python 环境问题，零 Python 改动）

## 手工验收（AC，真实客户端）

在任意项目目录 `murmur mcp install` → Claude Code / Cursor / VS Code 重新加载 MCP 面板即可见 murmur server；重复执行无变化。#272 bin shim 落地后 command 解析免手工。

Closes #271