### PR TITLE
feat: MCP 全量工具面 — polish_text/list/get/delete 六工具齐备 (Spec #258 #270, closes #270)

### DIFF
--- a/cli/lib/historyReader.mjs
+++ b/cli/lib/historyReader.mjs
@@ -22,6 +22,42 @@ function escapeLikePattern(text) {
   return text.replace(/[\\%_]/g, (char) => `\\${char}`);
 }
 
+// [20260912_Feat_270_McpFullTools] Ticket #270: single-row read + the
+// not-found wording mirror. The MCP server (src/helpers/mcp/mcpServer.ts,
+// bundled by build:mcp) imports BOTH from here so the CLI's read model stays
+// the single source for local history reads:
+//   - getTranscriptionById mirrors the app's DatabaseManager
+//     .getTranscriptionById (database.ts: SELECT * WHERE id = ?) with the
+//     same readonly open discipline as listTranscriptions above.
+//   - TRANSCRIPTION_NOT_FOUND_MESSAGE mirrors historyService's TS constant
+//     of the same name (importing the TS file here is impossible — cli/ is
+//     plain ESM with zero deps — so the value is mirrored and the parity is
+//     locked by a test in tests/unit/mcpServer.test.ts).
+export const TRANSCRIPTION_NOT_FOUND_MESSAGE = "转录记录不存在";
+
+/**
+ * Read ONE transcription record by id (mirrors the app's
+ * getTranscriptionById columns via SELECT *), newest-independent.
+ * Returns the row object, or undefined when the id matches nothing.
+ *
+ * Throws when the database cannot be opened — same contract as
+ * listTranscriptions (the caller decides how to surface it).
+ *
+ * @param {string} dbPath Path to the app's transcriptions.db.
+ * @param {number} id Transcription record id.
+ * @returns {object | undefined} The full row, or undefined when absent.
+ */
+export function getTranscriptionById(dbPath, id) {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    const stmt = db.prepare("SELECT * FROM transcriptions WHERE id = ?");
+    return stmt.get(id);
+  } finally {
+    db.close();
+  }
+}
+// [20260912_Feat_270_McpFullTools] END
+
 /**
  * List transcription records, newest first (same ORDER BY as
  * getTranscriptions). `query` does a literal substring match over text and
@@ -29,6 +65,14 @@ function escapeLikePattern(text) {
  *
  * Throws when the database cannot be opened or queried — the CLI maps that
  * to exit code 1 (runtime error).
+ *
+ * @param {string} dbPath Path to the app's transcriptions.db.
+ * @param {object} [options]
+ * @param {string | null} [options.query] Literal substring filter over text
+ *   and processed_text (null disables the filter).
+ * @param {number} [options.limit] Positive integer page size
+ *   (default DEFAULT_HISTORY_LIMIT).
+ * @returns {Array<object>} Rows newest-first.
  */
 export function listTranscriptions(
   dbPath,

--- a/src/helpers/mcp/mcpServer.ts
+++ b/src/helpers/mcp/mcpServer.ts
@@ -21,13 +21,49 @@
 // owns it). Every diagnostic this module emits goes through the `log` sink,
 // which defaults to process.stderr — console.log is never used, and the
 // protocol transports (stdio or in-memory) never receive log output.
+//
+// [20260912_Feat_270_McpFullTools] Ticket #270 grows the surface to SIX
+// tools, split by the single-writer principle:
+//   - CHANNEL-BACKED (the running app owns every write): polish_text and
+//     delete_transcription ride the existing `polish` / `history_delete`
+//     channel methods (ticket #268) through the injected bridge — the app
+//     MUST be running, and app-down surfaces the actionable exit-4-class
+//     bridge message (same handling as transcribe_file).
+//   - LOCAL READONLY READS (no channel round-trip): list_transcriptions and
+//     get_transcription read the SQLite file DIRECTLY through the CLI's
+//     read model (cli/lib/historyReader.mjs — readonly opens never take the
+//     writer lock), so they work while the app runs AND while it does not
+//     (same rationale as the CLI's local subcommands, ticket #264).
+// The DB path for the local reads defaults to the CLI's resolveDatabasePath
+// over process.env, so the shipped CLI wiring (connect/version/log only)
+// needs no new argument; tests inject the temp path via deps.
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import fs from "node:fs";
 import { z } from "zod";
+// [20260912_Feat_270_McpFullTools] Ticket #270: the local-read model and
+// path resolution are the CLI's own modules (single source — build:mcp
+// bundles them in via these relative imports). The not-found wording is
+// MIRRORED here in JS because cli/ cannot import the TS historyService
+// constant; the parity is locked by a test in mcpServer.test.ts.
+import {
+  DEFAULT_HISTORY_LIMIT,
+  TRANSCRIPTION_NOT_FOUND_MESSAGE,
+  getTranscriptionById,
+  listTranscriptions,
+} from "../../../cli/lib/historyReader.mjs";
+import { resolveDatabasePath } from "../../../cli/lib/paths.mjs";
+import { CLI_POLISH_MODES } from "../../../cli/lib/channelBridge.mjs";
 
 /** Tool names exposed on the MCP surface (locked by mcpServer.test.ts). */
 export const MCP_TOOL_TRANSCRIBE_FILE = "transcribe_file";
 export const MCP_TOOL_GET_STATUS = "get_murmur_status";
+// [20260912_Feat_270_McpFullTools] Ticket #270 tool names (locked by
+// mcpServer.test.ts together with the #269 pair — six-tool surface).
+export const MCP_TOOL_POLISH_TEXT = "polish_text";
+export const MCP_TOOL_LIST_TRANSCRIPTIONS = "list_transcriptions";
+export const MCP_TOOL_GET_TRANSCRIPTION = "get_transcription";
+export const MCP_TOOL_DELETE_TRANSCRIPTION = "delete_transcription";
 
 /** Server identity reported during MCP initialize. */
 export const MCP_SERVER_NAME = "murmur";
@@ -53,6 +89,16 @@ export interface McpChannelBridge {
     onProgress?: (progress: unknown) => void,
     persist?: boolean,
   ): Promise<unknown>;
+  // [20260912_Feat_270_McpFullTools] Ticket #270 channel methods — the #268
+  // bridge (cli/lib/channelBridge.mjs connectChannelBridge) already provides
+  // both; the interface stays structural so tests can build the same shape
+  // on the real client kernel.
+  requestPolish(
+    text: string,
+    mode: string | undefined,
+    onProgress?: (progress: unknown) => void,
+  ): Promise<unknown>;
+  requestHistoryDelete(id: number): Promise<unknown>;
   close(): void;
 }
 
