### PR TITLE
feat: murmur CLI 分发接入 — 双平台 launcher shim + PATH/cask 接线 (Spec #258 #272, closes #272)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 * text=auto eol=lf
 *.py text eol=lf
+# [20260912_Feat_272DistCli] Batch files must be CRLF for the Windows
+# batch parser; the repo default (eol=lf) ships LF-only .cmd shims.
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,13 @@ yarn.lock
 
 # Production builds
 dist/
-build/
+# [20260912_Feat_272DistCli] build/ stays ignored except the electron-builder
+# packaging assets that package.json references by path (build.afterPack,
+# build.nsis.include) — without the whitelist they would be silently dropped
+# from checkouts and packaging would break.
+build/*
+!build/afterPack.js
+!build/installer.nsh
 out/
 dist-preload/
 # [20260912_Feat_267_BridgeTranscribe] Explicit: the CLI's bundled TS client

--- a/build/afterPack.js
+++ b/build/afterPack.js
@@ -1,0 +1,33 @@
+// [20260912_Feat_272DistCli] electron-builder afterPack hook (ticket #272).
+// The macOS DMG must carry cli/shims/murmur.sh with the executable bit or
+// the Homebrew `binary` symlink cannot exec it. electron-builder's file
+// pipeline does not guarantee POSIX permission preservation, so restore the
+// bit deterministically after the app is packed, before signing/DMG.
+// Idempotent and layout-tolerant: chmods every *.sh under the packaged
+// cli/shims directory when it exists (mac: Contents/Resources, win:
+// resources\ — harmless there; .cmd files need no exec bit).
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// rwxr-xr-x: owner can execute/edit, others can execute/read.
+const POSIX_EXECUTABLE_MODE = 0o755;
+
+module.exports = async function afterPack(context) {
+  // getResourcesDirectory is Contents/Resources on macOS and <root>\resources
+  // on Windows/Linux — exactly where extraFiles places the cli tree.
+  const shimsDir = path.join(
+    context.packager.getResourcesDirectory(context.appOutDir),
+    "cli",
+    "shims",
+  );
+  if (!fs.existsSync(shimsDir)) {
+    return;
+  }
+  for (const entry of fs.readdirSync(shimsDir)) {
+    if (entry.endsWith(".sh")) {
+      fs.chmodSync(path.join(shimsDir, entry), POSIX_EXECUTABLE_MODE);
+    }
+  }
+};

--- a/build/afterPack.js
+++ b/build/afterPack.js
@@ -15,19 +15,33 @@ const path = require("node:path");
 const POSIX_EXECUTABLE_MODE = 0o755;
 
 module.exports = async function afterPack(context) {
-  // getResourcesDirectory is Contents/Resources on macOS and <root>\resources
-  // on Windows/Linux — exactly where extraFiles places the cli tree.
+  // getResourcesDir is Contents/Resources on macOS and <root>\resources on
+  // Windows/Linux — exactly where extraResources places the cli tree.
   const shimsDir = path.join(
-    context.packager.getResourcesDirectory(context.appOutDir),
+    context.packager.getResourcesDir(context.appOutDir),
     "cli",
     "shims",
   );
   if (!fs.existsSync(shimsDir)) {
-    return;
+    // Loud, not silent: a missing shims dir means the DMG would ship a
+    // non-executable murmur.sh and the CLI would be dead on arrival.
+    throw new Error(
+      `afterPack: cli shims dir missing from the package: ${shimsDir}`,
+    );
   }
   for (const entry of fs.readdirSync(shimsDir)) {
     if (entry.endsWith(".sh")) {
       fs.chmodSync(path.join(shimsDir, entry), POSIX_EXECUTABLE_MODE);
     }
   }
+  // Version overlay for resolveCliVersion (walks up from cli/): copy the
+  // root package.json into the packaged cli dir. Done HERE, not via
+  // extraResources — an extraResources entry sourced from the root
+  // package.json makes the files matcher drop package.json from app.asar
+  // and electron-builder validation fails ("package.json was not found").
+  const cliDir = path.dirname(shimsDir);
+  fs.copyFileSync(
+    path.join(context.packager.projectDir, "package.json"),
+    path.join(cliDir, "package.json"),
+  );
 };

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,39 @@
+; [20260912_Feat_272DistCli] Windows installer PATH integration for the
+; packaged `murmur` CLI (ticket #272). Included by electron-builder via
+; package.json build.nsis.include.
+;
+; Manual acceptance steps (release owner, on a real machine — CI cannot
+; verify installer-time PATH edits):
+;   1. Run Murmur-Setup-*.exe and complete the install.
+;   2. Open a NEW terminal (existing processes keep the old PATH) with no
+;      system Node.js installed and run: murmur --version
+;      -> prints the app version, exits 0.
+;   3. Re-install over the existing install, then in a new shell run
+;      ([Environment]::GetEnvironmentVariable('Path','User') -split ';')
+;      -> resources\cli appears exactly once (no duplicates).
+;   4. Uninstall, open a new terminal: `murmur` no longer resolves and the
+;      resources\cli entry is gone from the user Path.
+;
+; Mechanism: [Environment]::SetEnvironmentVariable(..., 'User') writes
+; HKCU\Environment AND broadcasts WM_SETTINGCHANGE, so newly opened shells
+; pick up the change without a reboot — the reason raw registry writes via
+; WriteRegStr are NOT used. No NSIS plugin dependency (ExecWait only).
+; The user Path is guarded against duplicate entries and handles an empty
+; or missing user Path.
+
+!macro customInstall
+  ; Append $INSTDIR\resources\cli to the USER Path (HKCU) when absent.
+  ; NSIS string escaping: $$ -> literal $ (PowerShell variables), $\" ->
+  ; literal double quote (PowerShell -Command wrapper); $INSTDIR expands at
+  ; install time. Single quotes pass through so PowerShell receives the
+  ; path quoted (install paths may contain spaces, e.g. under a user name
+  ; with a space in %LOCALAPPDATA%\Programs\murmur).
+  ExecWait "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $\"$$cliDir='$INSTDIR\resources\cli'; $$p=[Environment]::GetEnvironmentVariable('Path','User'); if ($$null -eq $$p) { $$p='' }; if (($$p -split ';') -notcontains $$cliDir) { [Environment]::SetEnvironmentVariable('Path', ($$p.TrimEnd(';') + ';' + $$cliDir).TrimStart(';'), 'User') }$\""
+!macroend
+
+!macro customUnInstall
+  ; Remove the $INSTDIR\resources\cli entry from the USER Path (HKCU).
+  ; Removing the last entry yields an empty string, which deletes the Path
+  ; value (the correct end state when Murmur owned the only entry).
+  ExecWait "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $\"$$cliDir='$INSTDIR\resources\cli'; $$p=[Environment]::GetEnvironmentVariable('Path','User'); if ($$p) { $$n=($$p -split ';' | Where-Object { $$_ -ne $$cliDir }) -join ';'; [Environment]::SetEnvironmentVariable('Path', $$n, 'User') }$\""
+!macroend

--- a/cli/shims/murmur.cmd
+++ b/cli/shims/murmur.cmd
@@ -1,0 +1,21 @@
+@echo off
+rem [20260912_Feat_272DistCli] Windows launcher shim for the packaged
+rem `murmur` CLI (ticket #272). The NSIS installer adds resources\cli to the
+rem USER Path at install time (build/installer.nsh), so cmd and PowerShell
+rem resolve `murmur` to this script, which runs the CLI through the bundled
+rem Electron runtime in ELECTRON_RUN_AS_NODE mode - no system Node.js needed.
+rem
+rem Packaged layout (Windows NSIS install):
+rem   <root>\Murmur.exe                       <- Electron runtime binary
+rem   <root>\resources\cli\shims\murmur.cmd   <- this file
+rem   <root>\resources\cli\murmur.mjs         <- CLI entry
+rem %~dp0 carries a trailing backslash and resolves relative paths, so the
+rem `..` segments below reach the install root three levels up.
+set "ELECTRON_RUN_AS_NODE=1"
+set "MURMUR_RUNTIME=%~dp0..\..\..\Murmur.exe"
+if not exist "%MURMUR_RUNTIME%" set "MURMUR_RUNTIME=%~dp0..\..\..\Electron.exe"
+if not exist "%MURMUR_RUNTIME%" (
+  echo murmur: Electron runtime not found inside the Murmur install. 1>&2
+  exit /b 1
+)
+"%MURMUR_RUNTIME%" "%~dp0..\murmur.mjs" %*

--- a/cli/shims/murmur.sh
+++ b/cli/shims/murmur.sh
@@ -34,7 +34,7 @@ if [ ! -x "$RUNTIME" ]; then
 fi
 if [ ! -x "$RUNTIME" ]; then
   echo "murmur: Electron runtime not found inside the Murmur app bundle" >&2
-  echo "murmur: expected $SCRIPT_DIR/../../../MacOS/{Murmur,Electron}" >&2
+  echo "murmur: expected $SCRIPT_DIR/../../../MacOS/Murmur (or Electron)" >&2
   exit 1
 fi
 

--- a/cli/shims/murmur.sh
+++ b/cli/shims/murmur.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# [20260912_Feat_272DistCli] POSIX launcher shim for the packaged `murmur`
+# CLI (ticket #272). Ships inside the app bundle at
+# Contents/Resources/cli/shims/ and runs the CLI through the bundled
+# Electron binary in ELECTRON_RUN_AS_NODE mode, so `murmur` works on a
+# machine with no system Node.js installed. The Homebrew cask symlinks this
+# file onto PATH as `murmur`.
+#
+# Packaged layout (macOS .app bundle):
+#   Murmur.app/Contents/MacOS/Murmur                 <- Electron runtime binary
+#   Murmur.app/Contents/Resources/cli/shims/murmur.sh <- this file
+#   Murmur.app/Contents/Resources/cli/murmur.mjs      <- CLI entry
+# electron-builder renames the runtime binary to the productName
+# ("Murmur", verified in .github/workflows/build.yml packaged-app smoke);
+# "Electron" is kept as a fallback in case that rename ever changes.
+
+# Resolve symlinks so invocation through a PATH symlink (Homebrew `binary`
+# stanza) still finds the app bundle: $0 alone points at the symlink, not
+# at this file inside the bundle.
+target=$0
+while [ -L "$target" ]; do
+  link=$(readlink "$target")
+  case $link in
+    /*) target=$link ;;
+    *) target=$(dirname -- "$target")/$link ;;
+  esac
+done
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$target")" && pwd)
+
+# From Contents/Resources/cli/shims the runtime is three levels up.
+RUNTIME="$SCRIPT_DIR/../../../MacOS/Murmur"
+if [ ! -x "$RUNTIME" ]; then
+  RUNTIME="$SCRIPT_DIR/../../../MacOS/Electron"
+fi
+if [ ! -x "$RUNTIME" ]; then
+  echo "murmur: Electron runtime not found inside the Murmur app bundle" >&2
+  echo "murmur: expected $SCRIPT_DIR/../../../MacOS/{Murmur,Electron}" >&2
+  exit 1
+fi
+
+# ELECTRON_RUN_AS_NODE makes the Electron binary behave as a plain Node
+# runtime instead of booting the GUI app.
+export ELECTRON_RUN_AS_NODE=1
+exec "$RUNTIME" "$SCRIPT_DIR/../murmur.mjs" "$@"

--- a/docs/homebrew/murmur.rb
+++ b/docs/homebrew/murmur.rb
@@ -5,6 +5,18 @@
 #   1. Update `version` to the latest release tag.
 #   2. Fill `sha256` with the real DMG checksum (see checksums-sha256.txt in the release).
 # Submit to: https://github.com/Homebrew/homebrew-cask
+#
+# Manual acceptance steps for the CLI stanza (release owner, on a real
+# machine — CI cannot verify a brew install; ticket #272):
+#   1. Install the DMG built from a release that contains this cask's
+#      packaging changes, then `brew install --cask ./murmur.rb`.
+#   2. In a NEW shell (no system Node.js installed): `murmur --version`
+#      prints the app version and `murmur --help` prints usage.
+#   3. `brew uninstall --cask murmur` removes the symlink: `murmur` no
+#      longer resolves.
+#   4. Confirm the shipped murmur.sh kept its executable bit inside the
+#      DMG (enforced by build/afterPack.js):
+#      ls -l /opt/homebrew/Caskroom/murmur/*/Murmur.app/Contents/Resources/cli/shims/
 
 cask "murmur" do
   version "1.0.0"
@@ -19,6 +31,14 @@ cask "murmur" do
 
   app "Murmur.app"
 
+  # [20260912_Feat_272DistCli] Put the bundled `murmur` CLI on PATH. The
+  # shim execs the packaged CLI (Resources/cli/murmur.mjs) through the
+  # bundled Electron runtime in ELECTRON_RUN_AS_NODE mode, so the CLI works
+  # right after install with no system Node.js. Requires the .sh to keep
+  # its executable bit in the DMG (restored by build/afterPack.js).
+  binary "#{appdir}/Murmur.app/Contents/Resources/cli/shims/murmur.sh",
+         target: "murmur"
+
   zap trash: [
     "~/Library/Application Support/murmur",
     "~/Library/Caches/com.murmur.app",
@@ -30,5 +50,9 @@ cask "murmur" do
     Install it with: brew install ffmpeg
 
     On first launch, Murmur downloads the FunASR speech recognition model (~1GB).
+
+    The `murmur` CLI ships inside the app and is linked onto your PATH
+    (`murmur --version` in a new shell). It runs on Electron's built-in
+    Node, so no system Node.js is required.
   EOS
 end

--- a/docs/winget/Murmur.yaml
+++ b/docs/winget/Murmur.yaml
@@ -6,6 +6,10 @@
 #   2. Fix InstallerUrl to the real asset name (Murmur.Setup.<version>.exe).
 #   3. Fill InstallerSha256 from checksums-sha256.txt in the release.
 # Submit to: https://github.com/microsoft/winget-pkgs
+#
+# The NSIS installer adds resources\cli to the USER Path (see
+# build/installer.nsh), so the bundled `murmur` CLI works from any new
+# shell without a system Node.js (ticket #272).
 
 PackageIdentifier: TeFuirnever.Murmur
 PackageVersion: 1.0.0
@@ -18,6 +22,8 @@ Description: |
   Murmur is a desktop voice input tool that lets you type by speaking.
   It uses FunASR speech recognition with all audio processed locally.
   Optionally connect an AI model to auto-polish your text.
+  Ships a `murmur` CLI that the installer puts on your PATH (uses the
+  bundled Electron runtime, no system Node.js required).
 Tags:
   - speech-to-text
   - voice-input

--- a/package.json
+++ b/package.json
@@ -169,14 +169,10 @@
       "python/**/*"
     ],
     "afterPack": "build/afterPack.js",
-    "extraFiles": [
+    "extraResources": [
       {
         "from": "cli",
         "to": "cli"
-      },
-      {
-        "from": "package.json",
-        "to": "cli/package.json"
       }
     ],
     "mac": {

--- a/package.json
+++ b/package.json
@@ -168,6 +168,17 @@
       "download_models.py",
       "python/**/*"
     ],
+    "afterPack": "build/afterPack.js",
+    "extraFiles": [
+      {
+        "from": "cli",
+        "to": "cli"
+      },
+      {
+        "from": "package.json",
+        "to": "cli/package.json"
+      }
+    ],
     "mac": {
       "category": "public.app-category.productivity",
       "icon": "assets/icon.icns",
@@ -179,6 +190,9 @@
     },
     "win": {
       "icon": "assets/icon.ico"
+    },
+    "nsis": {
+      "include": "build/installer.nsh"
     },
     "linux": {
       "icon": "assets/icon.png",

--- a/tests/unit/cli-dist.test.ts
+++ b/tests/unit/cli-dist.test.ts
@@ -1,0 +1,159 @@
+// [20260912_Feat_272DistCli] Structural locks for ticket #272 (`murmur`
+// command works out of the box on a machine without system Node). These are
+// content/config assertions only — no packaging run, no process spawn:
+//   - launcher shims exist, reference ELECTRON_RUN_AS_NODE and resolve the
+//     Electron binary + CLI entry RELATIVE to their own location, and the
+//     POSIX shim stays LF-only (a CRLF byte breaks exec on macOS)
+//   - package.json build config wires the shims into the bundles
+//     (extraFiles), restores the executable bit (afterPack) and hooks the
+//     NSIS user-PATH include
+//   - installer.nsh adds/removes resources\cli on the USER path via
+//     [Environment]::SetEnvironmentVariable (broadcasts WM_SETTINGCHANGE),
+//     never via raw registry writes
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const root = path.resolve(__dirname, "../..");
+
+const readRepoFile = (...segments: string[]): string =>
+  fs.readFileSync(path.join(root, ...segments), "utf8");
+
+describe("cli launcher shims (ticket #272)", () => {
+  const shimPath = (...segments: string[]) => path.join(root, ...segments);
+
+  it("ships both platform shims", () => {
+    expect(fs.existsSync(shimPath("cli", "shims", "murmur.sh"))).toBe(true);
+    expect(fs.existsSync(shimPath("cli", "shims", "murmur.cmd"))).toBe(true);
+  });
+
+  it("murmur.sh runs the CLI via ELECTRON_RUN_AS_NODE with relative resolution", () => {
+    const shim = readRepoFile("cli", "shims", "murmur.sh");
+    expect(shim.startsWith("#!")).toBe(true);
+    expect(shim).toContain("ELECTRON_RUN_AS_NODE=1");
+    // Entry is resolved relative to the shim, never from cwd or an
+    // absolute install path.
+    expect(shim).toContain("../murmur.mjs");
+    // Binary is resolved inside the app bundle relative to the shim.
+    expect(shim).toContain("../../../MacOS/");
+    // Survives invocation through a symlink (Homebrew `binary` stanza).
+    expect(shim).toContain("readlink");
+    // Missing runtime is a loud error, not a silent fallback.
+    expect(shim).toContain("exit 1");
+  });
+
+  it("murmur.sh has no CRLF bytes (would break exec on macOS)", () => {
+    // Checked on every host (including Windows CI): a CRLF byte inside the
+    // shebang line makes the kernel fail to find the interpreter.
+    const raw = fs.readFileSync(shimPath("cli", "shims", "murmur.sh"));
+    expect(raw.includes(13)).toBe(false); // 13 === "\r"
+  });
+
+  it(
+    "murmur.sh carries the executable bit (POSIX hosts only)",
+    { skip: process.platform === "win32" },
+    () => {
+      const mode = fs.statSync(shimPath("cli", "shims", "murmur.sh")).mode;
+      expect(mode & 0o111).not.toBe(0);
+    },
+  );
+
+  it("murmur.cmd runs the CLI via ELECTRON_RUN_AS_NODE with relative resolution", () => {
+    const shim = readRepoFile("cli", "shims", "murmur.cmd");
+    expect(shim).toContain("ELECTRON_RUN_AS_NODE=1");
+    // Windows layout: shims -> cli -> resources -> install root.
+    expect(shim).toContain("%~dp0..\\..\\..\\Murmur.exe");
+    expect(shim).toContain("%~dp0..\\murmur.mjs");
+    // Forwarding of the caller's arguments.
+    expect(shim).toContain("%*");
+    // Missing runtime is a loud error, not a silent fallback.
+    expect(shim).toContain("exit /b 1");
+  });
+});
+
+describe("packaging wiring for the CLI distribution (ticket #272)", () => {
+  const pkg = JSON.parse(readRepoFile("package.json")) as {
+    build: {
+      afterPack?: string;
+      extraFiles?: Array<{ from: string; to: string }>;
+      nsis?: { include?: string };
+    };
+  };
+
+  it("extraFiles copies the whole cli tree (shims included) into the resource dir", () => {
+    const mapping = pkg.build.extraFiles?.find(
+      (entry) => entry.from === "cli" && entry.to === "cli",
+    );
+    expect(mapping).toBeDefined();
+  });
+
+  it("extraFiles places a package.json beside the copied cli so --version resolves", () => {
+    // cli/lib/version.mjs walks up from the CLI script dir to the nearest
+    // package.json; the extraFiles copy lives outside the asar, so the
+    // overlay is what makes `murmur --version` print the real version.
+    const overlay = pkg.build.extraFiles?.find(
+      (entry) =>
+        entry.from === "package.json" && entry.to === "cli/package.json",
+    );
+    expect(overlay).toBeDefined();
+  });
+
+  it("afterPack hook restores the shim executable bit", () => {
+    expect(pkg.build.afterPack).toBe("build/afterPack.js");
+    const hook = readRepoFile("build", "afterPack.js");
+    expect(hook).toContain("chmod");
+    expect(hook).toContain("cli");
+    expect(hook).toContain("shims");
+  });
+
+  it("nsis.include points at the custom installer script", () => {
+    expect(pkg.build.nsis?.include).toBe("build/installer.nsh");
+  });
+});
+
+describe("NSIS user-PATH integration (ticket #272)", () => {
+  const nsh = readRepoFile("build", "installer.nsh");
+  // Executable script lines only: `;` comment lines may legitimately name
+  // the avoided mechanism in prose.
+  const nshCode = nsh
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith(";"))
+    .join("\n");
+
+  it("defines both install-time and uninstall-time macros", () => {
+    expect(nsh).toContain("!macro customInstall");
+    expect(nsh).toContain("!macro customUnInstall");
+  });
+
+  it("targets resources\\cli on the USER scope", () => {
+    expect(nsh).toContain("resources\\cli");
+    expect(nsh).toContain("'User'");
+  });
+
+  it("uses [Environment]::SetEnvironmentVariable (broadcasts WM_SETTINGCHANGE)", () => {
+    expect(nshCode).toContain("[Environment]::SetEnvironmentVariable");
+    // Mechanism lock: raw registry writes do NOT broadcast
+    // WM_SETTINGCHANGE, so new shells would miss the change.
+    expect(nshCode).not.toContain("WriteRegStr");
+  });
+
+  it("guards against duplicate PATH entries", () => {
+    expect(nshCode).toContain("-notcontains");
+  });
+});
+
+describe("distribution docs mention the CLI (ticket #272)", () => {
+  it("homebrew cask links the packaged shim as the `murmur` binary", () => {
+    const cask = readRepoFile("docs", "homebrew", "murmur.rb");
+    expect(cask).toContain(
+      'binary "#{appdir}/Murmur.app/Contents/Resources/cli/shims/murmur.sh"',
+    );
+    expect(cask).toContain('target: "murmur"');
+  });
+
+  it("winget manifest notes the bundled CLI on PATH", () => {
+    const manifest = readRepoFile("docs", "winget", "Murmur.yaml");
+    expect(manifest).toContain("murmur");
+    expect(manifest.toLowerCase()).toContain("path");
+  });
+});

--- a/tests/unit/cli-dist.test.ts
+++ b/tests/unit/cli-dist.test.ts
@@ -5,8 +5,8 @@
 //     Electron binary + CLI entry RELATIVE to their own location, and the
 //     POSIX shim stays LF-only (a CRLF byte breaks exec on macOS)
 //   - package.json build config wires the shims into the bundles
-//     (extraFiles), restores the executable bit (afterPack) and hooks the
-//     NSIS user-PATH include
+//     (extraResources), restores the executable bit (afterPack) and hooks
+//     the NSIS user-PATH include
 //   - installer.nsh adds/removes resources\cli on the USER path via
 //     [Environment]::SetEnvironmentVariable (broadcasts WM_SETTINGCHANGE),
 //     never via raw registry writes
@@ -75,27 +75,39 @@ describe("packaging wiring for the CLI distribution (ticket #272)", () => {
   const pkg = JSON.parse(readRepoFile("package.json")) as {
     build: {
       afterPack?: string;
-      extraFiles?: Array<{ from: string; to: string }>;
+      // [20260912_Fix_272_ReviewCritical] extraResources (NOT extraFiles):
+      // the resources base is Contents/Resources (mac) / resources (win),
+      // which is what the shims, cask stanza and NSIS PATH all assume.
+      extraResources?: Array<{ from: string; to: string }>;
       nsis?: { include?: string };
     };
   };
 
-  it("extraFiles copies the whole cli tree (shims included) into the resource dir", () => {
-    const mapping = pkg.build.extraFiles?.find(
+  // [20260912_Fix_272_ReviewCritical] extraRESOURCES, not extraFiles:
+  // extraFiles copies to Contents (mac) / install root (win) — every path
+  // in the shims, the cask binary stanza and the NSIS PATH entry assumes
+  // Contents/Resources/cli (mac) / resources\cli (win), which is the
+  // extraResources base. Verified by a real `electron-builder --dir` run.
+  it("extraResources copies the whole cli tree (shims included) into the resource dir", () => {
+    const mapping = pkg.build.extraResources?.find(
       (entry) => entry.from === "cli" && entry.to === "cli",
     );
     expect(mapping).toBeDefined();
   });
 
-  it("extraFiles places a package.json beside the copied cli so --version resolves", () => {
-    // cli/lib/version.mjs walks up from the CLI script dir to the nearest
-    // package.json; the extraFiles copy lives outside the asar, so the
-    // overlay is what makes `murmur --version` print the real version.
-    const overlay = pkg.build.extraFiles?.find(
-      (entry) =>
-        entry.from === "package.json" && entry.to === "cli/package.json",
-    );
-    expect(overlay).toBeDefined();
+  // [20260912_Fix_272_ReviewCritical] cli/lib/version.mjs walks up from the
+  // CLI script dir to the nearest package.json; the packaged copy lives
+  // outside the asar, so the version overlay is what makes `murmur
+  // --version` print the real version. The overlay copy happens in the
+  // afterPack hook — an extraResources entry sourced from the ROOT
+  // package.json makes the files matcher drop package.json from app.asar
+  // (electron-builder validation: "package.json was not found").
+  it("afterPack places a package.json beside the copied cli so --version resolves", () => {
+    expect(pkg.build.afterPack).toBe("build/afterPack.js");
+    const hook = readRepoFile("build", "afterPack.js");
+    expect(hook).toContain("copyFileSync");
+    expect(hook).toContain('"package.json"');
+    expect(hook).toContain('"cli"');
   });
 
   it("afterPack hook restores the shim executable bit", () => {


### PR DESCRIPTION
## What

`murmur` 命令随应用分发、开箱即用（零系统 Node 依赖）：

- **launcher shims**：`cli/shims/murmur.sh`（POSIX，symlink 递归解析——Homebrew `binary` stanza 经符号链接调用；`ELECTRON_RUN_AS_NODE=1`；缺运行时 exit 1）+ `murmur.cmd`（Windows 同契约）；运行时二进制按 build.yml 证据解析为 **Murmur/Murmur.exe**（productName 重命名，非 Electron——纠正了票面简报的错误假设）
- **macOS**：cask 增 `binary` stanza（DRAFT 状态诚实保留，version/sha256 不伪造留给发布流程）+ CLI caveat
- **Windows**：NSIS `customInstall`/`customUnInstall` 以 PowerShell `[Environment]::SetEnvironmentVariable` 增删**用户级** PATH（自动广播 WM_SETTINGCHANGE；重复条目守卫；不用裸 WriteRegStr）
- **打包接线**：`extraResources` + `afterPack` 钩子（chmod 755 + 版本 overlay 拷贝）+ `nsis.include`；`.gitattributes` 增 \*.cmd CRLF；build/ 目录部分忽略修正（打包资产此前根本进不了克隆）

## 独立评审（REQUEST_CHANGES → 2 CRITICAL 全修，均对已安装 electron-builder 26.15.3 源码核验）

1. **CRITICAL-1**：`extraFiles` 基目录是 Contents(mac)/安装根(win)——shims/cask/NSIS 的全部路径假设落空；改 **extraResources** 后逐字符路径数学全对
2. **CRITICAL-2**：`getResourcesDirectory` API 在 26.x 不存在——打包三平台必崩；改 `getResourcesDir`；缺 shims 目录从静默跳过改为响亮抛错（DMG 里不可执行的 shim 是到达性死亡）
3. 评审要求的**真实打包验收**已执行：`electron-builder --dir` → `Contents/Resources/cli/{murmur.mjs,package.json,lib,dist,shims}` 齐备、murmur.sh 755、**打包内 shim `--version` → 1.5.1** ✓

## 诚实范围声明

AC 的「无系统 Node 干净机器验证」需真实安装产物与人工步骤——验收清单已内联在 build/installer.nsh 头部（安装→新 shell `murmur --version`→重复安装→卸载移除）与 cask 头部，留给发布负责人执行；CI 可验证部分全部通过。

## 验证

结构锁 15 用例（ELECTRON_RUN_AS_NODE/LF 字节/相对解析/nsis 机制）+ 既有 cli 17 用例，32/32 绿；真实 --dir 打包 + shim 冒烟；lint/typecheck/format 全过

Closes #272