@@ -65,6 +111,13 @@ export interface MurmurMcpServerDeps {
   version?: string;
   /** Diagnostic sink; defaults to process.stderr (never stdout). */
   log?: (chunk: string) => void;
+  // [20260912_Feat_270_McpFullTools] DB path for the LOCAL-READ tools
+  // (list_transcriptions / get_transcription). Defaults to the CLI's
+  // resolveDatabasePath over process.env (MURMUR_DB_PATH override wins,
+  // else dataDirectory/transcriptions.db) so the shipped CLI wiring — which
+  // passes only connect/version/log — needs no new argument. Resolved per
+  // call, mirroring the bridge's connect-per-call style.
+  resolveHistoryDbPath?: () => string;
 }
 
 /** Narrow an unknown channel result to a plain object record. */
@@ -77,6 +130,85 @@ function textBlock(text: string): { type: "text"; text: string } {
   return { type: "text", text };
 }
 
+// [20260912_Feat_270_McpFullTools] Default DB resolution for the local-read
+// tools: the SAME derivation the CLI uses (cli/lib/paths.mjs — MURMUR_DB_PATH
+// env override wins, else dataDirectory/transcriptions.db, which mirrors
+// database.ts initialize()).
+function defaultResolveHistoryDbPath(): string {
+  return resolveDatabasePath({ env: process.env });
+}
+
+/** One record in list_transcriptions' structuredContent (ticket #270): the
+ * FULL text, not a preview — the reader returns uncapped rows (the CLI's
+ * preview/truncation is a display concern applied by its renderer, not by
+ * the read model), and structured-content consumers can truncate themselves.
+ */
+interface McpHistoryListRecord {
+  id: number;
+  text: string;
+  created_at: string;
+}
+
+/** Narrow one raw history row (unknown across the .mjs interop boundary) to
+ * the list-record shape. Null only for a row without a numeric id — the
+ * reader's SELECT always yields the id column, so such a row is skipped,
+ * never fabricated. */
+function toHistoryListRecord(row: unknown): McpHistoryListRecord | null {
+  if (!isRecord(row) || typeof row.id !== "number") return null;
+  return {
+    id: row.id,
+    text: typeof row.text === "string" ? row.text : "",
+    created_at: typeof row.created_at === "string" ? row.created_at : "",
+  };
+}
+
+/** Split a channel polish result into the polished text plus every other
+ * field verbatim MINUS the envelope (`success`) — the ticket #270
+ * structuredContent contract for polish_text (e.g. model/usage pass
+ * through untouched). A non-string `text` coalesces to "". */
+function splitChannelResultText(record: Record<string, unknown>): {
+  text: string;
+  extra: Record<string, unknown>;
+} {
+  let text = "";
+  const extra: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "text") {
+      if (typeof value === "string") text = value;
+      continue;
+    }
+    if (key !== "success") extra[key] = value;
+  }
+  return { text, extra };
+}
+
+/** Format a channel polish progress chunk as a stderr log line (null for
+ * non-progress chunks — finish/abort deltas are noise in a diagnostic log).
+ * Mirrors the CLI's formatPolishProgressLine gate: chunkIndex/chunkCount are
+ * optional on the chunk. */
+function polishProgressLogLine(progress: unknown): string | null {
+  const record = isRecord(progress) ? progress : {};
+  if (record.type !== "progress") return null;
+  const { chunkIndex, chunkCount } = record;
+  if (
+    typeof chunkIndex === "number" &&
+    typeof chunkCount === "number" &&
+    Number.isFinite(chunkIndex) &&
+    Number.isFinite(chunkCount)
+  ) {
+    return `murmur mcp: polish_text progress 第 ${chunkIndex}/${chunkCount} 块\n`;
+  }
+  return "murmur mcp: polish_text progress\n";
+}
+
+/** Human summary line for the history list tool's content block.
+ * [20260912_Fix_270_Review] "返回" not "共" — with a limit applied the count
+ * is what this call returned, not the history total (structuredContent's
+ * records array stays authoritative for callers). */
+function recordCountSummary(count: number): string {
+  return `返回 ${count} 条记录`;
+}
+
 /**
  * Build the Murmur MCP server. One McpServer instance serves one transport;
  * call `runMcpStdio` for the CLI entry or `server.connect(...)` directly in
@@ -84,13 +216,17 @@ function textBlock(text: string): { type: "text"; text: string } {
  */
 export function createMurmurMcpServer(deps: MurmurMcpServerDeps): McpServer {
   const log = deps.log ?? defaultStderrLog;
+  // [20260912_Feat_270_McpFullTools] Local-read DB path resolver (per-call).
+  const resolveHistoryDbPath =
+    deps.resolveHistoryDbPath ?? defaultResolveHistoryDbPath;
   const server = new McpServer(
     {
       name: MCP_SERVER_NAME,
       version: deps.version ?? DEFAULT_SERVER_VERSION,
     },
-    // No extra capabilities: exactly the two tools below (tools capability
-    // is enabled implicitly by registerTool).
+    // No extra capabilities: exactly the six tools registered below
+    // (#269 core two + #270 full surface; tools capability is enabled
+    // implicitly by registerTool).
   );
 
   // --- transcribe_file ---------------------------------------------------
@@ -267,6 +403,336 @@ export function createMurmurMcpServer(deps: MurmurMcpServerDeps): McpServer {
             models_downloaded: record.models_downloaded === true,
           },
         };
+      } finally {
+        bridge.close();
+      }
+    },
+  );
+
+  // [20260912_Feat_270_McpFullTools] --- polish_text (ticket #270) ---------
+  // Channel-backed AI polish: the SAME `polish` method the CLI uses
+  // (ticket #268). The AI key NEVER crosses the channel — only the task
+  // (text + mode) does; the app decrypts the key in-process and runs the
+  // GUI-identical polish orchestrator. The mode gate mirrors the CLI's local
+  // validation against channelBridge.mjs CLI_POLISH_MODES (the same mirrored
+  // built-in list, parity-locked against getAIModes in cli-bridge.test.ts):
+  // custom app template modes are not statically enumerable, so they are not
+  // offered here either — the authoritative fallback stays server-side.
+  //
+  // PROGRESS DECISION (ticket #270, documented): channel progress chunks
+  // become `log` (stderr) lines — NOT MCP notifications/progress. The MCP
+  // progress notification is only delivered when the CLIENT opts in with a
+  // per-request _meta.progressToken, which the registerTool handler would
+  // have to thread through every call for marginal value (a notification
+  // without a token is dropped by clients); stderr keeps the stdout
+  // protocol channel pure (this module's red line) and keeps progress
+  // visible in every MCP host that surfaces server stderr.
+  //
+  // Annotation honesty (SDK 1.30 ToolAnnotations semantics):
+  //   - readOnlyHint FALSE: the call spends the user's AI-provider quota —
+  //     it drives an external provider call, an externally-visible effect.
+  //   - destructiveHint FALSE: polish only PRODUCES text; nothing stored is
+  //     deleted or overwritten (polish never writes history).
+  //   - idempotentHint FALSE: the provider may return different text per
+  //     call and every call costs quota — repeats are not free/no-op.
+  //   - openWorldHint FALSE: the tool talks only to the local Murmur app
+  //     (the app→provider hop is the app's own configuration).
+  server.registerTool(
+    MCP_TOOL_POLISH_TEXT,
+    {
+      title: "Polish text with Murmur AI",
+      description:
+        "Polish/rewrite text through the running Murmur desktop app using " +
+        "the user's configured AI provider and mode templates (the same " +
+        "modes as the Murmur GUI). The AI key stays inside the app process.",
+      inputSchema: {
+        text: z.string().min(1).describe("Text to polish"),
+        mode: z
+          .string()
+          .optional()
+          .describe(
+            `Polish mode (built-in modes: ${CLI_POLISH_MODES.join(", ")}); ` +
+              "omit for the app's entry-level default (optimize)",
+          ),
+      },
+      annotations: {
+        title: "Polish text with Murmur AI",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (args) => {
+      // Local mode gate BEFORE any connection (same order as the CLI): an
+      // unknown built-in mode is a usage error, not an app failure.
+      if (args.mode !== undefined && !CLI_POLISH_MODES.includes(args.mode)) {
+        return {
+          isError: true,
+          content: [
+            textBlock(
+              `未知的润色模式: ${args.mode}（可用模式: ${CLI_POLISH_MODES.join(", ")}）`,
+            ),
+          ],
+        };
+      }
+      let bridge: McpChannelBridge;
+      try {
+        bridge = await deps.connect();
+      } catch (error) {
+        // Connect failures carry an already-actionable Chinese message
+        // (BridgeUnavailableError from the CLI bridge kernel).
+        const message = error instanceof Error ? error.message : String(error);
+        log(`murmur mcp: polish_text connect failed: ${message}\n`);
+        return { isError: true, content: [textBlock(message)] };
+      }
+      try {
+        const result = await bridge.requestPolish(
+          args.text,
+          args.mode,
+          (progress) => {
+            const line = polishProgressLogLine(progress);
+            if (line !== null) log(line);
+          },
+        );
+        const record = isRecord(result) ? result : {};
+        if (record.success === false) {
+          // The service ran and reported a failure envelope: surface the
+          // message as a tool error (same shape as transcribe_file).
+          const message =
+            typeof record.error === "string" ? record.error : "未知错误";
+          return { isError: true, content: [textBlock(message)] };
+        }
+        // structuredContent: {text} plus every other channel result field
+        // verbatim minus the envelope (success) — model/usage/etc. pass
+        // through untouched (ticket #270 contract).
+        const { text, extra } = splitChannelResultText(record);
+        return {
+          content: [textBlock(text)],
+          structuredContent: { ...extra, text },
+        };
+      } catch (error) {
+        // Channel-level failure (error frame, disconnect, timeout).
+        const message = error instanceof Error ? error.message : String(error);
+        log(`murmur mcp: polish_text request failed: ${message}\n`);
+        return { isError: true, content: [textBlock(message)] };
+      } finally {
+        bridge.close();
+      }
+    },
+  );
+
+  // [20260912_Feat_270_McpFullTools] --- list_transcriptions ---------------
+  // LOCAL readonly history read (NO channel round-trip). Same rationale as
+  // the CLI's local subcommands (ticket #264): SQLite read-only opens never
+  // take the writer lock, so the read is single-writer-safe while the app
+  // runs AND works when the app is not running at all. The read model is
+  // the CLI's own historyReader.mjs — one implementation, two consumers.
+  //
+  // MISSING-DB SEMANTICS (ticket #270 decision, documented): a database file
+  // that does not exist means Murmur has never transcribed anything (the
+  // app creates the DB on first save). That is honestly an EMPTY history,
+  // so the tool answers a successful {records: []} — inventing an error
+  // would misreport a normal fresh-install state as a failure.
+  //
+  // Annotations: readOnlyHint TRUE (pure read via a readonly SQLite open),
+  // destructiveHint FALSE, idempotentHint TRUE (repeats neither write nor
+  // change effect), openWorldHint FALSE (local file only).
+  server.registerTool(
+    MCP_TOOL_LIST_TRANSCRIPTIONS,
+    {
+      title: "List Murmur transcription history",
+      description:
+        "List transcription records from Murmur's local history database " +
+        "(read-only; works even when the Murmur app is not running). " +
+        "Newest first; optional literal-substring query and limit. Each " +
+        "record carries id, full text and created_at.",
+      inputSchema: {
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "Literal substring filter over text and processed_text " +
+              "(LIKE wildcards are matched literally)",
+          ),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            `Maximum records to return (default ${DEFAULT_HISTORY_LIMIT})`,
+          ),
+      },
+      annotations: {
+        title: "List Murmur transcription history",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => {
+      const dbPath = resolveHistoryDbPath();
+      // Missing DB: never-transcribed == empty history (see block comment).
+      // The existsSync check also guarantees the readonly open below never
+      // materialises an empty DB as a side effect.
+      if (!fs.existsSync(dbPath)) {
+        return {
+          content: [textBlock(recordCountSummary(0))],
+          structuredContent: { records: [] },
+        };
+      }
+      try {
+        const rows = listTranscriptions(dbPath, {
+          query: args.query ?? null,
+          limit: args.limit ?? DEFAULT_HISTORY_LIMIT,
+        });
+        const records: McpHistoryListRecord[] = [];
+        for (const row of rows) {
+          const record = toHistoryListRecord(row);
+          if (record) records.push(record);
+        }
+        return {
+          content: [textBlock(recordCountSummary(records.length))],
+          structuredContent: { records },
+        };
+      } catch (error) {
+        // The DB exists but cannot be read (locked/corrupt) — an error the
+        // caller cannot resolve by retrying blindly; surface the message.
+        const message = error instanceof Error ? error.message : String(error);
+        log(`murmur mcp: list_transcriptions read failed: ${message}\n`);
+        return { isError: true, content: [textBlock(message)] };
+      }
+    },
+  );
+
+  // [20260912_Feat_270_McpFullTools] --- get_transcription -----------------
+  // LOCAL readonly single-row read through historyReader.getTranscriptionById
+  // (mirrors the app's DatabaseManager.getTranscriptionById: SELECT * WHERE
+  // id = ?). Same no-channel rationale as list_transcriptions above.
+  //
+  // NOT-FOUND SEMANTICS: a missing id — including the missing-DB case
+  // (nothing was ever transcribed, so no id can exist) — answers isError
+  // with 转录记录不存在: the SAME wording the GUI/CLI delete path uses
+  // (historyService's TRANSCRIPTION_NOT_FOUND_MESSAGE, mirrored in JS in
+  // historyReader.mjs; the parity is locked by mcpServer.test.ts).
+  //
+  // Annotations: readOnlyHint TRUE, destructiveHint FALSE, idempotentHint
+  // TRUE (pure read), openWorldHint FALSE.
+  server.registerTool(
+    MCP_TOOL_GET_TRANSCRIPTION,
+    {
+      title: "Get one Murmur transcription",
+      description:
+        "Read ONE transcription record (full row: id, text, processed_text, " +
+        "duration, created_at, ...) from Murmur's local history database, " +
+        "read-only (works even when the Murmur app is not running).",
+      inputSchema: {
+        id: z
+          .number()
+          .int()
+          .positive()
+          .describe("Transcription record id (from list_transcriptions)"),
+      },
+      annotations: {
+        title: "Get one Murmur transcription",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => {
+      const dbPath = resolveHistoryDbPath();
+      if (fs.existsSync(dbPath)) {
+        try {
+          const row: unknown = getTranscriptionById(dbPath, args.id);
+          if (isRecord(row)) {
+            return {
+              content: [
+                textBlock(typeof row.text === "string" ? row.text : ""),
+              ],
+              // The full row verbatim — the reader mirrors the app's
+              // getTranscriptionById columns (SELECT *).
+              structuredContent: row,
+            };
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          log(`murmur mcp: get_transcription read failed: ${message}\n`);
+          return { isError: true, content: [textBlock(message)] };
+        }
+      }
+      // Missing row OR missing DB → the same single not-found answer.
+      return {
+        isError: true,
+        content: [textBlock(TRANSCRIPTION_NOT_FOUND_MESSAGE)],
+      };
+    },
+  );
+
+  // [20260912_Feat_270_McpFullTools] --- delete_transcription --------------
+  // Channel-backed delete via `history_delete` (ticket #268). WRITES go
+  // through the running app ON PURPOSE — the single-writer principle: the
+  // app process owns the DB writer, so the tool REQUIRES the app to be
+  // running and surfaces the actionable bridge message otherwise (same
+  // handling as transcribe_file).
+  //
+  // NOT-FOUND SEMANTICS: deleting a missing id makes the channel service
+  // throw 转录记录不存在 (historyService's constant via the #268 wrapper) —
+  // surfaced as isError below, so the wording stays identical across
+  // GUI/CLI/MCP for the same condition.
+  //
+  // Annotations (honest per SDK semantics): destructiveHint TRUE (permanently
+  // deletes one history row; there is no undo), readOnlyHint FALSE,
+  // idempotentHint FALSE — a REPEAT of a successful delete hits the
+  // missing-row error, so "same arguments → no error" does NOT hold.
+  // openWorldHint FALSE.
+  server.registerTool(
+    MCP_TOOL_DELETE_TRANSCRIPTION,
+    {
+      title: "Delete a Murmur transcription",
+      description:
+        "Permanently delete ONE transcription record from Murmur's history " +
+        "through the running Murmur desktop app (the app is the single " +
+        "DB writer). There is no undo; deleting an unknown id is an error.",
+      inputSchema: {
+        id: z
+          .number()
+          .int()
+          .positive()
+          .describe("Transcription record id (from list_transcriptions)"),
+      },
+      annotations: {
+        title: "Delete a Murmur transcription",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (args) => {
+      let bridge: McpChannelBridge;
+      try {
+        bridge = await deps.connect();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`murmur mcp: delete_transcription connect failed: ${message}\n`);
+        return { isError: true, content: [textBlock(message)] };
+      }
+      try {
+        await bridge.requestHistoryDelete(args.id);
+        return {
+          content: [textBlock(`已删除记录 #${args.id}`)],
+          structuredContent: { deleted: true, id: args.id },
+        };
+      } catch (error) {
+        // Includes the 转录记录不存在 not-found error frame for a missing id.
+        const message = error instanceof Error ? error.message : String(error);
+        log(`murmur mcp: delete_transcription request failed: ${message}\n`);
+        return { isError: true, content: [textBlock(message)] };
       } finally {
         bridge.close();
       }

--- a/tests/unit/mcpServer.test.ts
+++ b/tests/unit/mcpServer.test.ts
@@ -5,7 +5,7 @@
 // PRODUCTION bridge connector (cli/lib/channelBridge.mjs over the bundled
 // cli/dist/channelClient.mjs — built in-process via esbuild, same pattern
 // as cli-bridge.test.ts) against a REAL in-process channel server. Locked
-// here: the exact two-tool surface with honest annotations (transcribe_file
+// here: the exact six-tool surface with honest annotations (transcribe_file
 // must NOT claim readOnly), the save→persist threading, the diarize honest
 // refusal, status semantics (unreachable = successful {reachable:false},
 // NOT an error), and the stderr-only logging rule (stdout is the protocol
@@ -38,6 +38,19 @@ import {
   writeChannelEndpointFile,
   writeChannelTokenFile,
 } from "../../src/helpers/localChannel/endpoint";
+// [20260912_Feat_270_McpFullTools] Ticket #270 additions: the new tool-name
+// constants, the JS-mirrored not-found constant plus the TS source of truth
+// for the parity lock, and node:sqlite for the temp history DB behind the
+// local-read tools.
+import { DatabaseSync } from "node:sqlite";
+import {
+  MCP_TOOL_DELETE_TRANSCRIPTION,
+  MCP_TOOL_GET_TRANSCRIPTION,
+  MCP_TOOL_LIST_TRANSCRIPTIONS,
+  MCP_TOOL_POLISH_TEXT,
+} from "../../src/helpers/mcp/mcpServer";
+import { TRANSCRIPTION_NOT_FOUND_MESSAGE } from "../../src/helpers/services/historyService";
+import { TRANSCRIPTION_NOT_FOUND_MESSAGE as TRANSCRIPTION_NOT_FOUND_MESSAGE_MIRRORED } from "../../cli/lib/historyReader.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -198,13 +211,23 @@ describe("murmur mcp server (ticket #269)", () => {
   }
 
   describe("tools/list surface", () => {
-    it("enumerates exactly the two tools with honest annotations", async () => {
+    // [20260912_Feat_270_McpFullTools] Ticket #270 grows the locked surface
+    // from two to SIX tools; the annotation locks below are the drift guard
+    // for all of them.
+    it("enumerates exactly the six tools with honest annotations", async () => {
       freshTmp();
       const { client } = await makeSession(makeConnectDeps());
       const { tools } = await client.listTools();
-      expect(tools).toHaveLength(2);
+      expect(tools).toHaveLength(6);
       const names = tools.map((tool) => tool.name).sort();
-      expect(names).toEqual([MCP_TOOL_GET_STATUS, MCP_TOOL_TRANSCRIBE_FILE]);
+      expect(names).toEqual([
+        MCP_TOOL_DELETE_TRANSCRIPTION,
+        MCP_TOOL_GET_STATUS,
+        MCP_TOOL_GET_TRANSCRIPTION,
+        MCP_TOOL_LIST_TRANSCRIPTIONS,
+        MCP_TOOL_POLISH_TEXT,
+        MCP_TOOL_TRANSCRIBE_FILE,
+      ]);
 
       // Honesty lock (ticket #269): save:true CAN write history, so
       // transcribe_file must NOT claim readOnly. It never deletes
@@ -229,6 +252,47 @@ describe("murmur mcp server (ticket #269)", () => {
         openWorldHint: false,
       });
       expect(tools[0]?.inputSchema).toMatchObject({ type: "object" });
+
+      // Ticket #270 honesty locks. polish_text CALLS the AI provider — it
+      // must never claim read-only, produces text only (destructive:false),
+      // and costs quota per repeat (idempotent:false).
+      const polish = tools.find((tool) => tool.name === MCP_TOOL_POLISH_TEXT);
+      expect(polish?.annotations).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      });
+      // Both local reads are pure reads (readonly SQLite, no writes).
+      const list = tools.find(
+        (tool) => tool.name === MCP_TOOL_LIST_TRANSCRIPTIONS,
+      );
+      expect(list?.annotations).toMatchObject({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      const getOne = tools.find(
+        (tool) => tool.name === MCP_TOOL_GET_TRANSCRIPTION,
+      );
+      expect(getOne?.annotations).toMatchObject({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      // delete_transcription removes a row: destructive, and NOT idempotent
+      // (repeating a successful delete errors on the now-missing row).
+      const del = tools.find(
+        (tool) => tool.name === MCP_TOOL_DELETE_TRANSCRIPTION,
+      );
+      expect(del?.annotations).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      });
     });
 
     it("reports the injected version and server name in initialize", async () => {
@@ -508,6 +572,479 @@ describe("murmur mcp server (ticket #269)", () => {
       expect(stdoutWrites).toEqual([]);
       // The connect failure WAS diagnosed on the stderr sink.
       expect(logged.join("")).toContain("transcribe_file connect failed");
+    });
+  });
+
+  // [20260912_Feat_270_McpFullTools] --- ticket #270 tool surface ---
+  // polish_text / delete_transcription are CHANNEL-backed (single-writer:
+  // the running app owns every DB write); list_transcriptions /
+  // get_transcription are LOCAL readonly reads via cli/lib/historyReader.mjs
+  // against a real temp SQLite DB mirroring the app schema (same pattern as
+  // cli-history.test.ts).
+
+  /** One seed row for the temp history DB; unspecified columns default. */
+  interface SeedRow270 {
+    text: string;
+    processed_text?: string | null;
+    created_at: string;
+  }
+
+  /**
+   * Create a transcriptions DB with the app's post-migration schema
+   * (database.ts createTables + ALTERs) and insert the rows in order.
+   */
+  function createAppDb270(dbPath: string, rows: SeedRow270[]): void {
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS transcriptions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          text TEXT NOT NULL,
+          raw_text TEXT,
+          processed_text TEXT,
+          confidence REAL,
+          language TEXT DEFAULT 'zh-CN',
+          duration REAL,
+          file_size INTEGER,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          source_type TEXT DEFAULT 'recording',
+          source_file_path TEXT,
+          segments TEXT,
+          manually_edited INTEGER DEFAULT 0
+        )
+      `);
+      const insert = db.prepare(`
+        INSERT INTO transcriptions
+          (text, processed_text, created_at)
+        VALUES (?, ?, ?)
+      `);
+      for (const row of rows) {
+        insert.run(row.text, row.processed_text ?? null, row.created_at);
+      }
+    } finally {
+      db.close();
+    }
+  }
+
+  describe("polish_text (ticket #270)", () => {
+    /** A channel server with a spy polish service. */
+    async function startPolishServer(
+      impl?: (
+        text: string,
+        mode: string | undefined,
+        onProgress?: (progress: unknown) => void,
+      ) => Promise<unknown>,
+    ) {
+      const polish = vi.fn(
+        (
+          text: string,
+          mode: string | undefined,
+          onProgress?: (progress: unknown) => void,
+        ) =>
+          impl
+            ? impl(text, mode, onProgress)
+            : Promise.resolve({ success: true, text: "润色结果" }),
+      );
+      await startServer({
+        transcribeFile: async () => ({ success: true }),
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+        polish,
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      return polish;
+    }
+
+    it("happy path: structuredContent is {text} plus extra channel fields verbatim minus the envelope; mode omitted → undefined reaches the service", async () => {
+      freshTmp();
+      const polish = await startPolishServer(() =>
+        Promise.resolve({ success: true, text: "润色结果", model: "glm-4" }),
+      );
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_POLISH_TEXT, {
+        text: "你好世界",
+      });
+      expect(result.isError).toBeUndefined();
+      // Envelope (success) stripped; model passes through verbatim.
+      expect(result.structuredContent).toEqual({
+        text: "润色结果",
+        model: "glm-4",
+      });
+      expect(result.content).toEqual([{ type: "text", text: "润色结果" }]);
+      expect(polish).toHaveBeenCalledTimes(1);
+      expect(polish.mock.calls[0]?.[0]).toBe("你好世界");
+      // No mode → undefined reaches the service (the app applies its
+      // entry-level "optimize" default, same as the GUI/CLI).
+      expect(polish.mock.calls[0]?.[1]).toBeUndefined();
+    });
+
+    it("mode passes through to the channel service", async () => {
+      freshTmp();
+      const polish = await startPolishServer();
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_POLISH_TEXT, {
+        text: "你好世界",
+        mode: "summarize",
+      });
+      expect(result.isError).toBeUndefined();
+      expect(polish.mock.calls[0]?.[1]).toBe("summarize");
+    });
+
+    it("unknown mode is refused BEFORE any channel traffic (local gate, mirrors the CLI)", async () => {
+      freshTmp();
+      const polish = await startPolishServer();
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_POLISH_TEXT, {
+        text: "你好世界",
+        mode: "no-such-mode",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: expect.stringContaining("未知的润色模式") },
+      ]);
+      expect(polish).not.toHaveBeenCalled();
+    });
+
+    it("service failure envelope → isError with the message", async () => {
+      freshTmp();
+      await startPolishServer(() =>
+        Promise.resolve({ success: false, error: "AI 调用失败" }),
+      );
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_POLISH_TEXT, {
+        text: "你好世界",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "AI 调用失败" }]);
+    });
+
+    it("channel progress chunks become stderr log lines (never stdout/protocol)", async () => {
+      freshTmp();
+      await startPolishServer((_text, _mode, onProgress) => {
+        onProgress?.({ type: "progress", chunkIndex: 1, chunkCount: 2 });
+        return Promise.resolve({ success: true, text: "分块结果" });
+      });
+      const logged: string[] = [];
+      const stdoutWrites: string[] = [];
+      const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+        chunk: unknown,
+      ) => {
+        stdoutWrites.push(String(chunk));
+        return true;
+      }) as typeof process.stdout.write);
+      try {
+        const { client } = await makeSession(
+          makeConnectDeps({ log: (chunk) => logged.push(chunk) }),
+        );
+        const result = await callTool(client, MCP_TOOL_POLISH_TEXT, {
+          text: "长文本",
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.structuredContent).toEqual({ text: "分块结果" });
+      } finally {
+        stdoutSpy.mockRestore();
+      }
+      expect(stdoutWrites).toEqual([]);
+      expect(logged.join("")).toContain("polish_text progress");
+      expect(logged.join("")).toContain("1/2");
+    });
+
+    it("app not running: isError with the actionable bridge message", async () => {
+      freshTmp();
+      // No discovery files at all — the production connector classifies this
+      // as unreachable (the same failure the CLI maps to exit 4).
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_POLISH_TEXT, {
+        text: "你好世界",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: expect.stringContaining("应用可能未运行") },
+      ]);
+    });
+  });
+
+  describe("list_transcriptions (ticket #270)", () => {
+    it("empty DB → successful {records: []}", async () => {
+      freshTmp();
+      const dbPath = path.join(tmpDir, "transcriptions.db");
+      createAppDb270(dbPath, []);
+      const { client } = await makeSession(
+        makeConnectDeps({ resolveHistoryDbPath: () => dbPath }),
+      );
+      const result = await callTool(client, MCP_TOOL_LIST_TRANSCRIPTIONS, {});
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({ records: [] });
+    });
+
+    it("seeded DB: newest-first records with full text; query filters; limit truncates", async () => {
+      freshTmp();
+      const dbPath = path.join(tmpDir, "transcriptions.db");
+      createAppDb270(dbPath, [
+        {
+          text: "meeting minutes topic",
+          created_at: "2026-09-12 10:00:01",
+        },
+        {
+          text: "raw chatter",
+          processed_text: "polished budget talk",
+          created_at: "2026-09-12 10:00:02",
+        },
+        { text: "unrelated", created_at: "2026-09-12 10:00:03" },
+      ]);
+      const { client } = await makeSession(
+        makeConnectDeps({ resolveHistoryDbPath: () => dbPath }),
+      );
+
+      // Newest first, full text (no preview cap — documented decision).
+      const all = await callTool(client, MCP_TOOL_LIST_TRANSCRIPTIONS, {});
+      expect(all.isError).toBeUndefined();
+      expect(all.structuredContent).toEqual({
+        records: [
+          { id: 3, text: "unrelated", created_at: "2026-09-12 10:00:03" },
+          {
+            id: 2,
+            text: "raw chatter",
+            created_at: "2026-09-12 10:00:02",
+          },
+          {
+            id: 1,
+            text: "meeting minutes topic",
+            created_at: "2026-09-12 10:00:01",
+          },
+        ],
+      });
+
+      // query: literal substring over text AND processed_text.
+      const textHit = await callTool(client, MCP_TOOL_LIST_TRANSCRIPTIONS, {
+        query: "meeting",
+      });
+      expect(textHit.structuredContent).toEqual({
+        records: [
+          {
+            id: 1,
+            text: "meeting minutes topic",
+            created_at: "2026-09-12 10:00:01",
+          },
+        ],
+      });
+      const processedHit = await callTool(
+        client,
+        MCP_TOOL_LIST_TRANSCRIPTIONS,
+        { query: "budget" },
+      );
+      expect(processedHit.structuredContent).toEqual({
+        records: [
+          {
+            id: 2,
+            text: "raw chatter",
+            created_at: "2026-09-12 10:00:02",
+          },
+        ],
+      });
+
+      // limit truncates newest-first.
+      const limited = await callTool(client, MCP_TOOL_LIST_TRANSCRIPTIONS, {
+        limit: 2,
+      });
+      expect(
+        (
+          limited.structuredContent as {
+            records: Array<{ id: number }>;
+          }
+        ).records.map((record) => record.id),
+      ).toEqual([3, 2]);
+    });
+
+    it("missing DB file → successful {records: []}; the file is never created (readonly open guarantee)", async () => {
+      freshTmp();
+      const dbPath = path.join(tmpDir, "does-not-exist.db");
+      const { client } = await makeSession(
+        makeConnectDeps({ resolveHistoryDbPath: () => dbPath }),
+      );
+      const result = await callTool(client, MCP_TOOL_LIST_TRANSCRIPTIONS, {});
+      // Never-transcribed == empty history (documented #270 decision) — a
+      // normal fresh install is NOT an error.
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({ records: [] });
+      expect(fs.existsSync(dbPath)).toBe(false);
+    });
+  });
+
+  // [20260912_Fix_270_Review] Non-integer ids are rejected by the zod
+  // input schemas as PROTOCOL errors (SDK converts to InvalidParams —
+  // client.callTool rejects rather than returning isError). Locked here so
+  // the usage-error surface of both id-taking tools is explicit.
+  describe("id schema protocol errors (ticket #270 review)", () => {
+    // SDK 1.30 surfaces zod input-schema failures as an isError RESULT
+    // carrying the -32602 InvalidParams text (NOT a callTool rejection) —
+    // locked so this usage-error surface is explicit and distinct from the
+    // tools' own isError convention.
+    it("get_transcription rejects a fractional id as an InvalidParams error result", async () => {
+      freshTmp();
+      const { client } = await makeSession(
+        makeConnectDeps({
+          resolveHistoryDbPath: () => path.join(tmpDir, "x.db"),
+        }),
+      );
+      const result = (await client.callTool({
+        name: MCP_TOOL_GET_TRANSCRIPTION,
+        arguments: { id: 1.5 },
+      })) as CallToolResult;
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain("-32602");
+      expect(JSON.stringify(result.content)).toContain("Invalid");
+    });
+
+    it("delete_transcription rejects a fractional id as an InvalidParams error result", async () => {
+      freshTmp();
+      const { client } = await makeSession(makeConnectDeps());
+      const result = (await client.callTool({
+        name: MCP_TOOL_DELETE_TRANSCRIPTION,
+        arguments: { id: 1.5 },
+      })) as CallToolResult;
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain("-32602");
+    });
+  });
+
+  describe("get_transcription (ticket #270)", () => {
+    it("existing id → the full row as structuredContent", async () => {
+      freshTmp();
+      const dbPath = path.join(tmpDir, "transcriptions.db");
+      createAppDb270(dbPath, [
+        {
+          text: "完整记录",
+          processed_text: "润色后",
+          created_at: "2026-09-12 10:00:01",
+        },
+        { text: "second", created_at: "2026-09-12 10:00:02" },
+      ]);
+      const { client } = await makeSession(
+        makeConnectDeps({ resolveHistoryDbPath: () => dbPath }),
+      );
+      const result = await callTool(client, MCP_TOOL_GET_TRANSCRIPTION, {
+        id: 1,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({
+        id: 1,
+        text: "完整记录",
+        raw_text: null,
+        processed_text: "润色后",
+        confidence: null,
+        language: "zh-CN",
+        duration: null,
+        file_size: null,
+        created_at: "2026-09-12 10:00:01",
+        // updated_at is the INSERT time (CURRENT_TIMESTAMP), not the seeded
+        // created_at — only its shape is locked here.
+        updated_at: expect.any(String),
+        source_type: "recording",
+        source_file_path: null,
+        segments: null,
+        manually_edited: 0,
+      });
+      expect(result.content).toEqual([{ type: "text", text: "完整记录" }]);
+    });
+
+    it("missing id → isError 转录记录不存在", async () => {
+      freshTmp();
+      const dbPath = path.join(tmpDir, "transcriptions.db");
+      createAppDb270(dbPath, [
+        { text: "only one", created_at: "2026-09-12 10:00:01" },
+      ]);
+      const { client } = await makeSession(
+        makeConnectDeps({ resolveHistoryDbPath: () => dbPath }),
+      );
+      const result = await callTool(client, MCP_TOOL_GET_TRANSCRIPTION, {
+        id: 999,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: "转录记录不存在" },
+      ]);
+    });
+
+    it("missing DB file → isError 转录记录不存在 (no row can exist without a DB)", async () => {
+      freshTmp();
+      const dbPath = path.join(tmpDir, "does-not-exist.db");
+      const { client } = await makeSession(
+        makeConnectDeps({ resolveHistoryDbPath: () => dbPath }),
+      );
+      const result = await callTool(client, MCP_TOOL_GET_TRANSCRIPTION, {
+        id: 1,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: "转录记录不存在" },
+      ]);
+    });
+
+    it("not-found wording parity lock: the JS mirror in historyReader.mjs equals the historyService TS constant", () => {
+      expect(TRANSCRIPTION_NOT_FOUND_MESSAGE_MIRRORED).toBe(
+        TRANSCRIPTION_NOT_FOUND_MESSAGE,
+      );
+      expect(TRANSCRIPTION_NOT_FOUND_MESSAGE).toBe("转录记录不存在");
+    });
+  });
+
+  describe("delete_transcription (ticket #270)", () => {
+    it("channel-backed success → structuredContent {deleted:true, id}; the service receives the numeric id", async () => {
+      freshTmp();
+      const deleteTranscription = vi.fn(async (_id: number) => ({
+        success: true,
+        changes: 1,
+      }));
+      await startServer({
+        transcribeFile: async () => ({ success: true }),
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+        deleteTranscription,
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_DELETE_TRANSCRIPTION, {
+        id: 42,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({ deleted: true, id: 42 });
+      expect(deleteTranscription).toHaveBeenCalledTimes(1);
+      expect(deleteTranscription.mock.calls[0]?.[0]).toBe(42);
+    });
+
+    it("missing id → isError 转录记录不存在 (the channel service's not-found error frame)", async () => {
+      freshTmp();
+      const deleteTranscription = vi.fn(async (_id: number) => {
+        throw new Error(TRANSCRIPTION_NOT_FOUND_MESSAGE);
+      });
+      await startServer({
+        transcribeFile: async () => ({ success: true }),
+        checkEngineStatus: async () => ({ models_downloaded: true }),
+        deleteTranscription,
+      });
+      publishChannelFiles(tmpDir, TOKEN);
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_DELETE_TRANSCRIPTION, {
+        id: 7,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: "转录记录不存在" },
+      ]);
+    });
+
+    it("app not running: isError with the actionable bridge message (writes REQUIRE the running app)", async () => {
+      freshTmp();
+      // No discovery files — the single-writer principle means the tool
+      // cannot fulfil a delete without the app.
+      const { client } = await makeSession(makeConnectDeps());
+      const result = await callTool(client, MCP_TOOL_DELETE_TRANSCRIPTION, {
+        id: 42,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: expect.stringContaining("应用可能未运行") },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## What

在 #269 骨架上补齐 Spec #258 全量工具面（2 → 6）：

- **polish_text**(text, mode?)：通道 `polish` 方法（GUI 同源模式与提示词，密钥不出应用进程）；本地模式门先于连接（与 CLI 同序）；注解 readOnly:false 如实（耗 provider 配额）
- **list_transcriptions**(query?, limit?)：**本地只读** SQLite（#264 historyReader 单源——读不取写锁、应用未运行可用；缺库 = 诚实空集且永不创建文件）；参数化 LIKE + 通配转义（零注入）；limit 默认 50
- **get_transcription**(id)：只读单行 SELECT * 镜像（与 app getTranscriptionById 语句级一致）；缺行 → isError 「转录记录不存在」（JS↔TS 常量奇偶锁）
- **delete_transcription**(id)：通道 `history_delete` **单写者**（应用必须运行）；注解 destructive:true + idempotent:false 如实（重复命中缺行错误）

## 架构决策

读本地 / 写通道的物理分离：MCP 模块内**零 SQL 写**（评审 grep 证实）；单写者原则结构性成立而非约定成立。

## 独立 code-review

APPROVE（0 MAJOR / 3 MINOR / 4 NIT）：回归纪律核验（两源文件零删除行；唯一修改的既有测试是漂移锁 2→6 的必然更新）；注解诚实性逐工具核对。MINOR 已修：双处过期注释、计数措辞（限截下不虚报总数）、id schema 协议错误测试（SDK 1.30 以 isError 结果承载 -32602 而非 reject——契约显式化）。

## 验证

MCP 套件 30 用例全绿（真实 SDK 客户端 + 真实通道服务 + 真实临时 SQLite）；lint/typecheck 全过

Closes #270